### PR TITLE
feat: mobile terminal — real engine + CTF/easter-egg progression on phones

### DIFF
--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import type { Metadata } from "next"
 import { ArrowLeft, BriefcaseBusiness, CircleHelp, Keyboard, Mail, UserRound } from "lucide-react"
-import { HackerTerminal } from "@/components/hacker-terminal"
+import { TerminalSurface } from "@/components/terminal/TerminalSurface"
 import { OSPageShell } from "@/components/os/OSPageShell"
 import { OSWindow } from "@/components/os"
 
@@ -98,7 +98,7 @@ export default function TerminalPage() {
             <div className="mb-4 rounded-md border border-zinc-800 bg-zinc-950/45 p-3 text-xs leading-6 text-zinc-400 font-mono">
               System ready. Try <span className="text-emerald-400">help</span>, <span className="text-emerald-400">ls</span>, or <span className="text-emerald-400">cat ~/README.md</span>.
             </div>
-            <HackerTerminal />
+            <TerminalSurface />
           </OSWindow>
         </section>
       </div>

--- a/components/mobile-terminal.tsx
+++ b/components/mobile-terminal.tsx
@@ -1,179 +1,294 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+// === METADATA ===
+// Purpose: Mobile terminal — now a first-class peer of the desktop terminal.
+// Author: @Goodnbad.exe
+// Why: Previously a hardcoded "Lite Edition" with ~9 canned commands and a
+//   "switch to desktop" dead-end. Phone visitors could not discover easter eggs
+//   or progress the CTF at all. This drives the SAME engine as desktop
+//   (CommandProcessor + AuthManager + GameStateManager), so the full command
+//   set, easter eggs, and CTF challenges work on mobile — and because game state
+//   persists to a shared localStorage key, progress syncs across devices.
+// Security: No secrets. Same client-only engine the desktop terminal uses.
+// Complexity: O(1) per command (engine does the work).
+// === END METADATA ===
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { X, Terminal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { CommandProcessor } from '@/components/terminal/CommandProcessor';
+import { AuthManager } from '@/components/terminal/auth/AuthManager';
+import { GameStateManager } from '@/components/terminal/game/GameStateManager';
+import type { TerminalContext, CommandResult } from '@/components/terminal/types';
 
 interface MobileTerminalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+type EntryType = 'input' | 'output' | 'success' | 'error' | 'warning' | 'info' | 'system';
 interface HistoryEntry {
   content: string;
-  type: 'input' | 'output' | 'system' | 'error' | 'success';
-  isError?: boolean;
+  type: EntryType;
 }
 
+// Directory map for ls/pwd — mirrors the desktop terminal's structure so the
+// filesystem feels identical across surfaces.
+const FILE_SYSTEM: Record<string, string[]> = {
+  '~': ['projects', 'skills', 'experience', 'contact', 'certifications', 'README.md'],
+  '~/projects': ['magic-browser.js', 'raining-characters.js', 'prompting-engineering.js', 'pixel-game.js', 'masarat-events.js', 'first-website.html'],
+  '~/skills': ['security.txt', 'development.txt', 'leadership.txt', 'tools.txt'],
+  '~/experience': ['masarat-events.md', 'masarat-decor.md', 'thunderquote.md', 'kabel.md'],
+  '~/contact': ['email.txt', 'phone.txt', 'social.json'],
+  '~/certifications': ['google-cybersecurity.cert', 'ibm-cybersecurity.cert', 'google-analytics.cert', 'taylors-award.cert'],
+};
+
+// Tappable shortcuts — mobile users explore by tapping, not typing.
+const QUICK_COMMANDS = ['help', 'whoami', 'ls', 'hack', 'matrix', 'scan', 'ctf', 'stats', 'clear'];
+
+const PROMPT = 'goodnbad@exe ~ $';
+
+// Map an engine CommandResult.type to a rendered entry type.
+function resultEntryType(t: CommandResult['type']): EntryType {
+  switch (t) {
+    case 'success': return 'success';
+    case 'error':   return 'error';
+    case 'warning': return 'warning';
+    default:        return 'output';
+  }
+}
+
+const TYPE_CLASS: Record<EntryType, string> = {
+  input:   'text-emerald-500',
+  output:  'text-emerald-300',
+  success: 'text-emerald-400',
+  error:   'text-red-400',
+  warning: 'text-amber-400',
+  info:    'text-cyan-300',
+  system:  'text-emerald-600',
+};
+
 export function MobileTerminal({ isOpen, onClose }: MobileTerminalProps) {
-  const [history, setHistory] = useState<HistoryEntry[]>([])
-  const [currentInput, setCurrentInput] = useState('')
-  const [currentDirectory, setCurrentDirectory] = useState('~')
-  const terminalRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [currentInput, setCurrentInput] = useState('');
+  const [ready, setReady] = useState(false);
+  const [flash, setFlash] = useState(false);
+  const [cmdHistory, setCmdHistory] = useState<string[]>([]);
+  const [histIdx, setHistIdx] = useState(-1);
 
-  // Simple command processor for mobile
-  const processCommand = (command: string) => {
-    const cmd = command.toLowerCase().trim()
-    
-    switch (cmd) {
-      case 'help':
-        return "Available commands: help, clear, whoami, ls, pwd, about, contact, projects, skills\nTip: Use the desktop version for the full hacker terminal experience! 🚀"
-      case 'clear':
-        return 'CLEAR_TERMINAL'
-      case 'whoami':
-        return "goodnbad@exe - Hamzah Al-Ramli\nFresh Graduate & Lead Front-End Developer\nCybersecurity Enthusiast 🔐"
-      case 'ls':
-        return "projects/  skills/  experience/  contact/  certifications/  README.md"
-      case 'pwd':
-        return currentDirectory
-      case 'about':
-        return "👨‍💻 Hamzah Al-Ramli\n🎓 Fresh Graduate & Developer\n🚀 Passionate about problem-solving\n🔒 Cybersecurity & Web Development\n📍 Riyadh, Saudi Arabia"
-      case 'contact':
-        return "📧 alramli.hamzah@gmail.com\n📱 +966 50 850 1717\n💼 linkedin.com/in/hamzah-al-ramli-505\n🐙 github.com/goodnbadexe"
-      case 'projects':
-        return "🌐 Magic Browser - goodnbadexe.github.io/MagicB/\n🎮 Pixel Game X&O - v0-pixel-game-idea-two.vercel.app/\n🎯 Prompting Engineering - v0-prompting-is-all-you-need-ashy-delta.vercel.app/\n🎨 Raining Characters - v0-raining-characters-ten-livid.vercel.app/"
-      case 'skills':
-        return "💻 Full-Stack Development\n🔒 Cybersecurity & Risk Management\n📱 Mobile App Development (React Native, Swift, Java)\n🛠️ React, Next.js, Node.js, Python\n☁️ Cloud & DevOps Tools"
-      default:
-        if (cmd.includes('too many config') || cmd.includes('2 many config') || 
-            cmd.includes('many configuration') || cmd.includes('configurations')) {
-          return "🤖 Configuration overload detected! Even mobile terminals need a break from configs! 😄"
-        }
-        return `Command not found: ${command}\nType 'help' for available commands.`
-    }
-  }
+  // Engine — instantiated once, client-side only (localStorage access).
+  const procRef = useRef<CommandProcessor | null>(null);
+  const authRef = useRef<AuthManager | null>(null);
+  const gameRef = useRef<GameStateManager | null>(null);
 
-  const handleCommand = (command: string) => {
-    if (!command.trim()) {
-      setHistory(prev => [
-        ...prev,
-        { type: 'input', content: `goodnbad@exe ${currentDirectory} $ ${command}` }
-      ])
-      setCurrentInput('')
-      return
-    }
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    const result = processCommand(command)
-    
-    if (result === 'CLEAR_TERMINAL') {
-      setHistory([
-        { type: 'output', content: '✨ Look now it\'s clean! Have you found any keys or passwords? Something funny? 🔍' },
-        { type: 'output', content: '' },
-        { type: 'output', content: '📱 Mobile Terminal v1.0 - Lite Edition' },
-        { type: 'output', content: 'Welcome! Type "help" for commands or switch to desktop for full experience.' },
-        { type: 'output', content: '' }
-      ])
-    } else {
-      setHistory(prev => [
-        ...prev,
-        { type: 'input', content: `goodnbad@exe ${currentDirectory} $ ${command}` },
-        { type: 'output', content: result }
-      ])
-    }
-    
-    setCurrentInput('')
-  }
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleCommand(currentInput)
-    }
-  }
-
-  // Auto-scroll to bottom
   useEffect(() => {
-    if (terminalRef.current) {
-      terminalRef.current.scrollTop = terminalRef.current.scrollHeight
-    }
-  }, [history])
+    if (typeof window === 'undefined') return;
+    procRef.current ??= new CommandProcessor();
+    authRef.current ??= new AuthManager();
+    gameRef.current ??= new GameStateManager();
+    setReady(true);
+  }, []);
 
-  // Initialize terminal
+  const banner = useCallback((): HistoryEntry[] => {
+    const lvl = gameRef.current?.getGameState().level ?? 1;
+    return [
+      { type: 'system', content: 'GOODNBAD OS — mobile terminal [v2.0]' },
+      { type: 'system', content: `level ${lvl} · progress syncs with desktop` },
+      { type: 'output', content: "type 'help' · try 'hack', 'matrix', 'ctf', or 'stats'" },
+      { type: 'output', content: '' },
+    ];
+  }, []);
+
+  // Seed the banner once the engine is ready and the sheet is open.
   useEffect(() => {
-    if (isOpen && history.length === 0) {
-      setHistory([
-        { type: 'output', content: '📱 Mobile Terminal v1.0 - Lite Edition' },
-        { type: 'output', content: 'Welcome! Type "help" for commands or switch to desktop for full experience.' },
-        { type: 'output', content: '' }
-      ])
-    }
-  }, [isOpen, history.length])
+    if (isOpen && ready && history.length === 0) setHistory(banner());
+  }, [isOpen, ready, history.length, banner]);
 
-  // Focus input when opened
+  // Auto-scroll to newest output.
+  useEffect(() => {
+    if (terminalRef.current) terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+  }, [history]);
+
+  // Focus the input when opened.
   useEffect(() => {
     if (isOpen && inputRef.current) {
-      setTimeout(() => inputRef.current?.focus(), 100)
+      const id = setTimeout(() => inputRef.current?.focus(), 120);
+      return () => clearTimeout(id);
     }
-  }, [isOpen])
+  }, [isOpen]);
 
-  if (!isOpen) return null
+  const run = useCallback(async (raw: string) => {
+    const command = raw;
+    const promptLine: HistoryEntry = { type: 'input', content: `${PROMPT} ${command}` };
+
+    if (!command.trim()) {
+      setHistory((p) => [...p, promptLine]);
+      setCurrentInput('');
+      return;
+    }
+
+    // Up/down recall stack.
+    setCmdHistory((p) => [command.trim(), ...p.filter((c) => c !== command.trim())].slice(0, 50));
+    setHistIdx(-1);
+
+    const proc = procRef.current;
+    const auth = authRef.current;
+    const game = gameRef.current;
+    if (!proc || !auth || !game) {
+      setHistory((p) => [...p, promptLine, { type: 'output', content: 'Terminal still initializing…' }]);
+      setCurrentInput('');
+      return;
+    }
+
+    const user = auth.getCurrentUser();
+    const session = auth.getCurrentSession();
+    if (!user || !session) {
+      setHistory((p) => [...p, promptLine, { type: 'error', content: 'No active session. Reopen the terminal.' }]);
+      setCurrentInput('');
+      return;
+    }
+
+    // Same context shape the desktop terminal builds — handlers mutate
+    // `gameManager`, which persists to the shared localStorage key.
+    const context: TerminalContext = {
+      user,
+      session,
+      behaviorTracker: {
+        commandCounts: new Map<string, number>(),
+        patterns: [],
+        lastCommandTime: new Date(),
+        consecutiveHelps: 0,
+        discoveredSecrets: [],
+      },
+      gameState: game.getGameState(),
+      currentDirectory: '~',
+      fileSystem: FILE_SYSTEM,
+      gameManager: game,
+    };
+
+    try {
+      const result = await proc.executeCommand(command, context);
+
+      // `clear` resets the screen back to the banner (matches desktop).
+      if (result.type === 'clear') {
+        setHistory(banner());
+        setCurrentInput('');
+        return;
+      }
+
+      const out: HistoryEntry[] = [promptLine];
+      if (result.output) {
+        const entryType = resultEntryType(result.type);
+        for (const line of result.output.split('\n')) out.push({ type: entryType, content: line });
+      }
+      setHistory((p) => [...p, ...out]);
+
+      // Lightweight mobile feedback for effect-bearing commands.
+      if (result.triggerEffect || result.playSound === 'victory') {
+        setFlash(true);
+        setTimeout(() => setFlash(false), 240);
+      }
+    } catch (err: any) {
+      setHistory((p) => [...p, promptLine, { type: 'error', content: `Error: ${err?.message ?? err}` }]);
+    }
+
+    setCurrentInput('');
+  }, [banner]);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      run(currentInput);
+      return;
+    }
+    // Soft-keyboard arrow recall (hardware keyboards / tablets).
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHistIdx((i) => {
+        const next = Math.min(i + 1, cmdHistory.length - 1);
+        if (cmdHistory[next] !== undefined) setCurrentInput(cmdHistory[next]);
+        return next;
+      });
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHistIdx((i) => {
+        const next = Math.max(i - 1, -1);
+        setCurrentInput(next === -1 ? '' : cmdHistory[next] ?? '');
+        return next;
+      });
+    }
+  };
+
+  if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm md:hidden">
-      <div className="absolute inset-4 bg-zinc-900 rounded-lg border border-emerald-500/30 flex flex-col">
+      <div
+        className={cn(
+          'absolute inset-4 flex flex-col rounded-lg border bg-zinc-900 transition-colors duration-150',
+          flash ? 'border-emerald-400 shadow-[0_0_40px_-8px_rgba(16,185,129,0.6)]' : 'border-emerald-500/30',
+        )}
+      >
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-emerald-500/30">
+        <div className="flex items-center justify-between border-b border-emerald-500/30 p-4">
           <div className="flex items-center gap-2">
             <Terminal className="h-5 w-5 text-emerald-400" />
-            <span className="text-emerald-400 font-bold text-sm">Mobile Terminal</span>
+            <span className="text-sm font-bold text-emerald-400">Mobile Terminal</span>
           </div>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close terminal">
             <X className="h-4 w-4 text-emerald-400" />
           </Button>
         </div>
 
-        {/* Terminal Content */}
-        <div 
+        {/* Output */}
+        <div
           ref={terminalRef}
-          className="flex-1 overflow-auto p-4 font-mono text-sm text-emerald-300 bg-black/50"
+          className="flex-1 overflow-auto bg-black/50 p-4 font-mono text-sm"
+          onClick={() => inputRef.current?.focus()}
         >
-          {history.map((entry, index) => (
-            <div key={index} className="whitespace-pre-wrap mb-1">
-              {entry.type === 'input' ? (
-                <span className="text-emerald-500">{entry.content}</span>
-              ) : (
-                <span className={entry.isError ? 'text-red-400' : 'text-emerald-300'}>
-                  {entry.content}
-                </span>
-              )}
+          {history.map((entry, i) => (
+            <div key={i} className={cn('mb-1 whitespace-pre-wrap break-words', TYPE_CLASS[entry.type])}>
+              {entry.content}
             </div>
           ))}
-          
-          {/* Input Line */}
-          <div className="flex items-center mt-2 min-h-[44px]">
-            <span className="text-emerald-500 mr-2">
-              goodnbad@exe {currentDirectory} $
-            </span>
+
+          {/* Input line */}
+          <div className="mt-2 flex min-h-[44px] items-center">
+            <span className="mr-2 shrink-0 text-emerald-500">{PROMPT}</span>
             <input
               ref={inputRef}
               type="text"
               value={currentInput}
               onChange={(e) => setCurrentInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              className="flex-1 bg-transparent border-none outline-none text-emerald-300 caret-emerald-300 min-h-[44px] text-base"
-              placeholder="Type a command..."
+              onKeyDown={onKeyDown}
+              autoCapitalize="none"
+              autoCorrect="off"
+              autoComplete="off"
+              spellCheck={false}
+              // text-base (16px) prevents iOS zoom-on-focus; 44px row = touch target.
+              className="min-h-[44px] flex-1 border-none bg-transparent text-base text-emerald-300 caret-emerald-300 outline-none"
+              placeholder="type a command…"
             />
           </div>
         </div>
 
-        {/* Footer */}
-        <div className="p-3 border-t border-emerald-500/30 text-center">
-          <p className="text-xs text-zinc-400">
-            💡 Switch to desktop for the full hacker terminal experience!
-          </p>
+        {/* Quick-command chips — tap to explore without typing */}
+        <div className="flex flex-wrap gap-1.5 border-t border-emerald-500/30 p-3">
+          {QUICK_COMMANDS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => run(c)}
+              className="min-h-[36px] rounded border border-emerald-500/30 bg-emerald-950/40 px-2.5 font-mono text-xs text-emerald-300 transition-colors active:bg-emerald-900/60"
+            >
+              {c}
+            </button>
+          ))}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/components/terminal/TerminalSurface.tsx
+++ b/components/terminal/TerminalSurface.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+// === METADATA ===
+// Purpose: Responsive terminal entry point for the /terminal page.
+// Author: @Goodnbad.exe
+// Why: The page previously rendered the 963-line desktop <HackerTerminal/> for
+//   everyone, so phone visitors got a cramped desktop terminal. This splits the
+//   surface: desktop keeps the inline hacker terminal; mobile gets a launch
+//   button that opens the touch-optimized <MobileTerminal/> (same engine, shared
+//   progress). Desktop behavior is unchanged.
+// Security: Client-only; no secrets.
+// === END METADATA ===
+
+import { useState } from 'react'
+import { Terminal, Sparkles } from 'lucide-react'
+import { HackerTerminal } from '@/components/hacker-terminal'
+import { MobileTerminal } from '@/components/mobile-terminal'
+
+export function TerminalSurface() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      {/* Desktop / tablet: full inline hacker terminal */}
+      <div className="hidden md:block">
+        <HackerTerminal />
+      </div>
+
+      {/* Mobile: launch the touch-optimized terminal */}
+      <div className="md:hidden">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex min-h-[48px] w-full items-center justify-center gap-2 rounded-md border border-emerald-500/40 bg-emerald-950/40 px-4 font-mono text-sm font-semibold text-emerald-300 transition-colors active:bg-emerald-900/60"
+        >
+          <Terminal className="h-4 w-4" />
+          Launch terminal
+        </button>
+        <p className="mt-2 flex items-center gap-1.5 font-mono text-[11px] leading-5 text-zinc-500">
+          <Sparkles className="h-3 w-3 shrink-0 text-emerald-500/70" />
+          Full command set, easter eggs &amp; CTF — progress syncs with desktop.
+        </p>
+      </div>
+
+      {/* Self-gated: renders only on mobile (md:hidden) and only when open. */}
+      <MobileTerminal isOpen={open} onClose={() => setOpen(false)} />
+    </>
+  )
+}


### PR DESCRIPTION
## Problem
Two issues found while auditing the phone experience:
1. The `/terminal` page rendered the **963-line desktop HackerTerminal for everyone**, so phone visitors got a cramped desktop terminal.
2. The dedicated `MobileTerminal` component was a hardcoded **'Lite Edition'** (~9 canned commands) that told users to 'switch to desktop' — *and it was orphaned* (imported nowhere). Phone users could not discover easter eggs or progress the CTF at all.

## Fix
- **`mobile-terminal.tsx`** now drives the **same engine as desktop** — `CommandProcessor` + `AuthManager` + `GameStateManager`, builds the same `TerminalContext`, calls `executeCommand`. Full command set, easter eggs, and CTF challenges work on mobile.
- Game state + session persist to the **shared localStorage keys**, so CTF/easter-egg progress **syncs desktop ↔ mobile** automatically (no backend).
- Added tappable **quick-command chips** so users explore without typing.
- Kept mobile UX: 44px touch targets, `text-base` input (no iOS zoom), arrow-key recall.
- **`TerminalSurface.tsx`** (new) wires it in: desktop keeps the inline HackerTerminal; mobile gets a launch button → the MobileTerminal modal. Used on `/terminal`. **Desktop behavior unchanged.**

## Verification
`tsc --noEmit` clean · full `next build` green (`/terminal` prerenders).

## Risk
Medium. Desktop path is untouched (gated behind `hidden md:block`). All new mobile behavior is additive and self-gated (`md:hidden`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)