### PR TITLE
fix: move Facebook Graph call server-side and add env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# ----- Public runtime flags -----
+NEXT_PUBLIC_SOCIAL_DRY_RUN=true
+
+# ----- Social automation backend -----
+SOCIAL_DRY_RUN=true
+X_TOKEN=
+REDDIT_CLIENT_ID=
+REDDIT_SECRET=
+FACEBOOK_PAGE_TOKEN=
+GITHUB_TOKEN=
+LINKEDIN_TOKEN=
+
+# ----- Facebook profile card (server-side Graph API fetch) -----
+# Use a long-lived access token with permissions for the target profile/page.
+FACEBOOK_ACCESS_TOKEN=
+# Optional: defaults to "me" when omitted.
+FACEBOOK_PROFILE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# keep env template in repository
+!.env.example

--- a/app/api/facebook-profile/route.ts
+++ b/app/api/facebook-profile/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server'
+
+const GRAPH_API_VERSION = 'v23.0'
+const GRAPH_FIELDS = ['id', 'name', 'picture.width(400).height(400)', 'about', 'link', 'quotes'].join(',')
+
+export async function GET() {
+  const token = process.env.FACEBOOK_ACCESS_TOKEN
+  const profileId = process.env.FACEBOOK_PROFILE_ID || 'me'
+
+  if (!token) {
+    return NextResponse.json(
+      {
+        error: 'facebook_not_configured',
+        message: 'Missing FACEBOOK_ACCESS_TOKEN in environment.',
+      },
+      { status: 503 },
+    )
+  }
+
+  const endpoint = `https://graph.facebook.com/${GRAPH_API_VERSION}/${profileId}?fields=${encodeURIComponent(GRAPH_FIELDS)}&access_token=${encodeURIComponent(token)}`
+
+  try {
+    const response = await fetch(endpoint, {
+      cache: 'no-store',
+      next: { revalidate: 0 },
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.text()
+      return NextResponse.json(
+        {
+          error: 'facebook_upstream_error',
+          message: `Facebook API request failed with status ${response.status}.`,
+          upstream: errorBody.slice(0, 500),
+        },
+        { status: response.status },
+      )
+    }
+
+    const profile = await response.json()
+    return NextResponse.json(profile)
+  } catch {
+    return NextResponse.json(
+      {
+        error: 'facebook_fetch_failed',
+        message: 'Failed to reach Facebook Graph API.',
+      },
+      { status: 502 },
+    )
+  }
+}

--- a/components/facebook-about.tsx
+++ b/components/facebook-about.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Facebook, Loader2, UserCircle } from 'lucide-react';
 import Image from 'next/image';
-import { GlitchText } from '@/components/glitch-text';
 
 export function FacebookAbout() {
   const [fbData, setFbData] = useState<any>(null);
@@ -15,12 +14,11 @@ export function FacebookAbout() {
   useEffect(() => {
     async function fetchFacebookData() {
       try {
-        const token = "EAAb75ZCw1boMBRKixK8aejnzPSMiD6Eal8WDcl0FrSKHRZC4uCN21UdJbPg6TZChJg6K6TV6dRHn7mfP3EtBbUkLZAmZAKxUKaiQH8EEILO6kNRKcrFVdImsdfIVVfdSzeYNEuGM6oA6e719B0WibMirkwS8UIoqs7b8rkRPe6H3RZABgUDLJO19VxKZAV2wfs1RTxTYjc3LjKdnBaBrCQ9rotqPW2rKa4xwX6v8go0K6gY60wv7CBMxEOLRoneU8qB3ZCTtYYWCzL8AanlqIjzTckZCkhL5Q";
-        // Fetch data from Facebook Graph API
-        const response = await fetch(`https://graph.facebook.com/me?fields=id,name,picture.width(400).height(400),about,link,quotes&access_token=${token}`);
+        const response = await fetch('/api/facebook-profile', { cache: 'no-store' });
         
         if (!response.ok) {
-          throw new Error('Failed to fetch Facebook data');
+          const failure = await response.json().catch(() => ({}));
+          throw new Error(failure.message || 'Failed to fetch Facebook data');
         }
         
         const data = await response.json();


### PR DESCRIPTION
### Motivation
- The Facebook profile card used a hardcoded access token in the browser which leaks credentials and often fails due to expiry/permissions, so the fetch must be moved server-side for security and reliability.
- Make required environment variables explicit so local and Vercel deployments can be configured consistently.

### Description
- Add a server API route at `app/api/facebook-profile/route.ts` that calls the Facebook Graph API using `FACEBOOK_ACCESS_TOKEN` and optional `FACEBOOK_PROFILE_ID`, and returns structured upstream errors.
- Update `components/facebook-about.tsx` to remove the embedded token and fetch profile data from the internal endpoint `GET /api/facebook-profile` with improved error handling.
- Add `.env.example` listing `FACEBOOK_ACCESS_TOKEN`, `FACEBOOK_PROFILE_ID`, and other social automation vars (`SOCIAL_DRY_RUN`, `X_TOKEN`, `REDDIT_CLIENT_ID`, `REDDIT_SECRET`, `FACEBOOK_PAGE_TOKEN`, `GITHUB_TOKEN`, `LINKEDIN_TOKEN`, and `NEXT_PUBLIC_SOCIAL_DRY_RUN`).
- Update `.gitignore` to keep `.env.example` tracked while continuing to ignore real `.env*` files.

### Testing
- `npm run test` (`vitest`) passed: 3 test files, 8 tests total, all passed.
- `npm run build` failed in this environment due to network errors fetching Google Fonts (`fonts.googleapis.com`) during Next.js/Turbopack build; this is unrelated to the Facebook changes.
- `npm run lint` failed due to local ESLint configuration / Next.js lint invocation issues in this environment and not caused by the edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c80cee87e88320966f152027b260ee)