### PR TITLE
feat(news): multi-source THREAT WIRE feed (KEV + GitHub Advisory + NVD + RSS)

### DIFF
--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,5 +1,58 @@
 import { NextResponse } from 'next/server'
 
+/**
+ * THREAT WIRE feed — multi-source aggregation.
+ *
+ * CISA KEV is the guaranteed baseline (actively-exploited vulns, ransomware +
+ * remediation deadlines). GitHub Security Advisory DB extends + enriches it with
+ * real CVSS scores, ecosystems and CWEs. NVD optionally fills remaining CVSS gaps
+ * when a key is present. The Hacker News + BleepingComputer RSS feeds ride along as
+ * a separate `headlines` channel (they're articles, not CVEs — different shape).
+ *
+ * Every feed is isolated: one failing source degrades gracefully, it never breaks
+ * the route. KEV alone always yields a usable wire.
+ */
+
+export const revalidate = 1800
+const REVALIDATE = 1800
+const FEED_CAP = 30
+
+/* ── unified feed item (superset; UI fields stay backward-compatible) ── */
+interface FeedItem {
+  id: string
+  title: string
+  vendor: string
+  product: string
+  description: string
+  date: string
+  dueDate: string
+  ransomware: string
+  cwes: string[]
+  category: string
+  severity: 'critical' | 'high' | 'medium'
+  action: string
+  nvdUrl: string
+  cvss: number | null
+  ecosystem: string | null
+  source: string
+}
+
+interface Headline {
+  title: string
+  link: string
+  source: string
+  date: string
+}
+
+interface SourceStatus {
+  name: string
+  type: 'live' | 'rss' | 'detail' | 'class'
+  ok: boolean
+  count: number
+}
+
+/* ─────────────────────────── CISA KEV ─────────────────────────── */
+
 interface KevEntry {
   cveID: string
   vendorProject: string
@@ -14,74 +67,230 @@ interface KevEntry {
   cwes: string[]
 }
 
-export const revalidate = 1800
-
-export async function GET() {
+async function fetchKev(): Promise<{ items: FeedItem[]; total: number; ok: boolean }> {
   try {
     const res = await fetch(
       'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json',
-      { next: { revalidate: 1800 } }
+      { next: { revalidate: REVALIDATE }, signal: AbortSignal.timeout(10_000) }
     )
-    if (!res.ok) throw new Error(`CISA fetch failed: ${res.status}`)
-
+    if (!res.ok) throw new Error(`CISA ${res.status}`)
     const data = await res.json()
-    const vulns: KevEntry[] = data.vulnerabilities
-
-    const recent = vulns
+    const vulns: KevEntry[] = data.vulnerabilities ?? []
+    const items = vulns
       .sort((a, b) => new Date(b.dateAdded).getTime() - new Date(a.dateAdded).getTime())
       .slice(0, 24)
-      .map((v) => ({
-        id: v.cveID,
-        title: v.vulnerabilityName,
-        vendor: v.vendorProject,
-        product: v.product,
-        description: v.shortDescription,
-        date: v.dateAdded,
-        dueDate: v.dueDate,
-        ransomware: v.knownRansomwareCampaignUse,
-        cwes: v.cwes ?? [],
-        category: categorizeCVE(v),
-        severity: getSeverity(v),
-        action: v.requiredAction,
-        nvdUrl: `https://nvd.nist.gov/vuln/detail/${v.cveID}`,
-      }))
-
-    return NextResponse.json({
-      ok: true,
-      items: recent,
-      total: vulns.length,
-      source: 'CISA Known Exploited Vulnerabilities Catalog',
-      fetchedAt: new Date().toISOString(),
-    })
-  } catch (err: any) {
-    return NextResponse.json({ ok: false, error: err.message }, { status: 500 })
+      .map(
+        (v): FeedItem => ({
+          id: v.cveID,
+          title: v.vulnerabilityName,
+          vendor: v.vendorProject,
+          product: v.product,
+          description: v.shortDescription,
+          date: v.dateAdded,
+          dueDate: v.dueDate,
+          ransomware: v.knownRansomwareCampaignUse,
+          cwes: v.cwes ?? [],
+          category: categorizeCVE(v.vulnerabilityName, v.shortDescription, v.cwes ?? []),
+          severity: kevSeverity(v),
+          action: v.requiredAction,
+          nvdUrl: `https://nvd.nist.gov/vuln/detail/${v.cveID}`,
+          cvss: null,
+          ecosystem: null,
+          source: 'CISA KEV',
+        })
+      )
+    return { items, total: vulns.length, ok: true }
+  } catch {
+    return { items: [], total: 0, ok: false }
   }
 }
 
-function categorizeCVE(v: KevEntry): string {
-  const text = (v.vulnerabilityName + ' ' + v.shortDescription).toLowerCase()
-  const cwes = v.cwes ?? []
+/* ──────────────────── GitHub Security Advisory DB ──────────────────── */
 
+interface GhAdvisory {
+  ghsa_id: string
+  cve_id: string | null
+  summary: string
+  description: string
+  severity: string
+  published_at: string
+  html_url: string
+  cvss?: { score: number | null } | null
+  cvss_severities?: { cvss_v4?: { score: number | null }; cvss_v3?: { score: number | null } } | null
+  cwes?: { cwe_id: string }[]
+  vulnerabilities?: { package?: { ecosystem?: string; name?: string } }[]
+}
+
+function ghCvss(a: GhAdvisory): number | null {
+  const s = a.cvss?.score ?? a.cvss_severities?.cvss_v4?.score ?? a.cvss_severities?.cvss_v3?.score
+  return typeof s === 'number' && s > 0 ? s : null
+}
+
+function ghSeverity(s: string): 'critical' | 'high' | 'medium' | null {
+  const v = (s || '').toLowerCase()
+  if (v === 'critical') return 'critical'
+  if (v === 'high') return 'high'
+  if (v === 'medium' || v === 'moderate') return 'medium'
+  return null // drop low/unknown — keeps the wire and severity-mix meaningful
+}
+
+async function fetchGitHub(): Promise<{ items: FeedItem[]; ok: boolean }> {
+  try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'goodnbad-threatwire',
+      'X-GitHub-Api-Version': '2022-11-28',
+    }
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+
+    const res = await fetch(
+      'https://api.github.com/advisories?per_page=50&sort=published&direction=desc&type=reviewed',
+      { headers, next: { revalidate: REVALIDATE }, signal: AbortSignal.timeout(8_000) }
+    )
+    if (!res.ok) throw new Error(`GitHub ${res.status}`)
+    const data: GhAdvisory[] = await res.json()
+    if (!Array.isArray(data)) throw new Error('GitHub: unexpected shape')
+
+    const items: FeedItem[] = []
+    for (const a of data) {
+      const severity = ghSeverity(a.severity)
+      if (!severity) continue
+      const pkg = a.vulnerabilities?.[0]?.package
+      const cwes = (a.cwes ?? []).map((c) => c.cwe_id).filter(Boolean).slice(0, 3)
+      items.push({
+        id: a.cve_id || a.ghsa_id,
+        title: a.summary || 'Security advisory',
+        vendor: pkg?.ecosystem || 'GitHub',
+        product: pkg?.name || a.ghsa_id,
+        description: a.description || a.summary || '',
+        date: a.published_at,
+        dueDate: '',
+        ransomware: 'Unknown',
+        cwes,
+        category: categorizeCVE(a.summary || '', a.description || '', cwes),
+        severity,
+        action: '',
+        nvdUrl: a.cve_id ? `https://nvd.nist.gov/vuln/detail/${a.cve_id}` : a.html_url,
+        cvss: ghCvss(a),
+        ecosystem: pkg?.ecosystem || null,
+        source: 'GitHub Advisory',
+      })
+    }
+    return { items, ok: true }
+  } catch {
+    return { items: [], ok: false }
+  }
+}
+
+/* ──────────────────── NVD CVSS enrichment (opt-in) ──────────────────── */
+
+/**
+ * Fill CVSS for items still missing a score, via NVD. Gated on NVD_API_KEY —
+ * the unauthenticated limit (5 req / 30s) is too flaky for production, so without
+ * a key we rely on GitHub's CVSS cross-match and leave the rest honestly blank.
+ */
+async function enrichCvssNvd(items: FeedItem[]): Promise<boolean> {
+  const key = process.env.NVD_API_KEY
+  if (!key) return false
+  const targets = items.filter((i) => i.cvss == null && /^CVE-/i.test(i.id)).slice(0, 15)
+  if (!targets.length) return false
+
+  const results = await Promise.allSettled(
+    targets.map(async (item) => {
+      const res = await fetch(
+        `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=${encodeURIComponent(item.id)}`,
+        { headers: { apiKey: key }, next: { revalidate: REVALIDATE }, signal: AbortSignal.timeout(6_000) }
+      )
+      if (!res.ok) throw new Error(`NVD ${res.status}`)
+      const data = await res.json()
+      const metrics = data?.vulnerabilities?.[0]?.cve?.metrics
+      const score =
+        metrics?.cvssMetricV31?.[0]?.cvssData?.baseScore ??
+        metrics?.cvssMetricV30?.[0]?.cvssData?.baseScore ??
+        metrics?.cvssMetricV2?.[0]?.cvssData?.baseScore
+      if (typeof score === 'number') item.cvss = score
+    })
+  )
+  return results.some((r) => r.status === 'fulfilled')
+}
+
+/* ──────────────────────────── RSS digest ──────────────────────────── */
+
+const RSS_FEEDS = [
+  { url: 'https://feeds.feedburner.com/TheHackersNews', source: 'The Hacker News' },
+  { url: 'https://www.bleepingcomputer.com/feed/', source: 'BleepingComputer' },
+]
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&#8217;/g, '’')
+    .replace(/&#8216;/g, '‘')
+    .replace(/&#8211;/g, '–')
+    .replace(/<[^>]+>/g, '')
+    .trim()
+}
+
+function parseRss(xml: string, source: string): Headline[] {
+  const out: Headline[] = []
+  const items = xml.match(/<item[\s\S]*?<\/item>/gi) ?? []
+  for (const block of items.slice(0, 6)) {
+    const title = block.match(/<title>([\s\S]*?)<\/title>/i)?.[1]
+    const link = block.match(/<link>([\s\S]*?)<\/link>/i)?.[1]
+    const date = block.match(/<pubDate>([\s\S]*?)<\/pubDate>/i)?.[1]
+    if (!title || !link) continue
+    out.push({
+      title: decodeEntities(title),
+      link: decodeEntities(link),
+      source,
+      date: date ? new Date(date).toISOString() : '',
+    })
+  }
+  return out
+}
+
+async function fetchRss(url: string, source: string): Promise<Headline[]> {
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'goodnbad-threatwire' },
+      next: { revalidate: REVALIDATE },
+      signal: AbortSignal.timeout(6_000),
+    })
+    if (!res.ok) throw new Error(`${source} ${res.status}`)
+    return parseRss(await res.text(), source)
+  } catch {
+    return []
+  }
+}
+
+/* ────────────────────────── shared helpers ────────────────────────── */
+
+function categorizeCVE(name: string, desc: string, cwes: string[]): string {
+  const text = `${name} ${desc}`.toLowerCase()
   if (cwes.includes('CWE-89') || text.includes('sql injection')) return 'SQL Injection'
   if (cwes.includes('CWE-79') || text.includes('cross-site scripting') || text.includes(' xss')) return 'XSS'
   if (cwes.includes('CWE-78') || text.includes('command injection') || text.includes('os command')) return 'Command Injection'
   if (cwes.includes('CWE-22') || text.includes('path traversal') || text.includes('directory traversal')) return 'Path Traversal'
   if (cwes.includes('CWE-787') || cwes.includes('CWE-119') || text.includes('out-of-bounds') || text.includes('buffer overflow')) return 'Memory Corruption'
   if (cwes.includes('CWE-502') || text.includes('deserialization')) return 'Deserialization'
+  if (cwes.includes('CWE-918') || text.includes('ssrf') || text.includes('server-side request forgery')) return 'SSRF'
+  if (cwes.includes('CWE-1321') || text.includes('prototype pollution')) return 'Prototype Pollution'
   if (cwes.includes('CWE-20') || text.includes('improper input validation')) return 'Input Validation'
   if (text.includes('remote code execution') || text.includes(' rce')) return 'RCE'
   if (text.includes('privilege escalation')) return 'Privilege Escalation'
   if (text.includes('authentication bypass') || text.includes('improper authentication')) return 'Auth Bypass'
   if (text.includes('use-after-free') || text.includes('use after free')) return 'Use After Free'
-  if (text.includes('ssrf') || text.includes('server-side request forgery')) return 'SSRF'
   if (text.includes('xxe') || text.includes('xml external')) return 'XXE'
   return 'Vulnerability'
 }
 
-function getSeverity(v: KevEntry): 'critical' | 'high' | 'medium' {
+function kevSeverity(v: KevEntry): 'critical' | 'high' | 'medium' {
   const desc = v.shortDescription.toLowerCase()
-
-  // Critical: actively weaponized or full-compromise primitives.
   if (v.knownRansomwareCampaignUse === 'Known') return 'critical'
   if (
     desc.includes('unauthenticated') ||
@@ -90,8 +299,6 @@ function getSeverity(v: KevEntry): 'critical' | 'high' | 'medium' {
     desc.includes('arbitrary code')
   )
     return 'critical'
-
-  // High: serious but typically gated by auth, conditions, or limited scope.
   if (
     desc.includes('privilege escalation') ||
     desc.includes('authentication bypass') ||
@@ -107,7 +314,77 @@ function getSeverity(v: KevEntry): 'critical' | 'high' | 'medium' {
     desc.includes('ssrf')
   )
     return 'high'
-
-  // Medium: everything else still serious enough to land on the KEV catalog.
   return 'medium'
+}
+
+/* ──────────────────────────── route ──────────────────────────── */
+
+export async function GET() {
+  const [kev, gh, ...rssGroups] = await Promise.all([
+    fetchKev(),
+    fetchGitHub(),
+    ...RSS_FEEDS.map((f) => fetchRss(f.url, f.source)),
+  ])
+
+  // KEV is the spine; GitHub fills CVSS for shared CVEs, then extends with its own.
+  const ghByCve = new Map(gh.items.filter((i) => /^CVE-/i.test(i.id)).map((i) => [i.id.toUpperCase(), i]))
+  for (const item of kev.items) {
+    const match = ghByCve.get(item.id.toUpperCase())
+    if (match?.cvss != null) item.cvss = match.cvss
+    if (!item.ecosystem && match?.ecosystem) item.ecosystem = match.ecosystem
+  }
+
+  const seen = new Set(kev.items.map((i) => i.id.toUpperCase()))
+  const ghExtra = gh.items.filter((i) => !seen.has(i.id.toUpperCase()))
+
+  const merged = [...kev.items, ...ghExtra]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, FEED_CAP)
+
+  const nvdOk = await enrichCvssNvd(merged)
+
+  const scored = merged.filter((i) => typeof i.cvss === 'number')
+  const avgCvss = scored.length
+    ? Math.round((scored.reduce((s, i) => s + (i.cvss as number), 0) / scored.length) * 10) / 10
+    : null
+
+  const headlines = rssGroups
+    .flat()
+    .sort((a, b) => new Date(b.date || 0).getTime() - new Date(a.date || 0).getTime())
+    .slice(0, 8)
+
+  const usedKev = merged.filter((i) => i.source === 'CISA KEV').length
+  const usedGh = merged.filter((i) => i.source === 'GitHub Advisory').length
+  const sources: SourceStatus[] = [
+    { name: 'CISA KEV Catalog', type: 'live', ok: kev.ok, count: usedKev },
+    { name: 'GitHub Advisory DB', type: 'live', ok: gh.ok, count: usedGh },
+    { name: 'NVD / NIST', type: 'detail', ok: nvdOk || scored.length > 0, count: scored.length },
+    ...RSS_FEEDS.map((f, idx) => ({
+      name: f.source,
+      type: 'rss' as const,
+      ok: (rssGroups[idx]?.length ?? 0) > 0,
+      count: rssGroups[idx]?.length ?? 0,
+    })),
+    { name: 'MITRE CWE', type: 'class', ok: true, count: merged.reduce((n, i) => n + i.cwes.length, 0) },
+  ]
+
+  if (!merged.length) {
+    return NextResponse.json(
+      { ok: false, items: [], total: 0, source: '', fetchedAt: new Date().toISOString(), headlines, sources, avgCvss: null, error: 'All threat feeds are temporarily unavailable.' },
+      { status: 503 }
+    )
+  }
+
+  const activeSources = sources.filter((s) => s.ok && s.type !== 'class').map((s) => s.name)
+
+  return NextResponse.json({
+    ok: true,
+    items: merged,
+    total: kev.total,
+    source: activeSources.join(' + ') || 'CISA KEV Catalog',
+    fetchedAt: new Date().toISOString(),
+    headlines,
+    sources,
+    avgCvss,
+  })
 }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -24,6 +24,23 @@ interface NewsItem {
   severity: 'critical' | 'high' | 'medium'
   action: string
   nvdUrl: string
+  cvss?: number | null
+  ecosystem?: string | null
+  source?: string
+}
+
+interface Headline {
+  title: string
+  link: string
+  source: string
+  date: string
+}
+
+interface SourceStatus {
+  name: string
+  type: 'live' | 'rss' | 'detail' | 'class'
+  ok: boolean
+  count: number
 }
 
 interface NewsResponse {
@@ -32,6 +49,9 @@ interface NewsResponse {
   total: number
   source: string
   fetchedAt: string
+  headlines?: Headline[]
+  sources?: SourceStatus[]
+  avgCvss?: number | null
   error?: string
 }
 
@@ -148,6 +168,16 @@ export default function NewsPage() {
   }
   const maxMix = Math.max(counts.critical, counts.high, counts.medium, 1)
 
+  // Multi-source metadata (graceful defaults pre-load).
+  const sources: SourceStatus[] = data?.sources ?? [
+    { name: 'CISA KEV Catalog', type: 'live', ok: true, count: 0 },
+    { name: 'GitHub Advisory DB', type: 'live', ok: true, count: 0 },
+    { name: 'NVD / NIST', type: 'detail', ok: true, count: 0 },
+  ]
+  const headlines = data?.headlines ?? []
+  const avgCvss = data?.avgCvss ?? null
+  const chipSources = sources.filter((s) => s.type !== 'class')
+
   return (
     <main className="relative min-h-screen bg-gradient-to-b from-zinc-950 to-black text-zinc-100">
       {/* faint structural grid */}
@@ -174,7 +204,9 @@ export default function NewsPage() {
             </h1>
             <p className="mt-3 font-mono text-xs text-zinc-600">
               {data
-                ? `${data.total.toLocaleString()} KEVs tracked · ${items.length} in feed · CISA`
+                ? `${items.length} advisories · ${chipSources.filter((s) => s.ok).length} live sources${
+                    avgCvss != null ? ` · avg CVSS ${avgCvss.toFixed(1)}` : ''
+                  } · auto-synced`
                 : 'Reviewed vulnerability advisories · auto-synced'}
             </p>
           </div>
@@ -191,9 +223,9 @@ export default function NewsPage() {
 
         {/* Source chips */}
         <div className="mt-6 flex flex-wrap gap-2">
-          <SourceChip label="CISA KEV Catalog" state="live" />
-          <SourceChip label="NVD / NIST" state="detail" />
-          <SourceChip label="MITRE CWE" state="detail" />
+          {chipSources.map((s) => (
+            <SourceChip key={s.name} label={s.name} type={s.type} ok={s.ok} />
+          ))}
         </div>
 
         {/* Global threat map (signature) */}
@@ -233,11 +265,13 @@ export default function NewsPage() {
               <div className="px-6 pb-6 pt-5">
                 <div className="mb-3.5 flex flex-wrap items-center gap-2.5">
                   <SevTag severity={lead.severity} />
+                  <CvssChip score={lead.cvss} />
                   <span className="rounded border border-zinc-700 px-2 py-0.5 font-mono text-[10px] text-zinc-300">{lead.category}</span>
                   <span className="rounded border border-zinc-800 px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-wide text-zinc-500">{lead.vendor}</span>
                   {lead.ransomware === 'Known' && (
                     <span className="rounded border border-rose-500/40 bg-rose-500/10 px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-wide text-rose-300">Ransomware</span>
                   )}
+                  <SourceTag source={lead.source} />
                 </div>
                 <h2 className="text-[clamp(1.35rem,3vw,1.85rem)] font-semibold leading-[1.18] tracking-tight text-balance [overflow-wrap:anywhere]">
                   {lead.title}
@@ -310,6 +344,7 @@ export default function NewsPage() {
               <Stat label="Advisories (feed)" value={items.length} className="text-emerald-400" />
               <Stat label="Critical" value={counts.critical} className="text-rose-400" />
               <Stat label="High" value={counts.high} className="text-orange-400" />
+              <Stat label="Avg CVSS" value={avgCvss != null ? avgCvss.toFixed(1) : '—'} className="text-zinc-100" />
               <Stat label="Ransomware linked" value={counts.ransomware} className="text-amber-400" />
             </RailPanel>
 
@@ -331,13 +366,37 @@ export default function NewsPage() {
             </RailPanel>
 
             <RailPanel title="source feeds">
-              <FeedRow name="CISA KEV Catalog" type="live" live />
-              <FeedRow name="NVD / NIST" type="detail" />
-              <FeedRow name="MITRE CWE" type="class" />
+              {sources.map((s) => (
+                <FeedRow key={s.name} name={s.name} type={s.type} ok={s.ok} count={s.count} />
+              ))}
               <p className="mt-3 border-t border-zinc-800/80 pt-3 font-mono text-[9.5px] leading-relaxed text-zinc-600">
-                Pulled server-side from the <b className="font-medium text-zinc-400">CISA KEV catalog</b> (no CORS, 30-min revalidate). Per-CVE links resolve to <b className="font-medium text-zinc-400">NVD</b>; weakness classes map to <b className="font-medium text-zinc-400">MITRE CWE</b>.
+                Aggregated server-side (no CORS, 30-min revalidate): <b className="font-medium text-zinc-400">CISA KEV</b> + <b className="font-medium text-zinc-400">GitHub Advisory DB</b> deduped by CVE, CVSS cross-matched. Headlines from <b className="font-medium text-zinc-400">RSS</b>; weakness classes map to <b className="font-medium text-zinc-400">MITRE CWE</b>.
               </p>
             </RailPanel>
+
+            {headlines.length > 0 && (
+              <RailPanel title="industry headlines">
+                <div className="flex flex-col">
+                  {headlines.map((h) => (
+                    <a
+                      key={h.link}
+                      href={h.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group border-t border-zinc-800/60 py-2.5 first:border-t-0 first:pt-0"
+                    >
+                      <p className="text-[12px] leading-snug text-zinc-300 transition-colors group-hover:text-emerald-400 [overflow-wrap:anywhere]">
+                        {h.title}
+                      </p>
+                      <div className="mt-1 flex items-center gap-2 font-mono text-[9px] uppercase tracking-wide text-zinc-600">
+                        <span>{h.source}</span>
+                        {h.date && <span className="ml-auto normal-case">{timeSince(h.date)}</span>}
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </RailPanel>
+            )}
           </aside>
         </div>
 
@@ -379,18 +438,44 @@ function SevTag({ severity }: { severity: Severity }) {
   )
 }
 
-function SourceChip({ label, state }: { label: string; state: 'live' | 'detail' }) {
+function SourceChip({ label, type, ok }: { label: string; type: SourceStatus['type']; ok: boolean }) {
+  const lit = ok && (type === 'live' || type === 'rss')
   return (
     <span className="inline-flex items-center gap-2 rounded-md border border-zinc-800 bg-zinc-900/40 px-2.5 py-1.5 font-mono text-[10px] tracking-wide text-zinc-500">
-      <span className={`h-1.5 w-1.5 rounded-full ${state === 'live' ? 'bg-emerald-500 shadow-[0_0_5px] shadow-emerald-500' : 'bg-zinc-600'}`} />
+      <span className={`h-1.5 w-1.5 rounded-full ${lit ? 'bg-emerald-500 shadow-[0_0_5px] shadow-emerald-500' : ok ? 'bg-zinc-600' : 'bg-rose-500/70'}`} />
       {label}
-      {state === 'live' && <b className="ml-0.5 font-medium text-emerald-400">live</b>}
+      {type === 'live' && ok && <b className="ml-0.5 font-medium text-emerald-400">live</b>}
+      {type === 'rss' && ok && <b className="ml-0.5 font-medium text-zinc-400">rss</b>}
+    </span>
+  )
+}
+
+function CvssChip({ score }: { score?: number | null }) {
+  if (score == null) return null
+  const color =
+    score >= 9
+      ? 'border-rose-500/40 bg-rose-500/10 text-rose-300'
+      : score >= 7
+        ? 'border-orange-500/40 bg-orange-500/10 text-orange-300'
+        : score >= 4
+          ? 'border-yellow-500/35 bg-yellow-500/10 text-yellow-200'
+          : 'border-zinc-700 text-zinc-300'
+  return <span className={`rounded border px-1.5 py-0.5 font-mono text-[10px] ${color}`}>CVSS {score.toFixed(1)}</span>
+}
+
+function SourceTag({ source }: { source?: string }) {
+  if (!source) return null
+  const label = source === 'CISA KEV' ? 'KEV' : source === 'GitHub Advisory' ? 'GH' : source
+  return (
+    <span className="ml-auto rounded border border-zinc-800 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wide text-zinc-500">
+      {label}
     </span>
   )
 }
 
 function AdvisoryCard({ item }: { item: NewsItem }) {
-  const overdue = new Date(item.dueDate) < new Date()
+  const hasDue = !!item.dueDate && !Number.isNaN(new Date(item.dueDate).getTime())
+  const overdue = hasDue && new Date(item.dueDate) < new Date()
   return (
     <a
       href={item.nvdUrl}
@@ -400,12 +485,14 @@ function AdvisoryCard({ item }: { item: NewsItem }) {
     >
       <div className="mb-2.5 flex flex-wrap items-center gap-2">
         <SevTag severity={item.severity} />
+        <CvssChip score={item.cvss} />
         <span className="rounded border border-zinc-700 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300">{item.category}</span>
         <span className="font-mono text-[10px] text-zinc-600">{item.id}</span>
         <span className="rounded border border-zinc-800 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wide text-zinc-500">{item.vendor}</span>
         {item.ransomware === 'Known' && (
           <span className="rounded border border-rose-500/40 bg-rose-500/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wide text-rose-300">Ransomware</span>
         )}
+        <SourceTag source={item.source} />
       </div>
       <h3 className="text-sm font-medium leading-snug tracking-tight [overflow-wrap:anywhere]">{item.title}</h3>
       <p className="mt-1.5 line-clamp-2 text-[12.5px] leading-relaxed text-zinc-500 [overflow-wrap:anywhere]">{item.description}</p>
@@ -414,11 +501,13 @@ function AdvisoryCard({ item }: { item: NewsItem }) {
         {item.cwes.slice(0, 2).map((cwe) => (
           <span key={cwe} className="rounded border border-zinc-800 px-1.5 py-0.5 text-zinc-500">{cwe}</span>
         ))}
-        <span className="inline-flex items-center gap-1">
-          <Calendar className="h-3 w-3" />
-          <span className="text-zinc-500">due</span>
-          <span className={overdue ? 'text-rose-400' : 'text-zinc-400'}>{formatDate(item.dueDate)}</span>
-        </span>
+        {hasDue && (
+          <span className="inline-flex items-center gap-1">
+            <Calendar className="h-3 w-3" />
+            <span className="text-zinc-500">due</span>
+            <span className={overdue ? 'text-rose-400' : 'text-zinc-400'}>{formatDate(item.dueDate)}</span>
+          </span>
+        )}
         <span className="ml-auto">{timeSince(item.date)}</span>
       </div>
     </a>
@@ -446,12 +535,14 @@ function Stat({ label, value, className }: { label: string; value: number | stri
   )
 }
 
-function FeedRow({ name, type, live }: { name: string; type: string; live?: boolean }) {
+function FeedRow({ name, type, ok, count }: { name: string; type: SourceStatus['type']; ok: boolean; count: number }) {
+  const lit = ok && (type === 'live' || type === 'rss')
   return (
     <div className="flex items-center gap-2.5 py-1 font-mono text-[11px] text-zinc-400">
-      <span className={`h-1.5 w-1.5 flex-none rounded-full ${live ? 'bg-emerald-500 shadow-[0_0_5px] shadow-emerald-500' : 'bg-zinc-700'}`} />
+      <span className={`h-1.5 w-1.5 flex-none rounded-full ${lit ? 'bg-emerald-500 shadow-[0_0_5px] shadow-emerald-500' : ok ? 'bg-zinc-700' : 'bg-rose-500/70'}`} />
       <span className="text-zinc-200">{name}</span>
-      <span className="ml-auto text-[9px] uppercase tracking-wide text-zinc-600">{type}</span>
+      {count > 0 && <span className="text-zinc-600">{count}</span>}
+      <span className="ml-auto text-[9px] uppercase tracking-wide text-zinc-600">{ok ? type : 'down'}</span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Realises the **News Concept ("THREAT WIRE")** "source feeds" panel for real — the multi-source **route upgrade** that `globe-loader/chats/chat1.md` flagged as "the next step" after PR #15 shipped the UI. Keeps the shipped UI intact; makes the data multi-source.

### `app/api/news/route.ts` — multi-source aggregation
- **CISA KEV** stays the guaranteed baseline (ransomware + remediation deadlines).
- **GitHub Security Advisory DB** added as a second live feed → real **CVSS**, ecosystem, CWEs. Merged with KEV deduped by CVE id; KEV items get CVSS **cross-matched** from GitHub for free.
- **NVD** optional CVSS enrichment, gated on `NVD_API_KEY` (unauth limit too flaky for prod).
- **The Hacker News + BleepingComputer** RSS → separate honest `headlines[]` channel (articles, not CVEs).
- Every feed isolated in `try/catch` + `AbortSignal.timeout`; one failure degrades gracefully, KEV alone always yields a usable wire. Returns `sources[]` status, `avgCvss`, `headlines[]`.

### `app/news/page.tsx` — surfaces new data, same layout
- CVSS chips on lead + cards; **"Avg CVSS"** stat restored to the intelligence rail.
- Source chips + "source feeds" panel now driven by real `sources[]` (live/rss/down states).
- New **"industry headlines"** rail panel; KEV/GH source tags; due-date badge guarded for feeds without a deadline.

## Test plan
- [x] `tsc --noEmit` clean (zero errors in changed files)
- [x] `next build` green in a clean-room worktree (exit 0; `/news` static, `/api/news` 30m revalidate)
- [ ] Visual QA at 375 / 768 / 1440 + reduced-motion (browser MCP profile locked locally)
- [ ] Confirm GitHub Advisory + RSS feeds populate in prod (set optional `GITHUB_TOKEN` / `NVD_API_KEY` for headroom)