### PR TITLE
feat(subscribe): in-page Moyasar card payment (test mode)

### DIFF
--- a/app/subscribe/MoyasarPayment.tsx
+++ b/app/subscribe/MoyasarPayment.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useEffect, useRef, useState } from "react"
+import { MOYASAR_PK, MOYASAR_TEST } from "@/lib/subscribe/config"
+
+// Moyasar Payment Form (mpf) — loaded from CDN at runtime.
+const MPF_CSS = "https://cdn.moyasar.com/mpf/1.14.0/moyasar.css"
+const MPF_JS = "https://cdn.moyasar.com/mpf/1.14.0/moyasar.js"
+
+declare global {
+  interface Window {
+    Moyasar?: { init: (opts: Record<string, unknown>) => void }
+  }
+}
+
+function ensureCss() {
+  if (document.querySelector(`link[data-mpf]`)) return
+  const link = document.createElement("link")
+  link.rel = "stylesheet"
+  link.href = MPF_CSS
+  link.setAttribute("data-mpf", "1")
+  document.head.appendChild(link)
+}
+
+function ensureScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (window.Moyasar) return resolve()
+    const existing = document.querySelector<HTMLScriptElement>(`script[data-mpf]`)
+    if (existing) {
+      existing.addEventListener("load", () => resolve())
+      existing.addEventListener("error", () => reject(new Error("mpf")))
+      return
+    }
+    const s = document.createElement("script")
+    s.src = MPF_JS
+    s.setAttribute("data-mpf", "1")
+    s.onload = () => resolve()
+    s.onerror = () => reject(new Error("mpf"))
+    document.head.appendChild(s)
+  })
+}
+
+/**
+ * In-page Moyasar card form. Renders the real payment form (Mada + cards) right
+ * inside the funnel — no redirect to an external page before paying. On submit,
+ * Moyasar handles 3-D Secure and returns the browser to `callback_url`
+ * (`/subscribe?id=…&status=…`), which the funnel reads to show the result.
+ */
+export function MoyasarPayment({
+  amountSar,
+  description,
+  metadata,
+}: {
+  amountSar: number
+  description: string
+  metadata: Record<string, string>
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const initialized = useRef(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (initialized.current) return
+    initialized.current = true // guard synchronously — parent re-renders each second (countdown)
+    let cancelled = false
+    ;(async () => {
+      try {
+        ensureCss()
+        await ensureScript()
+        if (cancelled || !window.Moyasar || !ref.current) return
+        window.Moyasar.init({
+          element: ".mysr-form",
+          amount: Math.round(amountSar * 100), // halalas
+          currency: "SAR",
+          description,
+          publishable_api_key: MOYASAR_PK,
+          callback_url: `${window.location.origin}/subscribe`,
+          methods: ["creditcard"],
+          metadata,
+        })
+      } catch {
+        if (!cancelled) setError("Couldn't load the payment form. Please refresh and try again.")
+      }
+    })()
+    return () => { cancelled = true }
+  }, [amountSar, description, metadata])
+
+  return (
+    <div className="space-y-3">
+      <div ref={ref} className="mysr-form" />
+      {error && <p className="text-center font-mono text-[11px] text-red-400">{error}</p>}
+      {MOYASAR_TEST && (
+        <div className="rounded-md border border-yellow-800/50 bg-yellow-950/15 px-3 py-2.5 text-center">
+          <p className="font-mono text-[10px] uppercase tracking-widest text-yellow-500">test mode</p>
+          <p className="mt-1 font-mono text-[11px] text-zinc-400">
+            Card <span className="text-zinc-200">4111 1111 1111 1111</span> · any future date · CVC <span className="text-zinc-200">123</span> · OTP <span className="text-zinc-200">123456</span>
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/subscribe/README.md
+++ b/app/subscribe/README.md
@@ -13,18 +13,28 @@ personalized promo code (visitor's name + date, e.g. `sara_jun07`).
 
 ## Make it live — 2 things to set (Vercel → Settings → Environment Variables)
 
-### 1) Payment links (one per plan)
-Create a checkout for each tier in **Moyasar** or **Tap** (both do Mada + Apple Pay,
-best for Saudi) or a **Stripe Payment Link**, then set:
+### 1) Payment — in-page Moyasar card form (default)
+GET MY PLAN now opens a **Moyasar card form right on the page** (no redirect before
+paying). It ships in **test mode** by default so you can verify the flow with the
+test card `4111 1111 1111 1111` (any future date · CVC 123 · OTP 123456).
 
+To go **live with Moyasar**, set the live publishable key and **redeploy**:
 ```
-NEXT_PUBLIC_CHECKOUT_TRIAL=https://...     # 1-week, 9 SAR
-NEXT_PUBLIC_CHECKOUT_MONTH=https://...      # 4-week, 29 SAR  (most popular)
-NEXT_PUBLIC_CHECKOUT_QUARTER=https://...    # 12-week, 69 SAR (best value)
+NEXT_PUBLIC_MOYASAR_PK=pk_live_...
 ```
-These are inlined at **build time** → after setting them, **redeploy**.
-If a link is empty, that plan captures the lead and shows a "we'll email your plan"
-confirmation instead of charging — never a fake checkout.
+> ⚠️ Moyasar (and Tap) require a **Commercial Registration (CR)** to activate live
+> payments. No CR yet? See the no-CR path below.
+
+### No-CR path to take real money ASAP (recommended to start)
+Use a **Merchant-of-Record** — they let an individual sell worldwide, handle
+VAT/compliance, and need **no CR**:
+- **Gumroad** — fastest (~5 min), individual creators, overlay checkout.
+- **Lemon Squeezy** / **Paddle** — MoR with subscriptions + on-page overlay.
+
+Create a product per tier, then either drop the overlay link in
+`NEXT_PUBLIC_CHECKOUT_*` (an overlay mode can be wired to keep it on-page) or ping me
+to wire the overlay. Switch to **Moyasar live** later (lower fees, Mada + Apple Pay)
+once the CR is sorted.
 
 ### 2) Lead delivery (so you get every quiz lead for the weekly PDF)
 Set **one** (or both). Runtime vars — no redeploy needed beyond the next deploy.

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -8,8 +8,9 @@ import {
 } from "lucide-react"
 import { QUIZ, QUIZ_TOTAL } from "@/lib/subscribe/quiz"
 import {
-  BUILD_STEPS, PLANS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, checkoutUrl, type Plan,
+  BUILD_STEPS, PLANS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, planById, type Plan,
 } from "@/lib/subscribe/config"
+import { MoyasarPayment } from "./MoyasarPayment"
 
 const ICONS: Record<string, LucideIcon> = {
   user: User, zap: Zap, wrench: Wrench, alert: AlertTriangle, layers: Layers, clock: Clock,
@@ -21,7 +22,7 @@ const ICONS: Record<string, LucideIcon> = {
 const OFFER_KEY = "gnb_vault_offer_expires"
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-type Phase = "intro" | "quiz" | "loading" | "plan" | "done"
+type Phase = "intro" | "quiz" | "loading" | "plan" | "pay" | "success" | "payfail"
 
 function useCountdown(expiresAt: number | null) {
   const [remaining, setRemaining] = useState(PROMO_WINDOW_MS)
@@ -47,7 +48,7 @@ export default function SubscribePage() {
   const [promo, setPromo] = useState<string | null>(null)
   const [expiresAt, setExpiresAt] = useState<number | null>(null)
   const [selected, setSelected] = useState<Plan["id"]>("month")
-  const [submitting, setSubmitting] = useState(false)
+  const [payResult, setPayResult] = useState<{ status: string; id: string | null; message: string | null } | null>(null)
   const topRef = useRef<HTMLDivElement>(null)
 
   const { display: countdown, expired } = useCountdown(expiresAt)
@@ -56,6 +57,17 @@ export default function SubscribePage() {
 
   const scrollTop = useCallback(() => {
     topRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }, [])
+
+  // Moyasar redirects the browser back here after 3-D Secure with
+  // ?id=&status=&message= — read it and show the result, then clean the URL.
+  useEffect(() => {
+    const sp = new URLSearchParams(window.location.search)
+    const status = sp.get("status")
+    if (!status) return
+    setPayResult({ status, id: sp.get("id"), message: sp.get("message") })
+    setPhase(status === "paid" ? "success" : "payfail")
+    window.history.replaceState({}, "", "/subscribe")
   }, [])
 
   // Fire-and-forget lead capture (never blocks the funnel).
@@ -136,19 +148,9 @@ export default function SubscribePage() {
   }, [phase, scrollTop])
 
   const handleGetPlan = useCallback(() => {
-    setSubmitting(true)
-    sendLead(selected, promo)
-    const url = checkoutUrl(selected)
-    if (url) {
-      window.location.href = url
-      return
-    }
-    // No payment link configured yet → honest confirmation, lead already captured.
-    window.setTimeout(() => {
-      setSubmitting(false)
-      setPhase("done")
-      scrollTop()
-    }, 600)
+    sendLead(selected, promo) // capture the lead, then pay in-page (no exit)
+    setPhase("pay")
+    scrollTop()
   }, [selected, promo, sendLead, scrollTop])
 
   const progressPct = useMemo(() => Math.round((qIndex / QUIZ_TOTAL) * 100), [qIndex])
@@ -376,10 +378,9 @@ export default function SubscribePage() {
             <button
               type="button"
               onClick={handleGetPlan}
-              disabled={submitting}
-              className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 py-4 font-mono text-sm font-bold uppercase tracking-wide text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400 disabled:opacity-60"
+              className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 py-4 font-mono text-sm font-bold uppercase tracking-wide text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
             >
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <>GET MY PLAN <ArrowRight className="h-4 w-4" /></>}
+              GET MY PLAN <ArrowRight className="h-4 w-4" />
             </button>
 
             <p className="text-center font-mono text-[11px] text-emerald-600/80" dir="rtl">{PRODUCT.socialProofAr}</p>
@@ -404,17 +405,77 @@ export default function SubscribePage() {
           </section>
         )}
 
-        {/* ── DONE (no payment link configured yet) ──────────────────────── */}
-        {phase === "done" && (
+        {/* ── PAY (in-page Moyasar card form — no exit before paying) ─────── */}
+        {phase === "pay" && promo && (() => {
+          const sel = planById(selected)
+          return (
+            <section className="animate-[os-panel-in_0.4s_cubic-bezier(0.16,1,0.3,1)_both] space-y-4">
+              <button
+                type="button"
+                onClick={() => { setPhase("plan"); scrollTop() }}
+                className="flex items-center gap-1 font-mono text-[11px] uppercase tracking-widest text-zinc-600 hover:text-zinc-400"
+              >
+                <ArrowLeft className="h-3 w-3" /> change plan
+              </button>
+
+              <div className="rounded-xl border border-emerald-800 bg-emerald-950/15 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-mono text-xs font-semibold uppercase tracking-wide text-zinc-200">{sel.en}</p>
+                    <p className="text-xs text-zinc-500" dir="rtl">{sel.ar}</p>
+                  </div>
+                  <div className="text-right">
+                    <span className="font-mono text-2xl font-bold text-emerald-300">{sel.price}</span>
+                    <span className="font-mono text-xs text-zinc-500"> SAR</span>
+                    <p className="font-mono text-[10px] text-zinc-600">{sel.perDay}</p>
+                  </div>
+                </div>
+                <div className="mt-3 flex items-center gap-2 border-t border-emerald-900/40 pt-2.5">
+                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                  <span className="font-mono text-[10px] text-emerald-600">promo <span className="text-emerald-400">{promo}</span> applied</span>
+                </div>
+              </div>
+
+              <MoyasarPayment
+                amountSar={sel.price}
+                description={`Toolkit Vault · ${sel.en} · ${promo}`}
+                metadata={{ plan: sel.id, promo: promo ?? "", name, email }}
+              />
+
+              <p className="text-center font-mono text-[10px] text-zinc-700" dir="rtl">
+                دفع آمن · إلغاء في أي وقت · secure payment
+              </p>
+            </section>
+          )
+        })()}
+
+        {/* ── SUCCESS (Moyasar returned paid) ─────────────────────────────── */}
+        {phase === "success" && (
           <section className="animate-[os-panel-in_0.4s_cubic-bezier(0.16,1,0.3,1)_both] space-y-4 pt-8 text-center">
             <CheckCircle2 className="mx-auto h-10 w-10 text-emerald-500" />
-            <h2 className="text-xl font-bold text-zinc-100" dir="rtl">تم! أنت داخل القائمة</h2>
-            <p className="text-sm text-zinc-400" dir="rtl">
-              بنرسل خطتك الأولى وكود الخصم <span className="font-mono text-emerald-400">{promo}</span> على <span className="font-mono text-zinc-200">{email}</span>.
-            </p>
+            <h2 className="text-xl font-bold text-zinc-100" dir="rtl">تم الدفع! أهلاً فيك</h2>
+            <p className="text-sm text-zinc-400" dir="rtl">بنرسل لك أول حقيبة أدوات على إيميلك قريب.</p>
             <p className="font-mono text-xs text-zinc-600">
-              You&apos;re on the list — your first toolkit + promo is on its way to {email}.
+              Payment confirmed — your first toolkit is on its way.
+              {payResult?.id ? ` (ref ${payResult.id.slice(0, 12)})` : ""}
             </p>
+          </section>
+        )}
+
+        {/* ── PAYMENT FAILED ──────────────────────────────────────────────── */}
+        {phase === "payfail" && (
+          <section className="animate-[os-panel-in_0.4s_cubic-bezier(0.16,1,0.3,1)_both] space-y-4 pt-8 text-center">
+            <AlertTriangle className="mx-auto h-10 w-10 text-red-400" />
+            <h2 className="text-xl font-bold text-zinc-100" dir="rtl">ما تم الدفع</h2>
+            <p className="text-sm text-zinc-400" dir="rtl">صار خطأ في الدفع. جرّب مرة ثانية.</p>
+            {payResult?.message && <p className="font-mono text-[11px] text-zinc-600">{payResult.message}</p>}
+            <button
+              type="button"
+              onClick={() => { setPhase("plan"); scrollTop() }}
+              className="mx-auto flex items-center gap-2 rounded-md border border-zinc-700 px-4 py-2.5 font-mono text-xs text-zinc-300 transition-colors hover:border-zinc-500"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" /> try again
+            </button>
           </section>
         )}
 

--- a/lib/subscribe/config.ts
+++ b/lib/subscribe/config.ts
@@ -143,3 +143,17 @@ export function checkoutUrl(planId: Plan["id"]): string {
   }
   return (map[planId] ?? "").trim()
 }
+
+/**
+ * Moyasar publishable key — safe to ship client-side (it can only CREATE
+ * payments, never read/refund). Defaults to the project's TEST key so the
+ * in-page card form works immediately for verification. For live charging set
+ * NEXT_PUBLIC_MOYASAR_PK to a pk_live_… (requires a Commercial Registration, or
+ * switch to a Merchant-of-Record). Never commit a secret (sk_) key.
+ */
+export const MOYASAR_PK = (process.env.NEXT_PUBLIC_MOYASAR_PK || "pk_test_MWeYAjgV2RfLPQzDufrY1pToi8L3867vnUFuHiF1").trim()
+export const MOYASAR_TEST = MOYASAR_PK.startsWith("pk_test")
+
+export function planById(id: Plan["id"]): Plan {
+  return PLANS.find((p) => p.id === id) ?? PLANS[1]
+}


### PR DESCRIPTION
GET MY PLAN now opens a **Moyasar card form on the page** (no exit before paying): quiz → plan → inline card form → 3-D Secure → success/fail.

- `MoyasarPayment.tsx` mounts Moyasar mpf (v1.14) for the selected plan (SAR → halalas), callback back to `/subscribe`.
- New `pay` / `success` / `payfail` phases; reads Moyasar's `?id&status&message` on return.
- Ships in **test mode** (default test publishable key, test-card hint) so payments verify immediately; set `NEXT_PUBLIC_MOYASAR_PK=pk_live_…` for live.
- README documents that Moyasar live needs a **CR**, plus the **no-CR Merchant-of-Record** path (Gumroad / Lemon Squeezy) to take real money now.

Verified in browser: form mounts (4 card inputs), promo + plan summary correct. `tsc` + `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)