### PR TITLE
fix: merged loader 50/50 side-by-side on desktop

### DIFF
--- a/app/lab/LoaderPreview.tsx
+++ b/app/lab/LoaderPreview.tsx
@@ -53,8 +53,9 @@ export function LoaderPreview() {
           </div>
           <div className="flex items-center justify-between">
             <p className="text-[11px] text-zinc-500">
-              Globe (top 50%) + boot log (bottom 50%) in one crossfading overlay · adapts to the
-              device: canvas globe on desktop, canvas-free SVG globe on mobile / reduced-motion.
+              Boot log + globe split 50/50 — side-by-side on desktop (globe right), stacked on
+              mobile — in one crossfading overlay. Canvas globe on desktop, canvas-free SVG globe on
+              mobile / reduced-motion.
             </p>
             <ReplayButton onClick={() => setMergedKey((k) => k + 1)} />
           </div>
@@ -74,7 +75,7 @@ export function LoaderPreview() {
             </div>
             <div className="flex items-center justify-between">
               <p className="text-[11px] text-zinc-500">
-                Orthographic globe + comet whirl · the canvas top-half of the merged loader.
+                Orthographic globe + comet whirl · the canvas globe half of the merged loader.
               </p>
               <ReplayButton onClick={() => setGlobeKey((k) => k + 1)} />
             </div>
@@ -89,7 +90,7 @@ export function LoaderPreview() {
             </div>
             <div className="flex items-center justify-between">
               <p className="text-[11px] text-zinc-500">
-                Terminal boot log · the canvas-free bottom-half of the merged loader.
+                Terminal boot log · the canvas-free boot-log half of the merged loader.
               </p>
               <ReplayButton onClick={() => setBootKey((k) => k + 1)} />
             </div>

--- a/components/os/OSLoader.tsx
+++ b/components/os/OSLoader.tsx
@@ -8,10 +8,14 @@ import { BootLog } from "./BootLog"
 
 // ---------------------------------------------------------------------------
 // OSLoader — the unified entry loader. Merges the two former loaders into one
-// 50/50 composition: the spinning globe owns the top half, the terminal boot
-// log owns the bottom half, and the whole overlay crossfades in and out as a
-// single piece. This replaces the old hard either/or (desktop saw only the
-// globe, mobile saw only the boot log) with one screen where both coexist.
+// 50/50 composition that crossfades in and out as a single piece, replacing the
+// old hard either/or (desktop saw only the globe, mobile saw only the boot log).
+//
+// Layout is responsive:
+//   • desktop (md+) → side-by-side: boot log | globe  (globe on the right, to
+//     echo the homepage's globe-pushed-right placement)
+//   • mobile        → stacked:      globe over boot log  (a horizontal split
+//     would crush the mono boot-log column on a phone — ui-ux-pro-max)
 //
 // Globe variant is chosen for the device, NOT swapped abruptly mid-flight:
 //   • desktop, motion allowed → GlobeCanvas  (2D-context globe)
@@ -74,7 +78,8 @@ export function OSLoader({ onComplete, embedded = false, loop = false, className
       aria-label="Loading"
       className={cn(
         embedded ? "absolute inset-0" : "fixed inset-0 z-[100]",
-        "flex flex-col overflow-hidden bg-zinc-950",
+        // Stacked on mobile, side-by-side (globe right) on desktop.
+        "flex flex-col overflow-hidden bg-zinc-950 md:flex-row-reverse",
         "pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]",
         "transition-opacity duration-500",
         exiting ? "pointer-events-none opacity-0" : "opacity-100",
@@ -84,20 +89,20 @@ export function OSLoader({ onComplete, embedded = false, loop = false, className
       {/* Faint scanline texture to match the OS aesthetic. */}
       <div className="pointer-events-none absolute inset-0 bg-[repeating-linear-gradient(0deg,transparent,transparent_2px,rgba(0,0,0,0.04)_2px,rgba(0,0,0,0.04)_4px)]" />
 
-      {/* Top 50% — globe */}
-      <div className="relative flex min-h-0 flex-1 items-center justify-center">
+      {/* Globe — top half (mobile) / right half (desktop) */}
+      <div className="relative flex min-h-0 min-w-0 flex-1 items-center justify-center">
         {variant === "canvas" ? (
-          <GlobeCanvas className="absolute inset-0" sizeFactor={0.34} />
+          <GlobeCanvas className="absolute inset-0" sizeFactor={0.34} maxRadius={200} />
         ) : (
           <GlobeRings />
         )}
       </div>
 
-      {/* Hairline seam between the two halves */}
-      <div className="mx-auto h-px w-2/3 max-w-md shrink-0 bg-gradient-to-r from-transparent via-emerald-900/40 to-transparent" />
+      {/* Hairline seam between the two halves — horizontal (mobile) / vertical (desktop) */}
+      <div className="mx-auto h-px w-2/3 max-w-md shrink-0 bg-gradient-to-r from-transparent via-emerald-900/40 to-transparent md:mx-0 md:my-auto md:h-2/3 md:w-px md:max-h-md md:bg-gradient-to-b" />
 
-      {/* Bottom 50% — boot log */}
-      <div className="flex min-h-0 flex-1 items-center justify-center px-6">
+      {/* Boot log — bottom half (mobile) / left half (desktop) */}
+      <div className="flex min-h-0 min-w-0 flex-1 items-center justify-center px-6">
         <BootLog />
       </div>
 


### PR DESCRIPTION
Follow-up to #16. The 50/50 split was stacked (globe top / boot log bottom); the intent was **side-by-side**.

- Desktop (md+): boot log **left**, globe **right** (`flex-col` → `md:flex-row-reverse`), vertical seam.
- Mobile: stays **stacked** (globe over boot log) — a horizontal split crushes the mono boot-log column on a phone (ui-ux-pro-max).
- Globe `maxRadius` bumped for the wider desktop half; seam flips horizontal→vertical.

Canvas-free mobile + zero-`<canvas>`-<768px E2E guard unchanged. `tsc` clean; Playwright re-verified (mobile = 0 canvas); visually confirmed side-by-side (desktop) + stacked (mobile).