### PR TITLE
feat(subscribe): EN/AR language toggle

### DIFF
--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -49,11 +49,15 @@ export default function SubscribePage() {
   const [expiresAt, setExpiresAt] = useState<number | null>(null)
   const [selected, setSelected] = useState<Plan["id"]>("monthly")
   const [payResult, setPayResult] = useState<{ status: string; id: string | null; message: string | null } | null>(null)
+  const [lang, setLang] = useState<"ar" | "en">("ar")
   const topRef = useRef<HTMLDivElement>(null)
 
   const { display: countdown, expired } = useCountdown(expiresAt)
   const name = answers.name ?? ""
   const email = answers.email ?? ""
+  const isAr = lang === "ar"
+  const tr = (ar: string, en: string) => (isAr ? ar : en)
+  const dir = isAr ? "rtl" : "ltr"
 
   const scrollTop = useCallback(() => {
     topRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
@@ -165,15 +169,22 @@ export default function SubscribePage() {
       <div ref={topRef} className="relative z-10 mx-auto max-w-lg px-4 pt-10 sm:pt-14">
 
         {/* Brand header */}
-        <div className="mb-7 text-center">
+        <div className="mb-6 text-center">
+          {/* Language toggle — always visible, front and center */}
+          <div className="mb-4 flex justify-center">
+            <div className="inline-flex rounded-full border border-zinc-700 bg-zinc-900/70 p-0.5 font-mono text-[11px]" role="group" aria-label="Language">
+              <button type="button" onClick={() => setLang("ar")} className={["rounded-full px-3.5 py-1 transition-colors", isAr ? "bg-emerald-500 font-semibold text-emerald-950" : "text-zinc-400 hover:text-zinc-200"].join(" ")}>العربية</button>
+              <button type="button" onClick={() => setLang("en")} className={["rounded-full px-3.5 py-1 transition-colors", !isAr ? "bg-emerald-500 font-semibold text-emerald-950" : "text-zinc-400 hover:text-zinc-200"].join(" ")}>English</button>
+            </div>
+          </div>
           <span className="mb-3 inline-block rounded border border-emerald-900 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-emerald-700">
             goodnbad · {PRODUCT.brandEn}
           </span>
-          <h1 className="mb-1 text-2xl font-bold leading-tight text-zinc-100 sm:text-3xl" dir="rtl">
-            {PRODUCT.brandAr}
+          <h1 className="mb-1 text-2xl font-bold leading-tight text-zinc-100 sm:text-3xl" dir={dir}>
+            {tr(PRODUCT.brandAr, PRODUCT.brandEn)}
           </h1>
-          <p className="font-mono text-sm leading-snug text-zinc-500">
-            Curated AI tools & underground repos — a weekly toolkit, built around you.
+          <p className="font-mono text-sm leading-snug text-zinc-500" dir={dir}>
+            {tr("أدوات ذكاء اصطناعي ومستودعات مختارة — حقيبة أسبوعية مبنية حولك.", "Curated AI tools & underground repos — a weekly toolkit, built around you.")}
           </p>
         </div>
 
@@ -182,14 +193,11 @@ export default function SubscribePage() {
           <section className="animate-[os-panel-in_0.4s_cubic-bezier(0.16,1,0.3,1)_both] space-y-5 text-center">
             <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-6 backdrop-blur-sm">
               <Rocket className="mx-auto mb-4 h-7 w-7 text-emerald-500" />
-              <h2 className="text-xl font-bold text-zinc-100" dir="rtl">
-                خلّنا نبني خطتك في دقيقة
+              <h2 className="text-xl font-bold text-zinc-100" dir={dir}>
+                {tr("خلّنا نبني خطتك في دقيقة", "Let's build your plan in a minute")}
               </h2>
-              <p className="mt-1.5 text-sm text-zinc-400" dir="rtl">
-                {QUIZ_TOTAL} سؤال سريع، وبنطلّع لك خطة أدوات مصمّمة على مقاسك.
-              </p>
-              <p className="mt-2 font-mono text-[11px] text-zinc-600">
-                {QUIZ_TOTAL} quick taps → your personalized AI toolkit plan.
+              <p className="mt-1.5 text-sm text-zinc-400" dir={dir}>
+                {tr(`${QUIZ_TOTAL} سؤال سريع، وبنطلّع لك خطة أدوات مصمّمة على مقاسك.`, `${QUIZ_TOTAL} quick taps → your personalized AI toolkit plan.`)}
               </p>
             </div>
             <button
@@ -197,10 +205,10 @@ export default function SubscribePage() {
               onClick={() => { setPhase("quiz"); scrollTop() }}
               className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 py-3.5 font-mono text-sm font-semibold uppercase tracking-wide text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
             >
-              <span dir="rtl">ابدأ · Start</span>
+              <span dir={dir}>{tr("ابدأ", "Start")}</span>
               <ArrowRight className="h-4 w-4" />
             </button>
-            <p className="font-mono text-[10px] text-zinc-700">free · no card to take the quiz</p>
+            <p className="font-mono text-[10px] text-zinc-700">{tr("مجاناً · بدون بطاقة لأخذ الاختبار", "free · no card to take the quiz")}</p>
           </section>
         )}
 
@@ -214,7 +222,7 @@ export default function SubscribePage() {
               <div className="flex items-center justify-between font-mono text-[10px] uppercase tracking-widest text-zinc-600">
                 {qIndex > 0 ? (
                   <button type="button" onClick={() => { setQIndex((i) => i - 1); scrollTop() }} className="flex items-center gap-1 hover:text-zinc-400">
-                    <ArrowLeft className="h-3 w-3" /> back
+                    <ArrowLeft className="h-3 w-3" /> {tr("رجوع", "back")}
                   </button>
                 ) : <span />}
                 <span>{qIndex + 1} / {QUIZ_TOTAL}</span>
@@ -222,11 +230,10 @@ export default function SubscribePage() {
             </div>
 
             <div key={q.id} className="animate-[os-panel-in_0.35s_cubic-bezier(0.16,1,0.3,1)_both] rounded-xl border border-zinc-800 bg-zinc-900/50 p-5 backdrop-blur-sm">
-              <div className="mb-4 flex items-start justify-between gap-3" dir="rtl">
+              <div className="mb-4 flex items-start justify-between gap-3" dir={dir}>
                 <div className="flex-1">
-                  <p className="text-base font-semibold text-zinc-100">{q.ar}</p>
-                  <p className="mt-1 font-mono text-[11px] text-zinc-500" dir="ltr">{q.en}</p>
-                  {"subEn" in q && q.subEn && <p className="mt-1 text-[11px] text-zinc-600" dir="ltr">{q.subEn}</p>}
+                  <p className="text-base font-semibold text-zinc-100" dir={dir}>{tr(q.ar, q.en)}</p>
+                  {!isAr && "subEn" in q && q.subEn && <p className="mt-1 text-[11px] text-zinc-600" dir="ltr">{q.subEn}</p>}
                 </div>
                 <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-emerald-900/70 bg-emerald-950/20 text-emerald-500">
                   {(() => { const Icon = ICONS[q.icon] ?? Sparkles; return <Icon className="h-4 w-4" /> })()}
@@ -249,8 +256,7 @@ export default function SubscribePage() {
                             : "border-zinc-800 bg-zinc-900/60 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-900",
                         ].join(" ")}
                       >
-                        <span className="font-mono text-[11px] text-zinc-500">{opt.en}</span>
-                        <span dir="rtl">{opt.ar}</span>
+                        <span dir={dir} className="text-sm font-medium">{tr(opt.ar, opt.en)}</span>
                       </button>
                     )
                   })}
@@ -274,7 +280,7 @@ export default function SubscribePage() {
                     disabled={!canAdvanceText}
                     className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 py-3 font-mono text-sm font-semibold text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-30"
                   >
-                    {qIndex === QUIZ_TOTAL - 1 ? "Build my plan" : "Continue"} <ArrowRight className="h-4 w-4" />
+                    {tr(qIndex === QUIZ_TOTAL - 1 ? "ابنِ خطتي" : "متابعة", qIndex === QUIZ_TOTAL - 1 ? "Build my plan" : "Continue")} <ArrowRight className="h-4 w-4" />
                   </button>
                 </div>
               )}
@@ -287,9 +293,8 @@ export default function SubscribePage() {
           <section className="animate-[os-panel-in_0.4s_cubic-bezier(0.16,1,0.3,1)_both] space-y-5 pt-6 text-center">
             <Loader2 className="mx-auto h-8 w-8 animate-spin text-emerald-500" />
             <div>
-              <p className="text-lg font-semibold text-zinc-100" dir="rtl">نبني خطتك…</p>
-              <p className="mt-1 font-mono text-sm text-emerald-400">{BUILD_STEPS[buildStep]?.en}</p>
-              <p className="mt-0.5 text-xs text-zinc-500" dir="rtl">{BUILD_STEPS[buildStep]?.ar}</p>
+              <p className="text-lg font-semibold text-zinc-100" dir={dir}>{tr("نبني خطتك…", "Building your plan…")}</p>
+              <p className="mt-1 font-mono text-sm text-emerald-400" dir={dir}>{tr(BUILD_STEPS[buildStep]?.ar ?? "", BUILD_STEPS[buildStep]?.en ?? "")}</p>
             </div>
             <div className="mx-auto h-1 w-56 overflow-hidden rounded-full bg-zinc-800">
               <div className="h-full bg-emerald-500 transition-all duration-100" style={{ width: `${buildPct}%` }} />
@@ -303,12 +308,9 @@ export default function SubscribePage() {
           <section className="animate-[os-panel-in_0.45s_cubic-bezier(0.16,1,0.3,1)_both] space-y-5">
 
             <div className="text-center">
-              <h2 className="text-xl font-bold leading-tight text-zinc-100 sm:text-2xl" dir="rtl">
-                {PRODUCT.headlineAr}
+              <h2 className="text-xl font-bold leading-tight text-zinc-100 sm:text-2xl" dir={dir}>
+                {tr(PRODUCT.headlineAr, PRODUCT.headlineEn)}
               </h2>
-              <p className="mt-1.5 font-mono text-xs text-zinc-500">
-                {PRODUCT.headlineEn.replace("personalized AI plan", "")}<span className="text-emerald-400">personalized AI plan</span>
-              </p>
             </div>
 
             {/* Promo + real countdown */}
@@ -321,8 +323,8 @@ export default function SubscribePage() {
               <div className={["mt-3 flex items-center justify-center gap-2 font-mono text-sm", expired ? "text-red-400" : "text-yellow-400"].join(" ")}>
                 <Clock className="h-3.5 w-3.5" />
                 {expired
-                  ? <span dir="rtl">انتهى العرض · offer expired</span>
-                  : <span>expires in <span className="font-bold tabular-nums">{countdown}</span></span>}
+                  ? <span dir={dir}>{tr("انتهى العرض", "offer expired")}</span>
+                  : <span dir={dir}>{tr("ينتهي خلال ", "expires in ")}<span className="font-bold tabular-nums">{countdown}</span></span>}
               </div>
             </div>
 
@@ -347,14 +349,14 @@ export default function SubscribePage() {
                         </span>
                         <div>
                           <div className="flex flex-wrap items-center gap-1.5">
-                            <span className="font-mono text-xs font-semibold uppercase tracking-wide text-zinc-200">{plan.en}</span>
+                            <span className="font-mono text-xs font-semibold uppercase tracking-wide text-zinc-200">{tr(plan.ar, plan.en)}</span>
                             {plan.tag && (
                               <span className={["rounded px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-widest", plan.best ? "bg-yellow-500/15 text-yellow-400 border border-yellow-700/40" : "bg-emerald-500/15 text-emerald-400 border border-emerald-700/40"].join(" ")}>
                                 {plan.tag}
                               </span>
                             )}
                           </div>
-                          <p className="mt-0.5 text-xs text-zinc-500" dir="rtl">{plan.ar}</p>
+                          <p className="mt-0.5 text-xs text-zinc-500" dir={dir}>{plan.perDay}</p>
                           {plan.badge && <p className="mt-1 font-mono text-[10px] text-emerald-500">{plan.badge}</p>}
                         </div>
                       </div>
@@ -379,27 +381,26 @@ export default function SubscribePage() {
               onClick={handleGetPlan}
               className="flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 py-4 font-mono text-sm font-bold uppercase tracking-wide text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
             >
-              GET MY PLAN <ArrowRight className="h-4 w-4" />
+              {tr("احصل على خطتي", "GET MY PLAN")} <ArrowRight className="h-4 w-4" />
             </button>
 
-            <p className="text-center font-mono text-[11px] text-emerald-600/80" dir="rtl">{PRODUCT.socialProofAr}</p>
+            <p className="text-center font-mono text-[11px] text-emerald-600/80" dir={dir}>{tr(PRODUCT.socialProofAr, PRODUCT.socialProofEn)}</p>
 
             {/* What you get */}
             <div className="space-y-2 rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-4 py-4">
-              <p className="mb-1 font-mono text-[10px] uppercase tracking-widest text-zinc-600">what you get · ما تحصل عليه</p>
+              <p className="mb-1 font-mono text-[10px] uppercase tracking-widest text-zinc-600" dir={dir}>{tr("ما تحصل عليه", "what you get")}</p>
               {PRODUCT.benefits.map((b) => (
                 <div key={b.en} className="flex items-start gap-2">
                   <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
                   <div>
-                    <p className="text-xs text-zinc-300" dir="rtl">{b.ar}</p>
-                    <p className="font-mono text-[10px] text-zinc-600">{b.en}</p>
+                    <p className="text-xs text-zinc-300" dir={dir}>{tr(b.ar, b.en)}</p>
                   </div>
                 </div>
               ))}
             </div>
 
-            <p className="text-center font-mono text-[10px] text-zinc-700" dir="rtl">
-              إلغاء في أي وقت · بدون تجديد تلقائي · cancel anytime
+            <p className="text-center font-mono text-[10px] text-zinc-700" dir={dir}>
+              {tr("إلغاء في أي وقت · بدون تجديد تلقائي", "cancel anytime · no auto-renewal surprises")}
             </p>
           </section>
         )}


### PR DESCRIPTION
Adds a prominent, always-visible العربية|English toggle to the /subscribe funnel. Shows one language at a time (header, 21-question quiz, loading, countdown paywall) with correct RTL/LTR direction. Checkout flow untouched.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an always-visible العربية|English language toggle to the `/subscribe` funnel, wiring a `tr(ar, en)` helper and `dir` attribute across the intro, quiz, loading, and plan/paywall phases so only one language is shown at a time.

- The toggle itself is cleanly implemented with persistent state across all phases and correct RTL/LTR `dir` switching throughout most of the funnel.
- Two gaps remain in the plan/paywall phase: `plan.perDay` (the billing period sub-text) has no Arabic equivalent in the `Plan` type and always renders in English regardless of the active language, and the promo-applied banner retains hardcoded bilingual text that doesn't respect the toggle.
- The `success` and `payfail` post-checkout screens also ignore the toggle, hardcoding `dir=\"rtl\"` and Arabic-only copy even when the user is in English mode.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The toggle wiring is solid for most of the funnel, but the plan/paywall phase has two strings that don't respect the active language, and post-checkout result screens are fully Arabic regardless of the user's selection.

The billing sub-text in plan cards (plan.perDay) is English-only and lacks an Arabic equivalent in the config type, so Arabic-mode users see English text in a spot the PR intends to translate. The promo banner label is similarly hardcoded. Together these are present, visible defects on the main conversion screen. The success/payfail screens compound this by ignoring the toggle entirely — a user who switched to English will land on a fully Arabic confirmation page.

app/subscribe/page.tsx — specifically the plan-card perDay sub-label, the promo banner text, and the success/payfail phase copy.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/subscribe/page.tsx | Adds an العربية|English toggle and wires tr(ar, en) + dir={dir} throughout intro, quiz, loading, and plan phases. Two issues: plan.perDay is English-only but rendered in Arabic mode with dir={dir}, and the promo banner label is left as hardcoded bilingual text. Success/payfail phases also ignore the toggle. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page Load
lang = 'ar'] --> T{Language Toggle
العربية / English}
    T -->|setLang| A
    A --> PH{phase}
    PH -->|intro| I[Intro
✅ tr + dir applied]
    PH -->|quiz| Q[Quiz
✅ tr + dir applied]
    PH -->|loading| L[Loading
✅ tr + dir applied]
    PH -->|plan| PL[Plan / Paywall]
    PL --> PL1[Plan headline
✅ tr applied]
    PL --> PL2[Promo banner
❌ hardcoded bilingual]
    PL --> PL3[Plan cards
⚠️ plan.perDay always EN]
    PL --> PL4[Benefits / CTAs
✅ tr applied]
    PH -->|pay| PAY[Checkout
🔒 intentionally untouched]
    PH -->|success| S[Success
❌ hardcoded Arabic dir=rtl]
    PH -->|payfail| F[Pay Failed
❌ hardcoded Arabic dir=rtl]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Page Load
lang = 'ar'] --> T{Language Toggle
العربية / English}
    T -->|setLang| A
    A --> PH{phase}
    PH -->|intro| I[Intro
✅ tr + dir applied]
    PH -->|quiz| Q[Quiz
✅ tr + dir applied]
    PH -->|loading| L[Loading
✅ tr + dir applied]
    PH -->|plan| PL[Plan / Paywall]
    PL --> PL1[Plan headline
✅ tr applied]
    PL --> PL2[Promo banner
❌ hardcoded bilingual]
    PL --> PL3[Plan cards
⚠️ plan.perDay always EN]
    PL --> PL4[Benefits / CTAs
✅ tr applied]
    PH -->|pay| PAY[Checkout
🔒 intentionally untouched]
    PH -->|success| S[Success
❌ hardcoded Arabic dir=rtl]
    PH -->|payfail| F[Pay Failed
❌ hardcoded Arabic dir=rtl]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `app/subscribe/page.tsx`, line 319-321 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/beca330a27e210e6f37c8ea84f23aa7f6bf26798/app/subscribe/page.tsx#L319-L321)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Promo banner text doesn't respect the language toggle**

   The promo-applied line `"promo applied · كود {name}"` is hardcoded bilingual text inside the `plan` phase — a phase the PR explicitly translates everywhere else. In English mode the label still shows Arabic `كود`, and there is no `dir` attribute to ensure correct rendering. This is the only untranslated string left in the paywall phase.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsubscribe%2Fpage.tsx%0ALine%3A%20319-321%0A%0AComment%3A%0A**Promo%20banner%20text%20doesn't%20respect%20the%20language%20toggle**%0A%0AThe%20promo-applied%20line%20%60%22promo%20applied%20%C2%B7%20%D9%83%D9%88%D8%AF%20%7Bname%7D%22%60%20is%20hardcoded%20bilingual%20text%20inside%20the%20%60plan%60%20phase%20%E2%80%94%20a%20phase%20the%20PR%20explicitly%20translates%20everywhere%20else.%20In%20English%20mode%20the%20label%20still%20shows%20Arabic%20%60%D9%83%D9%88%D8%AF%60%2C%20and%20there%20is%20no%20%60dir%60%20attribute%20to%20ensure%20correct%20rendering.%20This%20is%20the%20only%20untranslated%20string%20left%20in%20the%20paywall%20phase.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fsubscribe-lang-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsubscribe-lang-toggle%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsubscribe%2Fpage.tsx%0ALine%3A%20319-321%0A%0AComment%3A%0A**Promo%20banner%20text%20doesn't%20respect%20the%20language%20toggle**%0A%0AThe%20promo-applied%20line%20%60%22promo%20applied%20%C2%B7%20%D9%83%D9%88%D8%AF%20%7Bname%7D%22%60%20is%20hardcoded%20bilingual%20text%20inside%20the%20%60plan%60%20phase%20%E2%80%94%20a%20phase%20the%20PR%20explicitly%20translates%20everywhere%20else.%20In%20English%20mode%20the%20label%20still%20shows%20Arabic%20%60%D9%83%D9%88%D8%AF%60%2C%20and%20there%20is%20no%20%60dir%60%20attribute%20to%20ensure%20correct%20rendering.%20This%20is%20the%20only%20untranslated%20string%20left%20in%20the%20paywall%20phase.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `app/subscribe/page.tsx`, line 453-480 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/beca330a27e210e6f37c8ea84f23aa7f6bf26798/app/subscribe/page.tsx#L453-L480)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Success and payment-failure phases ignore the language toggle**

   Both `success` and `payfail` sections use hardcoded `dir="rtl"` with Arabic-only copy ("تم الدفع! أهلاً فيك", "ما تم الدفع"). The language toggle is always visible (including on these screens), so a user who has switched to English lands on a fully Arabic result page. The PR description lists these phases as "untouched" alongside the checkout flow, but unlike the Moyasar card form they are rendered inline by the same component and the `lang` state is available.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsubscribe%2Fpage.tsx%0ALine%3A%20453-480%0A%0AComment%3A%0A**Success%20and%20payment-failure%20phases%20ignore%20the%20language%20toggle**%0A%0ABoth%20%60success%60%20and%20%60payfail%60%20sections%20use%20hardcoded%20%60dir%3D%22rtl%22%60%20with%20Arabic-only%20copy%20%28%22%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9!%20%D8%A3%D9%87%D9%84%D8%A7%D9%8B%20%D9%81%D9%8A%D9%83%22%2C%20%22%D9%85%D8%A7%20%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9%22%29.%20The%20language%20toggle%20is%20always%20visible%20%28including%20on%20these%20screens%29%2C%20so%20a%20user%20who%20has%20switched%20to%20English%20lands%20on%20a%20fully%20Arabic%20result%20page.%20The%20PR%20description%20lists%20these%20phases%20as%20%22untouched%22%20alongside%20the%20checkout%20flow%2C%20but%20unlike%20the%20Moyasar%20card%20form%20they%20are%20rendered%20inline%20by%20the%20same%20component%20and%20the%20%60lang%60%20state%20is%20available.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fsubscribe-lang-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsubscribe-lang-toggle%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fsubscribe%2Fpage.tsx%0ALine%3A%20453-480%0A%0AComment%3A%0A**Success%20and%20payment-failure%20phases%20ignore%20the%20language%20toggle**%0A%0ABoth%20%60success%60%20and%20%60payfail%60%20sections%20use%20hardcoded%20%60dir%3D%22rtl%22%60%20with%20Arabic-only%20copy%20%28%22%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9!%20%D8%A3%D9%87%D9%84%D8%A7%D9%8B%20%D9%81%D9%8A%D9%83%22%2C%20%22%D9%85%D8%A7%20%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9%22%29.%20The%20language%20toggle%20is%20always%20visible%20%28including%20on%20these%20screens%29%2C%20so%20a%20user%20who%20has%20switched%20to%20English%20lands%20on%20a%20fully%20Arabic%20result%20page.%20The%20PR%20description%20lists%20these%20phases%20as%20%22untouched%22%20alongside%20the%20checkout%20flow%2C%20but%20unlike%20the%20Moyasar%20card%20form%20they%20are%20rendered%20inline%20by%20the%20same%20component%20and%20the%20%60lang%60%20state%20is%20available.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A359%0A**%60plan.perDay%60%20is%20English-only%20%E2%80%94%20Arabic%20mode%20shows%20English%20billing%20text**%0A%0A%60plan.perDay%60%20has%20no%20Arabic%20equivalent%20in%20the%20%60Plan%60%20type%20%28%60%22billed%20monthly%22%60%20%2F%20%60%22%E2%89%88%20%245.75%2Fmo%22%60%20are%20hardcoded%20English%20strings%20in%20%60lib%2Fsubscribe%2Fconfig.ts%60%29.%20When%20%60lang%20%3D%3D%3D%20%22ar%22%60%2C%20this%20sub-text%20under%20the%20plan%20name%20stays%20in%20English%20while%20%60dir%3D%7Bdir%7D%60%20wraps%20it%20in%20a%20RTL%20context%20%E2%80%94%20a%20direction%2Fcontent%20mismatch.%20It%20also%20duplicates%20the%20price%20column's%20%60perDay%60%20at%20line%20369%2C%20which%20was%20already%20rendering%20the%20same%20value.%0A%0AThe%20simplest%20fix%20is%20to%20either%20add%20%60perDayAr%60%20to%20the%20%60Plan%60%20type%20and%20call%20%60tr%28plan.perDayAr%2C%20plan.perDay%29%60%2C%20or%20keep%20only%20the%20right-column%20rendering%20and%20remove%20this%20line%20entirely.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A319-321%0A**Promo%20banner%20text%20doesn't%20respect%20the%20language%20toggle**%0A%0AThe%20promo-applied%20line%20%60%22promo%20applied%20%C2%B7%20%D9%83%D9%88%D8%AF%20%7Bname%7D%22%60%20is%20hardcoded%20bilingual%20text%20inside%20the%20%60plan%60%20phase%20%E2%80%94%20a%20phase%20the%20PR%20explicitly%20translates%20everywhere%20else.%20In%20English%20mode%20the%20label%20still%20shows%20Arabic%20%60%D9%83%D9%88%D8%AF%60%2C%20and%20there%20is%20no%20%60dir%60%20attribute%20to%20ensure%20correct%20rendering.%20This%20is%20the%20only%20untranslated%20string%20left%20in%20the%20paywall%20phase.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A453-480%0A**Success%20and%20payment-failure%20phases%20ignore%20the%20language%20toggle**%0A%0ABoth%20%60success%60%20and%20%60payfail%60%20sections%20use%20hardcoded%20%60dir%3D%22rtl%22%60%20with%20Arabic-only%20copy%20%28%22%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9!%20%D8%A3%D9%87%D9%84%D8%A7%D9%8B%20%D9%81%D9%8A%D9%83%22%2C%20%22%D9%85%D8%A7%20%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9%22%29.%20The%20language%20toggle%20is%20always%20visible%20%28including%20on%20these%20screens%29%2C%20so%20a%20user%20who%20has%20switched%20to%20English%20lands%20on%20a%20fully%20Arabic%20result%20page.%20The%20PR%20description%20lists%20these%20phases%20as%20%22untouched%22%20alongside%20the%20checkout%20flow%2C%20but%20unlike%20the%20Moyasar%20card%20form%20they%20are%20rendered%20inline%20by%20the%20same%20component%20and%20the%20%60lang%60%20state%20is%20available.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A176-177%0AThe%20active%20language%20button%20has%20no%20%60aria-pressed%60%20attribute%2C%20so%20screen-reader%20users%20cannot%20tell%20which%20language%20is%20currently%20selected.%20Adding%20it%20costs%20one%20line%20and%20satisfies%20the%20ARIA%20%60role%3D%22group%22%60%20semantics.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20aria-pressed%3D%7BisAr%7D%20onClick%3D%7B%28%29%20%3D%3E%20setLang%28%22ar%22%29%7D%20className%3D%7B%5B%22rounded-full%20px-3.5%20py-1%20transition-colors%22%2C%20isAr%20%3F%20%22bg-emerald-500%20font-semibold%20text-emerald-950%22%20%3A%20%22text-zinc-400%20hover%3Atext-zinc-200%22%5D.join%28%22%20%22%29%7D%3E%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9%3C%2Fbutton%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20aria-pressed%3D%7B!isAr%7D%20onClick%3D%7B%28%29%20%3D%3E%20setLang%28%22en%22%29%7D%20className%3D%7B%5B%22rounded-full%20px-3.5%20py-1%20transition-colors%22%2C%20!isAr%20%3F%20%22bg-emerald-500%20font-semibold%20text-emerald-950%22%20%3A%20%22text-zinc-400%20hover%3Atext-zinc-200%22%5D.join%28%22%20%22%29%7D%3EEnglish%3C%2Fbutton%3E%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fsubscribe-lang-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsubscribe-lang-toggle%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A359%0A**%60plan.perDay%60%20is%20English-only%20%E2%80%94%20Arabic%20mode%20shows%20English%20billing%20text**%0A%0A%60plan.perDay%60%20has%20no%20Arabic%20equivalent%20in%20the%20%60Plan%60%20type%20%28%60%22billed%20monthly%22%60%20%2F%20%60%22%E2%89%88%20%245.75%2Fmo%22%60%20are%20hardcoded%20English%20strings%20in%20%60lib%2Fsubscribe%2Fconfig.ts%60%29.%20When%20%60lang%20%3D%3D%3D%20%22ar%22%60%2C%20this%20sub-text%20under%20the%20plan%20name%20stays%20in%20English%20while%20%60dir%3D%7Bdir%7D%60%20wraps%20it%20in%20a%20RTL%20context%20%E2%80%94%20a%20direction%2Fcontent%20mismatch.%20It%20also%20duplicates%20the%20price%20column's%20%60perDay%60%20at%20line%20369%2C%20which%20was%20already%20rendering%20the%20same%20value.%0A%0AThe%20simplest%20fix%20is%20to%20either%20add%20%60perDayAr%60%20to%20the%20%60Plan%60%20type%20and%20call%20%60tr%28plan.perDayAr%2C%20plan.perDay%29%60%2C%20or%20keep%20only%20the%20right-column%20rendering%20and%20remove%20this%20line%20entirely.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A319-321%0A**Promo%20banner%20text%20doesn't%20respect%20the%20language%20toggle**%0A%0AThe%20promo-applied%20line%20%60%22promo%20applied%20%C2%B7%20%D9%83%D9%88%D8%AF%20%7Bname%7D%22%60%20is%20hardcoded%20bilingual%20text%20inside%20the%20%60plan%60%20phase%20%E2%80%94%20a%20phase%20the%20PR%20explicitly%20translates%20everywhere%20else.%20In%20English%20mode%20the%20label%20still%20shows%20Arabic%20%60%D9%83%D9%88%D8%AF%60%2C%20and%20there%20is%20no%20%60dir%60%20attribute%20to%20ensure%20correct%20rendering.%20This%20is%20the%20only%20untranslated%20string%20left%20in%20the%20paywall%20phase.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A453-480%0A**Success%20and%20payment-failure%20phases%20ignore%20the%20language%20toggle**%0A%0ABoth%20%60success%60%20and%20%60payfail%60%20sections%20use%20hardcoded%20%60dir%3D%22rtl%22%60%20with%20Arabic-only%20copy%20%28%22%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9!%20%D8%A3%D9%87%D9%84%D8%A7%D9%8B%20%D9%81%D9%8A%D9%83%22%2C%20%22%D9%85%D8%A7%20%D8%AA%D9%85%20%D8%A7%D9%84%D8%AF%D9%81%D8%B9%22%29.%20The%20language%20toggle%20is%20always%20visible%20%28including%20on%20these%20screens%29%2C%20so%20a%20user%20who%20has%20switched%20to%20English%20lands%20on%20a%20fully%20Arabic%20result%20page.%20The%20PR%20description%20lists%20these%20phases%20as%20%22untouched%22%20alongside%20the%20checkout%20flow%2C%20but%20unlike%20the%20Moyasar%20card%20form%20they%20are%20rendered%20inline%20by%20the%20same%20component%20and%20the%20%60lang%60%20state%20is%20available.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fsubscribe%2Fpage.tsx%3A176-177%0AThe%20active%20language%20button%20has%20no%20%60aria-pressed%60%20attribute%2C%20so%20screen-reader%20users%20cannot%20tell%20which%20language%20is%20currently%20selected.%20Adding%20it%20costs%20one%20line%20and%20satisfies%20the%20ARIA%20%60role%3D%22group%22%60%20semantics.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20aria-pressed%3D%7BisAr%7D%20onClick%3D%7B%28%29%20%3D%3E%20setLang%28%22ar%22%29%7D%20className%3D%7B%5B%22rounded-full%20px-3.5%20py-1%20transition-colors%22%2C%20isAr%20%3F%20%22bg-emerald-500%20font-semibold%20text-emerald-950%22%20%3A%20%22text-zinc-400%20hover%3Atext-zinc-200%22%5D.join%28%22%20%22%29%7D%3E%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9%3C%2Fbutton%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20aria-pressed%3D%7B!isAr%7D%20onClick%3D%7B%28%29%20%3D%3E%20setLang%28%22en%22%29%7D%20className%3D%7B%5B%22rounded-full%20px-3.5%20py-1%20transition-colors%22%2C%20!isAr%20%3F%20%22bg-emerald-500%20font-semibold%20text-emerald-950%22%20%3A%20%22text-zinc-400%20hover%3Atext-zinc-200%22%5D.join%28%22%20%22%29%7D%3EEnglish%3C%2Fbutton%3E%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(subscribe): add prominent EN/AR lan..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/beca330a27e210e6f37c8ea84f23aa7f6bf26798) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38658614)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->