### PR TITLE
feat(subscribe): wire funnel to Gumroad + Toolkit Vault entry points

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState, useEffect, type ElementType } from "react"
 import Link from "next/link"
 import dynamic from "next/dynamic"
-import { ArrowRight, Terminal, Layers, Radio, Mail, User, ChevronRight, ChevronDown, Maximize2, X, Building2, Rocket, Cloud, Database, Cable, Zap, WifiOff, Calendar, Flame, AlertTriangle, Sun } from "lucide-react"
+import { ArrowRight, Terminal, Layers, Radio, Mail, User, ChevronRight, ChevronDown, Maximize2, X, Building2, Rocket, Cloud, Database, Cable, Zap, WifiOff, Calendar, Flame, AlertTriangle, Sun, Lock } from "lucide-react"
 import { OSDesktop, OSTaskbar, AmbientFeed } from "@/components/os"
 import { cn } from "@/lib/utils"
 import type { FeedEntry } from "@/components/os"
@@ -45,6 +45,7 @@ const MODULE_ITEMS: { href: string; code: string; label: string; sub: string; Ic
   { href: "/signal",      code: "03", label: "SIGNAL",      sub: "Live activity · Feed",         Icon: Radio    },
   { href: "/contact",     code: "04", label: "CONTACT",     sub: "Encrypted channel",            Icon: Mail     },
   { href: "/terminal",    code: "05", label: "TERMINAL",    sub: "Command interface",            Icon: Terminal },
+  { href: "/subscribe",   code: "06", label: "TOOLKIT VAULT", sub: "Weekly security + AI tools · Subscribe", Icon: Lock },
 ]
 
 // Hero credential chips

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react"
 import { QUIZ, QUIZ_TOTAL } from "@/lib/subscribe/quiz"
 import {
-  BUILD_STEPS, PLANS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, planById, type Plan,
+  BUILD_STEPS, PLANS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, checkoutUrl, planById, type Plan,
 } from "@/lib/subscribe/config"
 import { MoyasarPayment } from "./MoyasarPayment"
 
@@ -47,7 +47,7 @@ export default function SubscribePage() {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [promo, setPromo] = useState<string | null>(null)
   const [expiresAt, setExpiresAt] = useState<number | null>(null)
-  const [selected, setSelected] = useState<Plan["id"]>("month")
+  const [selected, setSelected] = useState<Plan["id"]>("monthly")
   const [payResult, setPayResult] = useState<{ status: string; id: string | null; message: string | null } | null>(null)
   const topRef = useRef<HTMLDivElement>(null)
 
@@ -148,10 +148,9 @@ export default function SubscribePage() {
   }, [phase, scrollTop])
 
   const handleGetPlan = useCallback(() => {
-    sendLead(selected, promo) // capture the lead, then pay in-page (no exit)
-    setPhase("pay")
-    scrollTop()
-  }, [selected, promo, sendLead, scrollTop])
+    sendLead(selected, promo) // capture the lead, then hand off to Gumroad checkout (recurrence pre-selected)
+    window.location.href = checkoutUrl(selected)
+  }, [selected, promo, sendLead])
 
   const progressPct = useMemo(() => Math.round((qIndex / QUIZ_TOTAL) * 100), [qIndex])
 
@@ -361,12 +360,12 @@ export default function SubscribePage() {
                       </div>
                       <div className="shrink-0 text-right">
                         <div className="flex items-baseline justify-end gap-1.5">
-                          <span className="font-mono text-[11px] text-zinc-600 line-through">{plan.original}</span>
-                          <span className={["font-mono text-2xl font-bold", isSel ? "text-emerald-300" : "text-zinc-200"].join(" ")}>{plan.price}</span>
-                          <span className="font-mono text-xs text-zinc-500">SAR</span>
+                          {plan.original ? <span className="font-mono text-[11px] text-zinc-600 line-through">${plan.original}</span> : null}
+                          <span className={["font-mono text-2xl font-bold", isSel ? "text-emerald-300" : "text-zinc-200"].join(" ")}>${plan.price}</span>
+                          <span className="font-mono text-xs text-zinc-500">{plan.id === "yearly" ? "/yr" : "/mo"}</span>
                         </div>
                         <p className="mt-0.5 font-mono text-[10px] text-zinc-600">{plan.perDay}</p>
-                        <p className="font-mono text-[9px] text-zinc-700">{plan.usd}</p>
+                        {plan.usd ? <p className="font-mono text-[9px] text-emerald-500">{plan.usd}</p> : null}
                       </div>
                     </div>
                   </button>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -48,6 +48,7 @@ export function MobileNav({ showTerminal, onToggleTerminal }: MobileNavProps) {
             <ul className="space-y-6">
               {[
                 { href: "/services", label: "Hire Me", highlight: true },
+                { href: "/subscribe", label: "Toolkit Vault — Subscribe", highlight: true },
                 { href: "#about", label: "About" },
                 { href: "#skills", label: "Skills" },
                 { href: "#projects", label: "Projects" },

--- a/lib/subscribe/config.ts
+++ b/lib/subscribe/config.ts
@@ -11,21 +11,17 @@
 // === END METADATA ===
 
 export type Plan = {
-  id: "trial" | "month" | "quarter"
+  id: "monthly" | "yearly"
   en: string
   ar: string
-  badge: string | null
-  badgeAr: string | null
   tag: string | null
-  tagAr: string | null
-  original: number // SAR, strike-through
-  price: number // SAR
-  perDay: string // "1.04 SAR/day"
-  perDayAr: string // "١.٠٤ ر.س/يوم"
-  usd: string // "≈ $7.7"
-  weeks: number
-  highlight: boolean
+  badge: string | null
+  original: number | null // USD, strike-through (yearly only)
+  price: number // USD
+  perDay: string // small note line under the price
+  usd: string // secondary note (e.g. "save 36%")
   best: boolean
+  recurrence: "monthly" | "yearly" // Gumroad recurrence key for checkout deep-link
 }
 
 /** Real 10-minute discount window (persisted, never silently reset). */
@@ -35,55 +31,30 @@ export const SAR_PER_USD = 3.75
 
 export const PLANS: Plan[] = [
   {
-    id: "trial",
-    en: "1-Week Trial",
-    ar: "تجربة أسبوع",
-    badge: null,
-    badgeAr: null,
+    id: "monthly",
+    en: "Monthly",
+    ar: "اشتراك شهري",
     tag: null,
-    tagAr: null,
-    original: 19,
+    badge: null,
+    original: null,
     price: 9,
-    perDay: "1.29 SAR/day",
-    perDayAr: "١.٢٩ ر.س/يوم",
-    usd: "≈ $2.4",
-    weeks: 1,
-    highlight: false,
+    perDay: "billed monthly",
+    usd: "",
     best: false,
+    recurrence: "monthly",
   },
   {
-    id: "month",
-    en: "4-Week Plan",
-    ar: "خطة ٤ أسابيع",
-    badge: "SAVE 61%",
-    badgeAr: "وفّر ٦١٪",
-    tag: "MOST POPULAR",
-    tagAr: "الأكثر اختياراً",
-    original: 75,
-    price: 29,
-    perDay: "1.04 SAR/day",
-    perDayAr: "١.٠٤ ر.س/يوم",
-    usd: "≈ $7.7",
-    weeks: 4,
-    highlight: true,
-    best: false,
-  },
-  {
-    id: "quarter",
-    en: "12-Week Plan",
-    ar: "خطة ١٢ أسبوع",
-    badge: "SAVE 65%",
-    badgeAr: "وفّر ٦٥٪",
+    id: "yearly",
+    en: "Yearly",
+    ar: "اشتراك سنوي",
     tag: "BEST VALUE",
-    tagAr: "أفضل قيمة",
-    original: 199,
+    badge: "SAVE 36%",
+    original: 108,
     price: 69,
-    perDay: "0.82 SAR/day",
-    perDayAr: "٠.٨٢ ر.س/يوم",
-    usd: "≈ $18",
-    weeks: 12,
-    highlight: false,
+    perDay: "≈ $5.75/mo",
+    usd: "save 36%",
     best: true,
+    recurrence: "yearly",
   },
 ]
 
@@ -131,17 +102,14 @@ export function buildPromoCode(firstName: string): string {
 }
 
 /**
- * Resolve the checkout URL for a plan. Env (NEXT_PUBLIC_CHECKOUT_*) holds the
- * Moyasar/Tap/Stripe Payment Link. Returns "" when unconfigured so the funnel
- * uses the lead-capture fallback instead of a broken/fake checkout.
+ * The live Gumroad membership. checkoutUrl() deep-links straight into Gumroad
+ * checkout with the plan's recurrence pre-selected — verified working:
+ * `?wanted=true&recurrence=monthly|yearly` opens checkout pre-filled at $9 / $69.
  */
+export const GUMROAD_PRODUCT = "https://vault.goodnbad.info/l/xqybso"
+
 export function checkoutUrl(planId: Plan["id"]): string {
-  const map: Record<Plan["id"], string | undefined> = {
-    trial: process.env.NEXT_PUBLIC_CHECKOUT_TRIAL,
-    month: process.env.NEXT_PUBLIC_CHECKOUT_MONTH,
-    quarter: process.env.NEXT_PUBLIC_CHECKOUT_QUARTER,
-  }
-  return (map[planId] ?? "").trim()
+  return `${GUMROAD_PRODUCT}?wanted=true&recurrence=${planById(planId).recurrence}`
 }
 
 /**
@@ -155,5 +123,5 @@ export const MOYASAR_PK = (process.env.NEXT_PUBLIC_MOYASAR_PK || "pk_test_MWeYAj
 export const MOYASAR_TEST = MOYASAR_PK.startsWith("pk_test")
 
 export function planById(id: Plan["id"]): Plan {
-  return PLANS.find((p) => p.id === id) ?? PLANS[1]
+  return PLANS.find((p) => p.id === id) ?? PLANS[0]
 }


### PR DESCRIPTION
Wires the /subscribe quiz funnel to the live Gumroad membership and adds discoverable entry points.

## Changes
- `lib/subscribe/config.ts`: 3 SAR plans -> 2 USD plans (9/mo, 69/yr); `checkoutUrl()` deep-links into Gumroad checkout with recurrence pre-selected (verified: `?wanted=true&recurrence=monthly|yearly` opens pre-filled at 9/69).
- `app/subscribe/page.tsx`: GET MY PLAN redirects into the pre-filled Gumroad checkout; USD pricing display.
- `app/page.tsx`: homepage module launcher gains a TOOLKIT VAULT module -> /subscribe.
- `components/mobile-nav.tsx`: mobile nav gains a Toolkit Vault - Subscribe link.

## Test plan
- [ ] Preview: /subscribe quiz -> countdown -> GET MY PLAN -> Gumroad checkout opens pre-filled at the selected plan
- [ ] Homepage shows TOOLKIT VAULT module -> /subscribe
- [ ] tsc --noEmit passes (verified locally)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the `/subscribe` quiz funnel to a live Gumroad membership, replacing the previous SAR/Moyasar checkout with direct deep-links into Gumroad at `$9/mo` and `$69/yr`, and adds two new entry points (homepage module + mobile nav).

- **`lib/subscribe/config.ts`**: Three SAR plans replaced with two USD plans (`monthly`/`yearly`); `checkoutUrl()` now builds a Gumroad deep-link with `?wanted=true&recurrence=...`; `planById()` fallback corrected to `PLANS[0]` (monthly). A stale file-header comment, the unused `SAR_PER_USD` export, and a hard-coded product URL were also noted.
- **`app/subscribe/page.tsx`**: `handleGetPlan` now calls `window.location.href = checkoutUrl(selected)` instead of `setPhase("pay")`, making the entire Moyasar `pay`/`success`/`payfail` flow and its `MoyasarPayment` import unreachable dead code; the dead block still renders prices as SAR.
- **`app/page.tsx` / `components/mobile-nav.tsx`**: Straightforward addition of a TOOLKIT VAULT entry point in both the homepage module launcher and the mobile nav.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Gumroad redirect flow is correct and the lead-capture uses keepalive properly — safe to merge with the dead Moyasar block cleaned up.

The checkout redirect and new entry points work correctly. The dead Moyasar phase (including a stale SAR currency label) and outdated file metadata are the only substantive issues, none of which break the live user path.

app/subscribe/page.tsx (dead pay/success/payfail Moyasar block with wrong currency) and lib/subscribe/config.ts (stale header comment, unused SAR_PER_USD, hard-coded product URL)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/subscribe/config.ts | Plans migrated from 3 SAR plans to 2 USD plans; checkoutUrl() now deep-links to a hard-coded Gumroad URL; stale file-header comment and an unused SAR_PER_USD constant remain |
| app/subscribe/page.tsx | handleGetPlan now redirects to Gumroad instead of setPhase("pay"); the entire pay/success/payfail Moyasar flow and MoyasarPayment import are now unreachable dead code, and the pay phase still shows "SAR" currency |
| app/page.tsx | Adds TOOLKIT VAULT entry (code "06") to MODULE_ITEMS linking to /subscribe; Lock icon imported from lucide-react |
| components/mobile-nav.tsx | Adds "Toolkit Vault — Subscribe" link to mobile nav with highlight styling; straightforward addition |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant Subscribe as /subscribe page
    participant Lead as /api/subscribe/lead
    participant Gumroad as Gumroad Checkout

    User->>Subscribe: Completes quiz
    Subscribe->>Subscribe: Loading animation (2.6s)
    Subscribe->>Subscribe: Render plan paywall
    User->>Subscribe: Selects plan (monthly/yearly)
    User->>Subscribe: Clicks GET MY PLAN
    Subscribe->>Lead: POST (fire-and-forget, keepalive:true)
    Subscribe->>Gumroad: "window.location.href = checkoutUrl(selected)"
    Note over Gumroad: ?wanted=true&recurrence=monthly|yearly
    Gumroad-->>User: Pre-filled checkout at $9/$69
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant Subscribe as /subscribe page
    participant Lead as /api/subscribe/lead
    participant Gumroad as Gumroad Checkout

    User->>Subscribe: Completes quiz
    Subscribe->>Subscribe: Loading animation (2.6s)
    Subscribe->>Subscribe: Render plan paywall
    User->>Subscribe: Selects plan (monthly/yearly)
    User->>Subscribe: Clicks GET MY PLAN
    Subscribe->>Lead: POST (fire-and-forget, keepalive:true)
    Subscribe->>Gumroad: "window.location.href = checkoutUrl(selected)"
    Note over Gumroad: ?wanted=true&recurrence=monthly|yearly
    Gumroad-->>User: Pre-filled checkout at $9/$69
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `lib/subscribe/config.ts`, line 1-11 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/47a0faf9e03dc860855f0c033534fb40f9c0421c/lib/subscribe/config.ts#L1-L11)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The file-level metadata comment still describes the old SAR-based, three-plan structure ("9 / 29 / 69 SAR", "1-week / 4-week / 12-week", Moyasar/Tap/Stripe Payment Link fallback). Now that pricing is USD and checkout goes straight to Gumroad, this header actively misleads anyone reading the file.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsubscribe%2Fconfig.ts%0ALine%3A%201-11%0A%0AComment%3A%0AThe%20file-level%20metadata%20comment%20still%20describes%20the%20old%20SAR-based%2C%20three-plan%20structure%20%28%229%20%2F%2029%20%2F%2069%20SAR%22%2C%20%221-week%20%2F%204-week%20%2F%2012-week%22%2C%20Moyasar%2FTap%2FStripe%20Payment%20Link%20fallback%29.%20Now%20that%20pricing%20is%20USD%20and%20checkout%20goes%20straight%20to%20Gumroad%2C%20this%20header%20actively%20misleads%20anyone%20reading%20the%20file.%0A%0A%60%60%60suggestion%0A%2F%2F%20%3D%3D%3D%20METADATA%20%3D%3D%3D%0A%2F%2F%20Purpose%3A%20Pricing%2C%20product%20copy%2C%20promo%20%2B%20checkout%20config%20for%20the%20%2Fsubscribe%0A%2F%2F%20%20%20%20%20%20%20%20%20%20funnel.%20Two%20USD%20plans%3A%20%249%2Fmo%20%28monthly%29%20and%20%2469%2Fyr%20%28yearly%29.%0A%2F%2F%20%20%20%20%20%20%20%20%20%20Strike-through%20original%20on%20the%20yearly%20plan%20reflects%20the%20real%0A%2F%2F%20%20%20%20%20%20%20%20%20%20monthly-equivalent%20saving%20%2836%25%29.%0A%2F%2F%20Payment%3A%20CTA%20deep-links%20into%20Gumroad%20checkout%20via%20checkoutUrl%28%29%20with%0A%2F%2F%20%20%20%20%20%20%20%20%20%20recurrence%20pre-selected%20%28%3Fwanted%3Dtrue%26recurrence%3Dmonthly%7Cyearly%29.%0A%2F%2F%20%3D%3D%3D%20END%20METADATA%20%3D%3D%3D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Ftoolkit-vault-funnel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftoolkit-vault-funnel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsubscribe%2Fconfig.ts%0ALine%3A%201-11%0A%0AComment%3A%0AThe%20file-level%20metadata%20comment%20still%20describes%20the%20old%20SAR-based%2C%20three-plan%20structure%20%28%229%20%2F%2029%20%2F%2069%20SAR%22%2C%20%221-week%20%2F%204-week%20%2F%2012-week%22%2C%20Moyasar%2FTap%2FStripe%20Payment%20Link%20fallback%29.%20Now%20that%20pricing%20is%20USD%20and%20checkout%20goes%20straight%20to%20Gumroad%2C%20this%20header%20actively%20misleads%20anyone%20reading%20the%20file.%0A%0A%60%60%60suggestion%0A%2F%2F%20%3D%3D%3D%20METADATA%20%3D%3D%3D%0A%2F%2F%20Purpose%3A%20Pricing%2C%20product%20copy%2C%20promo%20%2B%20checkout%20config%20for%20the%20%2Fsubscribe%0A%2F%2F%20%20%20%20%20%20%20%20%20%20funnel.%20Two%20USD%20plans%3A%20%249%2Fmo%20%28monthly%29%20and%20%2469%2Fyr%20%28yearly%29.%0A%2F%2F%20%20%20%20%20%20%20%20%20%20Strike-through%20original%20on%20the%20yearly%20plan%20reflects%20the%20real%0A%2F%2F%20%20%20%20%20%20%20%20%20%20monthly-equivalent%20saving%20%2836%25%29.%0A%2F%2F%20Payment%3A%20CTA%20deep-links%20into%20Gumroad%20checkout%20via%20checkoutUrl%28%29%20with%0A%2F%2F%20%20%20%20%20%20%20%20%20%20recurrence%20pre-selected%20%28%3Fwanted%3Dtrue%26recurrence%3Dmonthly%7Cyearly%29.%0A%2F%2F%20%3D%3D%3D%20END%20METADATA%20%3D%3D%3D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `lib/subscribe/config.ts`, line 30-32 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/47a0faf9e03dc860855f0c033534fb40f9c0421c/lib/subscribe/config.ts#L30-L32)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `SAR_PER_USD` is no longer referenced anywhere in the codebase now that all pricing is in USD. Keeping it exported alongside the new USD-only `Plan` type is noise that implies a conversion path still exists.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsubscribe%2Fconfig.ts%0ALine%3A%2030-32%0A%0AComment%3A%0A%60SAR_PER_USD%60%20is%20no%20longer%20referenced%20anywhere%20in%20the%20codebase%20now%20that%20all%20pricing%20is%20in%20USD.%20Keeping%20it%20exported%20alongside%20the%20new%20USD-only%20%60Plan%60%20type%20is%20noise%20that%20implies%20a%20conversion%20path%20still%20exists.%0A%0A%60%60%60suggestion%0Aexport%20const%20PLANS%3A%20Plan%5B%5D%20%3D%20%5B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Ftoolkit-vault-funnel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftoolkit-vault-funnel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsubscribe%2Fconfig.ts%0ALine%3A%2030-32%0A%0AComment%3A%0A%60SAR_PER_USD%60%20is%20no%20longer%20referenced%20anywhere%20in%20the%20codebase%20now%20that%20all%20pricing%20is%20in%20USD.%20Keeping%20it%20exported%20alongside%20the%20new%20USD-only%20%60Plan%60%20type%20is%20noise%20that%20implies%20a%20conversion%20path%20still%20exists.%0A%0A%60%60%60suggestion%0Aexport%20const%20PLANS%3A%20Plan%5B%5D%20%3D%20%5B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


3. `app/subscribe/page.tsx`, line 407-449 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/47a0faf9e03dc860855f0c033534fb40f9c0421c/app/subscribe/page.tsx#L407-L449)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The entire `phase === "pay"` block (including `MoyasarPayment` on line 438) is now dead code — `handleGetPlan` redirects to Gumroad and never calls `setPhase("pay")`. Beyond the bundle weight of an unreachable component, the block still renders the price as `{sel.price} SAR` (line 427–428), so if this path is ever re-enabled it would display USD amounts labelled as SAR. The `MoyasarPayment` import on line 13 is also now unused. Consider removing the `pay` phase and its import, or at minimum updating the currency label, to avoid confusion.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsubscribe%2Fpage.tsx%0ALine%3A%20407-449%0A%0AComment%3A%0AThe%20entire%20%60phase%20%3D%3D%3D%20%22pay%22%60%20block%20%28including%20%60MoyasarPayment%60%20on%20line%20438%29%20is%20now%20dead%20code%20%E2%80%94%20%60handleGetPlan%60%20redirects%20to%20Gumroad%20and%20never%20calls%20%60setPhase%28%22pay%22%29%60.%20Beyond%20the%20bundle%20weight%20of%20an%20unreachable%20component%2C%20the%20block%20still%20renders%20the%20price%20as%20%60%7Bsel.price%7D%20SAR%60%20%28line%20427%E2%80%93428%29%2C%20so%20if%20this%20path%20is%20ever%20re-enabled%20it%20would%20display%20USD%20amounts%20labelled%20as%20SAR.%20The%20%60MoyasarPayment%60%20import%20on%20line%2013%20is%20also%20now%20unused.%20Consider%20removing%20the%20%60pay%60%20phase%20and%20its%20import%2C%20or%20at%20minimum%20updating%20the%20currency%20label%2C%20to%20avoid%20confusion.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Ftoolkit-vault-funnel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftoolkit-vault-funnel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsubscribe%2Fpage.tsx%0ALine%3A%20407-449%0A%0AComment%3A%0AThe%20entire%20%60phase%20%3D%3D%3D%20%22pay%22%60%20block%20%28including%20%60MoyasarPayment%60%20on%20line%20438%29%20is%20now%20dead%20code%20%E2%80%94%20%60handleGetPlan%60%20redirects%20to%20Gumroad%20and%20never%20calls%20%60setPhase%28%22pay%22%29%60.%20Beyond%20the%20bundle%20weight%20of%20an%20unreachable%20component%2C%20the%20block%20still%20renders%20the%20price%20as%20%60%7Bsel.price%7D%20SAR%60%20%28line%20427%E2%80%93428%29%2C%20so%20if%20this%20path%20is%20ever%20re-enabled%20it%20would%20display%20USD%20amounts%20labelled%20as%20SAR.%20The%20%60MoyasarPayment%60%20import%20on%20line%2013%20is%20also%20now%20unused.%20Consider%20removing%20the%20%60pay%60%20phase%20and%20its%20import%2C%20or%20at%20minimum%20updating%20the%20currency%20label%2C%20to%20avoid%20confusion.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Fsubscribe%2Fconfig.ts%3A1-11%0AThe%20file-level%20metadata%20comment%20still%20describes%20the%20old%20SAR-based%2C%20three-plan%20structure%20%28%229%20%2F%2029%20%2F%2069%20SAR%22%2C%20%221-week%20%2F%204-week%20%2F%2012-week%22%2C%20Moyasar%2FTap%2FStripe%20Payment%20Link%20fallback%29.%20Now%20that%20pricing%20is%20USD%20and%20checkout%20goes%20straight%20to%20Gumroad%2C%20this%20header%20actively%20misleads%20anyone%20reading%20the%20file.%0A%0A%60%60%60suggestion%0A%2F%2F%20%3D%3D%3D%20METADATA%20%3D%3D%3D%0A%2F%2F%20Purpose%3A%20Pricing%2C%20product%20copy%2C%20promo%20%2B%20checkout%20config%20for%20the%20%2Fsubscribe%0A%2F%2F%20%20%20%20%20%20%20%20%20%20funnel.%20Two%20USD%20plans%3A%20%249%2Fmo%20%28monthly%29%20and%20%2469%2Fyr%20%28yearly%29.%0A%2F%2F%20%20%20%20%20%20%20%20%20%20Strike-through%20original%20on%20the%20yearly%20plan%20reflects%20the%20real%0A%2F%2F%20%20%20%20%20%20%20%20%20%20monthly-equivalent%20saving%20%2836%25%29.%0A%2F%2F%20Payment%3A%20CTA%20deep-links%20into%20Gumroad%20checkout%20via%20checkoutUrl%28%29%20with%0A%2F%2F%20%20%20%20%20%20%20%20%20%20recurrence%20pre-selected%20%28%3Fwanted%3Dtrue%26recurrence%3Dmonthly%7Cyearly%29.%0A%2F%2F%20%3D%3D%3D%20END%20METADATA%20%3D%3D%3D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fsubscribe%2Fconfig.ts%3A30-32%0A%60SAR_PER_USD%60%20is%20no%20longer%20referenced%20anywhere%20in%20the%20codebase%20now%20that%20all%20pricing%20is%20in%20USD.%20Keeping%20it%20exported%20alongside%20the%20new%20USD-only%20%60Plan%60%20type%20is%20noise%20that%20implies%20a%20conversion%20path%20still%20exists.%0A%0A%60%60%60suggestion%0Aexport%20const%20PLANS%3A%20Plan%5B%5D%20%3D%20%5B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fsubscribe%2Fconfig.ts%3A109-113%0A%60GUMROAD_PRODUCT%60%20is%20hard-coded%20rather%20than%20read%20from%20an%20env%20var.%20This%20means%20switching%20to%20a%20staging%2Fsandbox%20product%20link%20for%20QA%20or%20a%20different%20URL%20after%20a%20product%20migration%20requires%20a%20full%20code%20change%20and%20redeployment.%20Consider%20%60process.env.NEXT_PUBLIC_GUMROAD_PRODUCT%20%3F%3F%20%22https%3A%2F%2Fvault.goodnbad.info%2Fl%2Fxqybso%22%60%20to%20keep%20the%20override%20path%20open%20without%20breaking%20anything%20today.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A407-449%0AThe%20entire%20%60phase%20%3D%3D%3D%20%22pay%22%60%20block%20%28including%20%60MoyasarPayment%60%20on%20line%20438%29%20is%20now%20dead%20code%20%E2%80%94%20%60handleGetPlan%60%20redirects%20to%20Gumroad%20and%20never%20calls%20%60setPhase%28%22pay%22%29%60.%20Beyond%20the%20bundle%20weight%20of%20an%20unreachable%20component%2C%20the%20block%20still%20renders%20the%20price%20as%20%60%7Bsel.price%7D%20SAR%60%20%28line%20427%E2%80%93428%29%2C%20so%20if%20this%20path%20is%20ever%20re-enabled%20it%20would%20display%20USD%20amounts%20labelled%20as%20SAR.%20The%20%60MoyasarPayment%60%20import%20on%20line%2013%20is%20also%20now%20unused.%20Consider%20removing%20the%20%60pay%60%20phase%20and%20its%20import%2C%20or%20at%20minimum%20updating%20the%20currency%20label%2C%20to%20avoid%20confusion.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Ftoolkit-vault-funnel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftoolkit-vault-funnel%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Fsubscribe%2Fconfig.ts%3A1-11%0AThe%20file-level%20metadata%20comment%20still%20describes%20the%20old%20SAR-based%2C%20three-plan%20structure%20%28%229%20%2F%2029%20%2F%2069%20SAR%22%2C%20%221-week%20%2F%204-week%20%2F%2012-week%22%2C%20Moyasar%2FTap%2FStripe%20Payment%20Link%20fallback%29.%20Now%20that%20pricing%20is%20USD%20and%20checkout%20goes%20straight%20to%20Gumroad%2C%20this%20header%20actively%20misleads%20anyone%20reading%20the%20file.%0A%0A%60%60%60suggestion%0A%2F%2F%20%3D%3D%3D%20METADATA%20%3D%3D%3D%0A%2F%2F%20Purpose%3A%20Pricing%2C%20product%20copy%2C%20promo%20%2B%20checkout%20config%20for%20the%20%2Fsubscribe%0A%2F%2F%20%20%20%20%20%20%20%20%20%20funnel.%20Two%20USD%20plans%3A%20%249%2Fmo%20%28monthly%29%20and%20%2469%2Fyr%20%28yearly%29.%0A%2F%2F%20%20%20%20%20%20%20%20%20%20Strike-through%20original%20on%20the%20yearly%20plan%20reflects%20the%20real%0A%2F%2F%20%20%20%20%20%20%20%20%20%20monthly-equivalent%20saving%20%2836%25%29.%0A%2F%2F%20Payment%3A%20CTA%20deep-links%20into%20Gumroad%20checkout%20via%20checkoutUrl%28%29%20with%0A%2F%2F%20%20%20%20%20%20%20%20%20%20recurrence%20pre-selected%20%28%3Fwanted%3Dtrue%26recurrence%3Dmonthly%7Cyearly%29.%0A%2F%2F%20%3D%3D%3D%20END%20METADATA%20%3D%3D%3D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fsubscribe%2Fconfig.ts%3A30-32%0A%60SAR_PER_USD%60%20is%20no%20longer%20referenced%20anywhere%20in%20the%20codebase%20now%20that%20all%20pricing%20is%20in%20USD.%20Keeping%20it%20exported%20alongside%20the%20new%20USD-only%20%60Plan%60%20type%20is%20noise%20that%20implies%20a%20conversion%20path%20still%20exists.%0A%0A%60%60%60suggestion%0Aexport%20const%20PLANS%3A%20Plan%5B%5D%20%3D%20%5B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fsubscribe%2Fconfig.ts%3A109-113%0A%60GUMROAD_PRODUCT%60%20is%20hard-coded%20rather%20than%20read%20from%20an%20env%20var.%20This%20means%20switching%20to%20a%20staging%2Fsandbox%20product%20link%20for%20QA%20or%20a%20different%20URL%20after%20a%20product%20migration%20requires%20a%20full%20code%20change%20and%20redeployment.%20Consider%20%60process.env.NEXT_PUBLIC_GUMROAD_PRODUCT%20%3F%3F%20%22https%3A%2F%2Fvault.goodnbad.info%2Fl%2Fxqybso%22%60%20to%20keep%20the%20override%20path%20open%20without%20breaking%20anything%20today.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A407-449%0AThe%20entire%20%60phase%20%3D%3D%3D%20%22pay%22%60%20block%20%28including%20%60MoyasarPayment%60%20on%20line%20438%29%20is%20now%20dead%20code%20%E2%80%94%20%60handleGetPlan%60%20redirects%20to%20Gumroad%20and%20never%20calls%20%60setPhase%28%22pay%22%29%60.%20Beyond%20the%20bundle%20weight%20of%20an%20unreachable%20component%2C%20the%20block%20still%20renders%20the%20price%20as%20%60%7Bsel.price%7D%20SAR%60%20%28line%20427%E2%80%93428%29%2C%20so%20if%20this%20path%20is%20ever%20re-enabled%20it%20would%20display%20USD%20amounts%20labelled%20as%20SAR.%20The%20%60MoyasarPayment%60%20import%20on%20line%2013%20is%20also%20now%20unused.%20Consider%20removing%20the%20%60pay%60%20phase%20and%20its%20import%2C%20or%20at%20minimum%20updating%20the%20currency%20label%2C%20to%20avoid%20confusion.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=29&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(subscribe): wire funnel to Gumroad ..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/47a0faf9e03dc860855f0c033534fb40f9c0421c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38647856)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->