### PR TITLE
feat(i18n): site-wide EN/AR language + key pages (phase 1)

### DIFF
--- a/app/contact/contact-content.tsx
+++ b/app/contact/contact-content.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import Link from "next/link"
+import type { ReactNode } from "react"
+import { ArrowRight, CheckCircle2, Download, Github, Linkedin, Mail, MessageSquareText } from "lucide-react"
+import { OSWindow } from "@/components/os"
+import { useLanguage } from "@/components/language-provider"
+import { ContactSubscribeCTA } from "@/components/contact-subscribe-cta"
+import {
+  contactActions,
+  contactEyebrow,
+  contactProfile,
+  contactResponseHeader,
+  contactTopics,
+} from "@/lib/content/contact"
+
+const actionIcons: Record<string, ReactNode> = {
+  "Email Hamzah": <Mail className="h-5 w-5" />,
+  LinkedIn: <Linkedin className="h-5 w-5" />,
+  GitHub: <Github className="h-5 w-5" />,
+  Resume: <Download className="h-5 w-5" />,
+}
+
+export function ContactContent() {
+  const { t, dir } = useLanguage()
+
+  const primaryAction = contactActions.find((action) => action.primary) ?? contactActions[0]
+  const secondaryActions = contactActions.filter((action) => action !== primaryAction)
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-8 md:py-12">
+      <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+        <OSWindow label="contact.channel" title="direct contact" status="active" className="os-panel-in">
+          <div className="space-y-6" dir={dir}>
+            <div>
+              <div className="flex items-center gap-2 text-emerald-400">
+                <MessageSquareText className="h-5 w-5" />
+                <p className="font-mono text-[10px] uppercase tracking-widest text-zinc-600">
+                  {t(contactEyebrow.ar, contactEyebrow.en)}
+                </p>
+              </div>
+              <h1 className="mt-3 text-3xl font-semibold leading-tight text-zinc-100 md:text-5xl">
+                {t(contactProfile.title.ar, contactProfile.title.en)}
+              </h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-300 md:text-base">
+                {t(contactProfile.description.ar, contactProfile.description.en)}
+              </p>
+            </div>
+
+            <Link
+              href={primaryAction.href}
+              className="group flex flex-col gap-3 rounded-md border border-emerald-800 bg-emerald-950/35 p-5 transition hover:border-emerald-600 hover:bg-emerald-950/60 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <span className="flex min-w-0 items-start gap-3">
+                <span className="mt-1 text-emerald-300">{actionIcons[primaryAction.key]}</span>
+                <span className="min-w-0">
+                  <span className="block text-lg font-semibold text-emerald-100">
+                    {t(primaryAction.label.ar, primaryAction.label.en)}
+                  </span>
+                  <span className="mt-1 block text-sm leading-6 text-emerald-200/75">
+                    {t(primaryAction.description.ar, primaryAction.description.en)}
+                  </span>
+                  <span className="mt-2 block truncate font-mono text-xs text-emerald-300/80" dir="ltr">
+                    {primaryAction.value}
+                  </span>
+                </span>
+              </span>
+              <ArrowRight className="h-5 w-5 shrink-0 text-emerald-400 transition group-hover:translate-x-0.5 rtl:rotate-180" />
+            </Link>
+
+            <ContactSubscribeCTA />
+          </div>
+        </OSWindow>
+
+        <OSWindow label="response.notes" title="make outreach easy" status="idle" className="os-panel-in">
+          <div className="space-y-4" dir={dir}>
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-widest text-zinc-600">
+                {t(contactResponseHeader.eyebrow.ar, contactResponseHeader.eyebrow.en)}
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-zinc-100">
+                {t(contactResponseHeader.title.ar, contactResponseHeader.title.en)}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-zinc-400">
+                {t(contactProfile.responseNote.ar, contactProfile.responseNote.en)}
+              </p>
+            </div>
+            <ul className="space-y-3 border-t border-zinc-800 pt-4">
+              {contactTopics.map((topic) => (
+                <li key={topic.en} className="flex gap-3 text-sm leading-6 text-zinc-300">
+                  <CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-emerald-500" />
+                  <span>{t(topic.ar, topic.en)}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </OSWindow>
+      </section>
+
+      <section className="mt-4 grid gap-4 md:grid-cols-3">
+        {secondaryActions.map((action) => (
+          <OSWindow key={action.key} label={action.key.toLowerCase()} title={action.value} status="idle" className="os-panel-in">
+            <Link
+              href={action.href}
+              target={action.href.startsWith("http") ? "_blank" : undefined}
+              rel={action.href.startsWith("http") ? "noopener noreferrer" : undefined}
+              className="group block"
+              dir={dir}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <span className="text-emerald-400">{actionIcons[action.key]}</span>
+                <ArrowRight className="h-4 w-4 text-zinc-700 transition group-hover:text-emerald-400 rtl:rotate-180" />
+              </div>
+              <h2 className="mt-4 text-lg font-semibold text-zinc-100">
+                {t(action.label.ar, action.label.en)}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-zinc-400">
+                {t(action.description.ar, action.description.en)}
+              </p>
+              <p className="mt-3 truncate font-mono text-[11px] text-zinc-600" dir="ltr">
+                {action.value}
+              </p>
+            </Link>
+          </OSWindow>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,10 +1,6 @@
-import Link from "next/link"
 import type { Metadata } from "next"
-import type { ReactNode } from "react"
-import { ArrowRight, CheckCircle2, Download, Github, Linkedin, Mail, MessageSquareText } from "lucide-react"
 import { OSPageShell } from "@/components/os/OSPageShell"
-import { OSWindow } from "@/components/os"
-import { contactActions, contactProfile, contactTopics } from "@/lib/content/contact"
+import { ContactContent } from "./contact-content"
 
 export const metadata: Metadata = {
   title: "Contact | Hamzah Al-Ramli",
@@ -15,97 +11,10 @@ export const metadata: Metadata = {
   },
 }
 
-const actionIcons: Record<string, ReactNode> = {
-  "Email Hamzah": <Mail className="h-5 w-5" />,
-  LinkedIn: <Linkedin className="h-5 w-5" />,
-  GitHub: <Github className="h-5 w-5" />,
-  Resume: <Download className="h-5 w-5" />,
-}
-
 export default function ContactPage() {
-  const primaryAction = contactActions.find((action) => action.primary) ?? contactActions[0]
-  const secondaryActions = contactActions.filter((action) => action !== primaryAction)
-
   return (
     <OSPageShell osName="contact.enc" label="Contact">
-      <div className="container mx-auto max-w-5xl px-4 py-8 md:py-12">
-        <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
-          <OSWindow label="contact.channel" title="direct contact" status="active" className="os-panel-in">
-            <div className="space-y-6">
-              <div>
-                <div className="flex items-center gap-2 text-emerald-400">
-                  <MessageSquareText className="h-5 w-5" />
-                  <p className="font-mono text-[10px] uppercase tracking-widest text-zinc-600">
-                    Contact
-                  </p>
-                </div>
-                <h1 className="mt-3 text-3xl font-semibold leading-tight text-zinc-100 md:text-5xl">
-                  {contactProfile.title}
-                </h1>
-                <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-300 md:text-base">
-                  {contactProfile.description}
-                </p>
-              </div>
-
-              <Link
-                href={primaryAction.href}
-                className="group flex flex-col gap-3 rounded-md border border-emerald-800 bg-emerald-950/35 p-5 transition hover:border-emerald-600 hover:bg-emerald-950/60 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <span className="flex min-w-0 items-start gap-3">
-                  <span className="mt-1 text-emerald-300">{actionIcons[primaryAction.label]}</span>
-                  <span className="min-w-0">
-                    <span className="block text-lg font-semibold text-emerald-100">{primaryAction.label}</span>
-                    <span className="mt-1 block text-sm leading-6 text-emerald-200/75">{primaryAction.description}</span>
-                    <span className="mt-2 block truncate font-mono text-xs text-emerald-300/80">{primaryAction.value}</span>
-                  </span>
-                </span>
-                <ArrowRight className="h-5 w-5 shrink-0 text-emerald-400 transition group-hover:translate-x-0.5" />
-              </Link>
-            </div>
-          </OSWindow>
-
-          <OSWindow label="response.notes" title="make outreach easy" status="idle" className="os-panel-in">
-            <div className="space-y-4">
-              <div>
-                <p className="font-mono text-[10px] uppercase tracking-widest text-zinc-600">
-                  Best message format
-                </p>
-                <h2 className="mt-2 text-xl font-semibold text-zinc-100">Send the useful details first</h2>
-                <p className="mt-2 text-sm leading-6 text-zinc-400">{contactProfile.responseNote}</p>
-              </div>
-              <ul className="space-y-3 border-t border-zinc-800 pt-4">
-                {contactTopics.map((topic) => (
-                  <li key={topic} className="flex gap-3 text-sm leading-6 text-zinc-300">
-                    <CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-emerald-500" />
-                    <span>{topic}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </OSWindow>
-        </section>
-
-        <section className="mt-4 grid gap-4 md:grid-cols-3">
-          {secondaryActions.map((action) => (
-            <OSWindow key={action.label} label={action.label.toLowerCase()} title={action.value} status="idle" className="os-panel-in">
-              <Link
-                href={action.href}
-                target={action.href.startsWith("http") ? "_blank" : undefined}
-                rel={action.href.startsWith("http") ? "noopener noreferrer" : undefined}
-                className="group block"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <span className="text-emerald-400">{actionIcons[action.label]}</span>
-                  <ArrowRight className="h-4 w-4 text-zinc-700 transition group-hover:text-emerald-400" />
-                </div>
-                <h2 className="mt-4 text-lg font-semibold text-zinc-100">{action.label}</h2>
-                <p className="mt-2 text-sm leading-6 text-zinc-400">{action.description}</p>
-                <p className="mt-3 truncate font-mono text-[11px] text-zinc-600">{action.value}</p>
-              </Link>
-            </OSWindow>
-          ))}
-        </section>
-      </div>
+      <ContactContent />
     </OSPageShell>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Noto_Kufi_Arabic } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { FullscreenButton } from "@/components/fullscreen"
 import { PortfolioAssistant } from "@/components/portfolio-assistant"
+import { LanguageProvider } from "@/components/language-provider"
 import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import type { Metadata } from "next"
@@ -190,9 +191,11 @@ export default function RootLayout({
       </head>
       <body className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} ${notoKufiArabic.variable} font-sans pb-24 md:pb-0`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
-          {children}
-          <FullscreenButton />
-          <PortfolioAssistant />
+          <LanguageProvider>
+            {children}
+            <FullscreenButton />
+            <PortfolioAssistant />
+          </LanguageProvider>
         </ThemeProvider>
         <Analytics />
         <SpeedInsights />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import type { FeedEntry } from "@/components/os"
 import type { ThreatIoc } from "@/app/api/threats/route"
 import { IocInspector } from "@/components/signal/IocInspector"
 import { MobileSignalOverlay } from "@/components/signal/MobileSignalOverlay"
+import { useLanguage } from "@/components/language-provider"
 
 // Globe — deferred: only loads after initial paint (via requestIdleCallback)
 // and never SSR'd. This keeps the homepage TTI fast; the globe fades in
@@ -39,20 +40,12 @@ const STATIC_ENTRIES: FeedEntry[] = [
 // neutral and only lights emerald on hover. Color means something here:
 // emerald = you, red = threat. Nothing else competes.
 // ---------------------------------------------------------------------------
-const MODULE_ITEMS: { href: string; code: string; label: string; sub: string; Icon: ElementType }[] = [
-  { href: "/subscribe",   code: "01", label: "TOOLKIT VAULT", sub: "Weekly security + AI tools · Subscribe", Icon: Lock },
-  { href: "/personnel",   code: "02", label: "PERSONNEL",   sub: "Dossier · CV · Clearance",     Icon: User     },
-  { href: "/deployments", code: "03", label: "DEPLOYMENTS", sub: "Mission files · Architecture", Icon: Layers   },
-  { href: "/contact",     code: "04", label: "CONTACT",     sub: "Encrypted channel",            Icon: Mail     },
-  { href: "/terminal",    code: "05", label: "TERMINAL",    sub: "Command interface",            Icon: Terminal },
-]
-
-// Hero credential chips
-const HERO_META = [
-  "CEH (pursuing)",
-  "Security+ (pursuing)",
-  "Google Cybersecurity",
-  "BSc CS · Taylor's University",
+const MODULE_ITEMS: { href: string; code: string; label: string; ar: string; sub: string; subAr: string; Icon: ElementType }[] = [
+  { href: "/subscribe",   code: "01", label: "TOOLKIT VAULT", ar: "خزينة الأدوات", sub: "Weekly security + AI tools · Subscribe", subAr: "أدوات الأمن والذكاء الاصطناعي أسبوعياً · اشترك", Icon: Lock },
+  { href: "/personnel",   code: "02", label: "PERSONNEL",   ar: "الملف الشخصي", sub: "Dossier · CV · Clearance",     subAr: "السيرة الذاتية · الملف · التصريح", Icon: User     },
+  { href: "/deployments", code: "03", label: "DEPLOYMENTS", ar: "المشاريع",     sub: "Mission files · Architecture", subAr: "ملفات المهام · البنية",            Icon: Layers   },
+  { href: "/contact",     code: "04", label: "CONTACT",     ar: "تواصل",        sub: "Encrypted channel",            subAr: "قناة مشفّرة",                      Icon: Mail     },
+  { href: "/terminal",    code: "05", label: "TERMINAL",    ar: "الطرفية",      sub: "Command interface",            subAr: "واجهة الأوامر",                    Icon: Terminal },
 ]
 
 // All layer labels (used to seed the default active set)
@@ -283,6 +276,7 @@ function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
 // Page
 // ---------------------------------------------------------------------------
 export default function HomePage() {
+  const { t, dir } = useLanguage()
   const [liveEntries,  setLiveEntries]  = useState<FeedEntry[]>([])
   const [recentIocs,   setRecentIocs]   = useState<ThreatIoc[]>([])
   const [hoveredIoc,   setHoveredIoc]   = useState<ThreatIoc | null>(null)
@@ -486,11 +480,11 @@ export default function HomePage() {
 
         {/* ── HERO IDENTITY ─────────────────────────────────── */}
         <section className={wrap(globeInspect, globeInspect ? "pt-4 pb-3" : "pt-[9vh] pb-[7vh]")}>
-          <div className="w-full pointer-events-auto">
+          <div className="w-full pointer-events-auto" dir={dir}>
             {/* Kicker */}
             <span className="inline-flex items-center gap-2.5 mb-[30px] rounded-[5px] border border-zinc-800 bg-zinc-900/50 px-3.5 py-[7px] font-mono text-[11px] uppercase tracking-[0.26em] text-zinc-400 backdrop-blur-sm">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_theme(colors.emerald.500)]" />
-              SUBJECT VERIFIED · RIYADH, SA
+              {t("الهوية موثّقة · الرياض، السعودية", "SUBJECT VERIFIED · RIYADH, SA")}
             </span>
 
             {/* Identity — display scale (sized to fit the left column), restrained
@@ -508,13 +502,18 @@ export default function HomePage() {
               className="mt-[26px] max-w-[48ch] leading-[1.5] text-zinc-300"
               style={{ fontSize: globeInspect ? "1rem" : "clamp(17px, 2vw, 21px)" }}
             >
-              Hamzah Al-Ramli — <span className="font-semibold text-zinc-100">Cybersecurity &amp; Automation Architect.</span>{" "}
-              I build defensive systems, threat tooling, and the automation that runs them.
+              {t("حمزة الرملي — ", "Hamzah Al-Ramli — ")}<span className="font-semibold text-zinc-100">{t("مهندس الأمن السيبراني والأتمتة.", "Cybersecurity & Automation Architect.")}</span>{" "}
+              {t("أبني أنظمة دفاعية وأدوات لرصد التهديدات والأتمتة التي تشغّلها.", "I build defensive systems, threat tooling, and the automation that runs them.")}
             </p>
 
-            {/* Credential chips */}
+            {/* Credential chips — cert names stay English; surrounding labels translate */}
             <div className="mt-[22px] flex flex-wrap gap-2.5 font-mono text-[11px] text-zinc-400">
-              {HERO_META.map((m) => (
+              {[
+                t("CEH (قيد الإنجاز)", "CEH (pursuing)"),
+                t("Security+ (قيد الإنجاز)", "Security+ (pursuing)"),
+                "Google Cybersecurity",
+                t("بكالوريوس علوم حاسب · جامعة تايلورز", "BSc CS · Taylor's University"),
+              ].map((m) => (
                 <span key={m} className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
                   {m}
                 </span>
@@ -528,13 +527,13 @@ export default function HomePage() {
                 className="inline-flex items-center gap-2.5 rounded-md bg-emerald-500 px-6 py-3.5 font-mono text-[13px] font-semibold uppercase tracking-[0.1em] text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
               >
                 <Mail className="h-4 w-4" />
-                Open encrypted channel
+                {t("افتح قناة مشفّرة", "Open encrypted channel")}
               </Link>
               <Link
                 href="/personnel"
                 className="inline-flex items-center gap-2.5 rounded-md border border-zinc-800 bg-zinc-950/40 px-6 py-3.5 font-mono text-[13px] font-medium uppercase tracking-[0.1em] text-zinc-300 backdrop-blur-sm transition-all hover:border-zinc-600 hover:text-zinc-100"
               >
-                View full dossier
+                {t("عرض الملف الكامل", "View full dossier")}
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </div>
@@ -553,20 +552,21 @@ export default function HomePage() {
               <span className="h-px flex-1 bg-zinc-900" />
             </div>
             <div className={cn("grid gap-3", globeInspect ? "grid-cols-1" : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-5")}>
-              {MODULE_ITEMS.map(({ href, code, label, sub, Icon }, i) => (
+              {MODULE_ITEMS.map((item, i) => (
                 <Link
-                  key={href}
-                  href={href}
+                  key={item.href}
+                  href={item.href}
                   style={{ animationDelay: `${i * 60}ms` }}
                   className="group relative overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/55 px-5 py-5 backdrop-blur-md transition-all duration-200 os-panel-in hover:-translate-y-[3px] hover:border-emerald-800/80 hover:bg-zinc-900/90"
+                  dir={dir}
                 >
-                  <span className="font-mono text-[11px] tracking-wider text-zinc-500">{code}</span>
+                  <span className="font-mono text-[11px] tracking-wider text-zinc-500">{item.code}</span>
                   <ChevronRight className="absolute right-4 top-5 h-4 w-4 text-zinc-700 transition-all group-hover:translate-x-0.5 group-hover:text-emerald-400" />
                   <div className="mb-4 mt-4 grid h-10 w-10 place-items-center rounded-lg border border-zinc-800 bg-zinc-950 text-zinc-400 transition-all group-hover:border-emerald-900 group-hover:text-emerald-400">
-                    <Icon className="h-[19px] w-[19px]" />
+                    <item.Icon className="h-[19px] w-[19px]" />
                   </div>
-                  <div className="font-mono text-sm font-semibold tracking-wide text-zinc-100">{label}</div>
-                  <div className="mt-1.5 font-mono text-[11px] leading-[1.5] text-zinc-500">{sub}</div>
+                  <div className="font-mono text-sm font-semibold tracking-wide text-zinc-100">{t(item.ar, item.label)}</div>
+                  <div className="mt-1.5 font-mono text-[11px] leading-[1.5] text-zinc-500">{t(item.subAr, item.sub)}</div>
                 </Link>
               ))}
             </div>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { GlitchText } from '@/components/glitch-text'
 import { MatrixBackground } from '@/components/matrix-background'
+import { useLanguage } from '@/components/language-provider'
 import { toast } from 'sonner'
 import {
   Shield, Search, Monitor, BookOpen, ArrowLeft,
@@ -25,24 +26,48 @@ const ACCENT_COLORS: Record<string, { rgb: string; hex: string }> = {
   'text-orange-400': { rgb: '251,146,60',   hex: '#fb923c' },
 }
 
-const SERVICES = [
+// Bilingual service catalog. Each user-facing string is an [ar, en] tuple,
+// resolved at render time via the language provider's `t(ar, en)` helper.
+// Technical terms / product names (CVSS, NCA ECC, SAMA CSF, ISO 27001, Entra ID,
+// Defender for Cloud, Sentinel, SIEM, MFA, M365, Azure) stay in English inside
+// the Arabic prose, per convention.
+type Bi = readonly [ar: string, en: string]
+
+interface Service {
+  id: string
+  icon: React.ReactNode
+  color: string
+  borderIdle: string
+  badge: string
+  tag: Bi
+  title: Bi
+  subtitle: Bi
+  duration: Bi
+  description: Bi
+  deliverables: readonly Bi[]
+}
+
+const SERVICES: readonly Service[] = [
   {
     id: 'pentest',
     icon: <Search className="h-5 w-5" />,
     color: 'text-red-400',
     borderIdle: 'border-red-500/25',
     badge: 'bg-red-500/10 text-red-400 border-red-500/20',
-    tag: 'Most Requested',
-    title: 'Penetration Testing',
-    subtitle: 'Find your weaknesses before attackers do',
-    duration: '3–7 business days',
-    description: 'Full-scope ethical hacking engagement: web apps, network infrastructure, or internal systems. Detailed report with CVSS scores, proof-of-concept, and remediation steps.',
+    tag: ['الأكثر طلباً', 'Most Requested'],
+    title: ['اختبار الاختراق', 'Penetration Testing'],
+    subtitle: ['اكتشف نقاط ضعفك قبل أن يكتشفها المهاجمون', 'Find your weaknesses before attackers do'],
+    duration: ['3–7 أيام عمل', '3–7 business days'],
+    description: [
+      'اختبار اختراق أخلاقي شامل: تطبيقات الويب أو البنية التحتية للشبكة أو الأنظمة الداخلية. تقرير مفصّل يتضمّن درجات CVSS وإثبات المفهوم وخطوات المعالجة.',
+      'Full-scope ethical hacking engagement: web apps, network infrastructure, or internal systems. Detailed report with CVSS scores, proof-of-concept, and remediation steps.',
+    ],
     deliverables: [
-      'Reconnaissance & attack surface mapping',
-      'Exploitation of discovered vulnerabilities',
-      'Full technical + executive report',
-      'Remediation walkthrough call',
-      'Re-test after fixes (1 round)',
+      ['استطلاع وتحديد سطح الهجوم', 'Reconnaissance & attack surface mapping'],
+      ['استغلال الثغرات المكتشفة', 'Exploitation of discovered vulnerabilities'],
+      ['تقرير فني وتنفيذي كامل', 'Full technical + executive report'],
+      ['مكالمة شرح لخطوات المعالجة', 'Remediation walkthrough call'],
+      ['إعادة اختبار بعد الإصلاح (جولة واحدة)', 'Re-test after fixes (1 round)'],
     ],
   },
   {
@@ -51,17 +76,20 @@ const SERVICES = [
     color: 'text-emerald-400',
     borderIdle: 'border-emerald-500/25',
     badge: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
-    tag: 'NCA / SAMA Ready',
-    title: 'Security Audit',
-    subtitle: 'Compliance-ready security assessment',
-    duration: '2–5 business days',
-    description: 'Structured review of your security posture mapped to NCA ECC, SAMA CSF, or ISO 27001. Identifies gaps and gives you a prioritized roadmap to compliance.',
+    tag: ['جاهز لـ NCA / SAMA', 'NCA / SAMA Ready'],
+    title: ['تدقيق أمني', 'Security Audit'],
+    subtitle: ['تقييم أمني جاهز للامتثال', 'Compliance-ready security assessment'],
+    duration: ['2–5 أيام عمل', '2–5 business days'],
+    description: [
+      'مراجعة منظّمة لوضعك الأمني وفق NCA ECC أو SAMA CSF أو ISO 27001. تحدّد الفجوات وتمنحك خارطة طريق مرتّبة حسب الأولوية للوصول إلى الامتثال.',
+      'Structured review of your security posture mapped to NCA ECC, SAMA CSF, or ISO 27001. Identifies gaps and gives you a prioritized roadmap to compliance.',
+    ],
     deliverables: [
-      'Gap analysis against chosen framework',
-      'Risk register with severity ratings',
-      'Prioritized remediation roadmap',
-      'Policy & procedure recommendations',
-      'Executive summary for management',
+      ['تحليل الفجوات مقابل الإطار المختار', 'Gap analysis against chosen framework'],
+      ['سجل مخاطر مع تصنيف درجات الخطورة', 'Risk register with severity ratings'],
+      ['خارطة طريق معالجة مرتّبة حسب الأولوية', 'Prioritized remediation roadmap'],
+      ['توصيات بالسياسات والإجراءات', 'Policy & procedure recommendations'],
+      ['ملخّص تنفيذي للإدارة', 'Executive summary for management'],
     ],
   },
   {
@@ -70,17 +98,20 @@ const SERVICES = [
     color: 'text-blue-400',
     borderIdle: 'border-blue-500/25',
     badge: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-    tag: 'Microsoft Certified',
-    title: 'Microsoft Security Setup',
-    subtitle: 'Harden your Azure & M365 environment',
-    duration: '2–4 business days',
-    description: 'Configure Entra ID, Defender for Cloud, Sentinel SIEM, conditional access policies, and MFA. Turn your Microsoft stack into a security-first environment.',
+    tag: ['معتمد من Microsoft', 'Microsoft Certified'],
+    title: ['إعداد أمن Microsoft', 'Microsoft Security Setup'],
+    subtitle: ['تحصين بيئة Azure و M365 لديك', 'Harden your Azure & M365 environment'],
+    duration: ['2–4 أيام عمل', '2–4 business days'],
+    description: [
+      'إعداد Entra ID و Defender for Cloud و Sentinel SIEM وسياسات الوصول المشروط والمصادقة الثنائية MFA. حوّل منظومة Microsoft لديك إلى بيئة تضع الأمن أولاً.',
+      'Configure Entra ID, Defender for Cloud, Sentinel SIEM, conditional access policies, and MFA. Turn your Microsoft stack into a security-first environment.',
+    ],
     deliverables: [
-      'Entra ID hardening & MFA rollout',
-      'Defender for Cloud configuration',
-      'Microsoft Sentinel SIEM setup',
-      'Conditional access policy design',
-      'Security score improvement report',
+      ['تحصين Entra ID وتفعيل MFA', 'Entra ID hardening & MFA rollout'],
+      ['إعداد Defender for Cloud', 'Defender for Cloud configuration'],
+      ['إعداد Microsoft Sentinel SIEM', 'Microsoft Sentinel SIEM setup'],
+      ['تصميم سياسات الوصول المشروط', 'Conditional access policy design'],
+      ['تقرير تحسين درجة الأمان', 'Security score improvement report'],
     ],
   },
   {
@@ -89,17 +120,20 @@ const SERVICES = [
     color: 'text-purple-400',
     borderIdle: 'border-purple-500/25',
     badge: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
-    tag: 'Monthly Retainer',
-    title: 'Security Monitoring',
-    subtitle: 'Eyes on your infrastructure 24/7',
-    duration: 'Ongoing',
-    description: 'Monthly retainer: threat monitoring, SIEM alert triage, monthly security report, incident response on-call, and proactive vulnerability alerts.',
+    tag: ['اشتراك شهري', 'Monthly Retainer'],
+    title: ['المراقبة الأمنية', 'Security Monitoring'],
+    subtitle: ['عيون على بنيتك التحتية على مدار الساعة', 'Eyes on your infrastructure 24/7'],
+    duration: ['مستمر', 'Ongoing'],
+    description: [
+      'اشتراك شهري: مراقبة التهديدات، وفرز تنبيهات SIEM، وتقرير أمني شهري، والاستجابة للحوادث عند الطلب، وتنبيهات استباقية بالثغرات.',
+      'Monthly retainer: threat monitoring, SIEM alert triage, monthly security report, incident response on-call, and proactive vulnerability alerts.',
+    ],
     deliverables: [
-      'SIEM alert triage & escalation',
-      'Monthly threat intelligence report',
-      'Vulnerability feed & patch advisory',
-      'Incident response (up to 8 hrs/mo)',
-      'Quarterly posture review call',
+      ['فرز تنبيهات SIEM وتصعيدها', 'SIEM alert triage & escalation'],
+      ['تقرير شهري لاستخبارات التهديدات', 'Monthly threat intelligence report'],
+      ['تغذية بالثغرات وإرشادات الترقيع', 'Vulnerability feed & patch advisory'],
+      ['الاستجابة للحوادث (حتى 8 ساعات شهرياً)', 'Incident response (up to 8 hrs/mo)'],
+      ['مكالمة مراجعة للوضع الأمني كل ربع سنة', 'Quarterly posture review call'],
     ],
   },
   {
@@ -108,17 +142,20 @@ const SERVICES = [
     color: 'text-yellow-400',
     borderIdle: 'border-yellow-500/25',
     badge: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-    tag: 'Teams & Corporates',
-    title: 'Security Awareness Training',
-    subtitle: 'Your people are your biggest risk',
-    duration: 'Half or full day',
-    description: 'Live training sessions for employees covering phishing, social engineering, password hygiene, incident reporting, and safe remote work. Arabic & English.',
+    tag: ['للفرق والشركات', 'Teams & Corporates'],
+    title: ['التوعية الأمنية', 'Security Awareness Training'],
+    subtitle: ['موظفوك هم أكبر مصدر للخطر', 'Your people are your biggest risk'],
+    duration: ['نصف يوم أو يوم كامل', 'Half or full day'],
+    description: [
+      'جلسات تدريب مباشرة للموظفين تغطّي التصيّد الاحتيالي والهندسة الاجتماعية وأمان كلمات المرور والإبلاغ عن الحوادث والعمل عن بُعد بأمان. بالعربية والإنجليزية.',
+      'Live training sessions for employees covering phishing, social engineering, password hygiene, incident reporting, and safe remote work. Arabic & English.',
+    ],
     deliverables: [
-      'Phishing simulation campaign',
-      'Live workshop (Arabic/English)',
-      'Customized training materials',
-      'Post-training quiz & scoring',
-      'Certificate of completion',
+      ['حملة محاكاة تصيّد احتيالي', 'Phishing simulation campaign'],
+      ['ورشة عمل مباشرة (عربي/إنجليزي)', 'Live workshop (Arabic/English)'],
+      ['مواد تدريبية مخصّصة', 'Customized training materials'],
+      ['اختبار وتقييم بعد التدريب', 'Post-training quiz & scoring'],
+      ['شهادة إتمام', 'Certificate of completion'],
     ],
   },
   {
@@ -127,17 +164,20 @@ const SERVICES = [
     color: 'text-orange-400',
     borderIdle: 'border-orange-500/25',
     badge: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
-    tag: 'Emergency Available',
-    title: 'Incident Response',
-    subtitle: 'Breach? Call now, not later.',
-    duration: 'As needed',
-    description: 'Rapid response to active breaches, ransomware, data leaks, or account compromise. Containment, forensic analysis, root cause identification, and recovery plan.',
+    tag: ['متاح للطوارئ', 'Emergency Available'],
+    title: ['الاستجابة للحوادث', 'Incident Response'],
+    subtitle: ['تعرّضت لاختراق؟ اتصل الآن لا لاحقاً.', 'Breach? Call now, not later.'],
+    duration: ['حسب الحاجة', 'As needed'],
+    description: [
+      'استجابة سريعة للاختراقات النشطة وبرامج الفدية وتسريبات البيانات أو اختراق الحسابات. احتواء وتحليل جنائي رقمي وتحديد السبب الجذري وخطة تعافٍ.',
+      'Rapid response to active breaches, ransomware, data leaks, or account compromise. Containment, forensic analysis, root cause identification, and recovery plan.',
+    ],
     deliverables: [
-      'Immediate remote triage',
-      'Threat containment & isolation',
-      'Forensic timeline reconstruction',
-      'Root cause analysis report',
-      'Recovery & hardening plan',
+      ['فرز فوري عن بُعد', 'Immediate remote triage'],
+      ['احتواء التهديد وعزله', 'Threat containment & isolation'],
+      ['إعادة بناء التسلسل الزمني الجنائي', 'Forensic timeline reconstruction'],
+      ['تقرير تحليل السبب الجذري', 'Root cause analysis report'],
+      ['خطة تعافٍ وتحصين', 'Recovery & hardening plan'],
     ],
   },
 ]
@@ -169,6 +209,7 @@ const inputCls =
   'w-full bg-zinc-950 border border-zinc-800 rounded px-3 py-2.5 text-sm text-zinc-200 placeholder:text-zinc-700 focus:outline-none focus:border-emerald-500/50 focus:shadow-[0_0_0_1px_rgba(16,185,129,0.2)] transition-all duration-150 font-mono'
 
 export default function ServicesPage() {
+  const { t, dir } = useLanguage()
   const [form, setForm] = useState<FormData>({
     name: '', email: '', company: '', service: '', message: '',
     preferredDate: '', preferredTime: '10:00',
@@ -183,7 +224,7 @@ export default function ServicesPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!form.name || !form.email || !form.service || !form.preferredDate) {
-      toast.error('Please fill in name, email, service, and preferred date.')
+      toast.error(t('يرجى تعبئة الاسم والبريد الإلكتروني والخدمة والتاريخ المفضّل.', 'Please fill in name, email, service, and preferred date.'))
       return
     }
     setSubmitState('sending')
@@ -205,15 +246,15 @@ export default function ServicesPage() {
       if (!res.ok || !data.ok) throw new Error(data.error ?? 'Booking failed')
       setMeetLink(data.meetLink)
       setSubmitState('success')
-      toast.success('Meeting booked! Check your email for the calendar invite.', { duration: 8000 })
+      toast.success(t('تم حجز الاجتماع! تحقّق من بريدك الإلكتروني لدعوة التقويم.', 'Meeting booked! Check your email for the calendar invite.'), { duration: 8000 })
     } catch (err: any) {
       setSubmitState('error')
-      toast.error(err.message ?? 'Something went wrong. Please try again.')
+      toast.error(err.message ?? t('حدث خطأ ما. يرجى المحاولة مرة أخرى.', 'Something went wrong. Please try again.'))
     }
   }
 
   return (
-    <div className="min-h-screen bg-[#09090b] text-white relative overflow-hidden">
+    <div dir={dir} className="min-h-screen bg-[#09090b] text-white relative overflow-hidden">
       <MatrixBackground />
 
       {/* Ambient glow */}
@@ -247,7 +288,7 @@ export default function ServicesPage() {
               className="border border-zinc-800 text-zinc-500 hover:text-zinc-100 hover:border-zinc-700 font-mono text-[11px] uppercase tracking-widest"
               asChild
             >
-              <Link href="/"><ArrowLeft className="mr-1.5 h-3 w-3" /> Portfolio</Link>
+              <Link href="/"><ArrowLeft className="mr-1.5 h-3 w-3" /> {t('الأعمال', 'Portfolio')}</Link>
             </Button>
           </nav>
         </div>
@@ -256,24 +297,31 @@ export default function ServicesPage() {
       <main className="relative z-10">
 
         {/* ── Hero ──────────────────────────────────────────────────────── */}
-        <section className="container mx-auto px-4 pt-16 pb-10 max-w-4xl">
+        <section dir={dir} className="container mx-auto px-4 pt-16 pb-10 max-w-4xl">
           <div className="inline-flex items-center gap-2 rounded border border-emerald-800/60 bg-emerald-950/20 px-3 py-1.5 font-mono text-[10px] text-emerald-400 uppercase tracking-widest mb-6">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse shadow-[0_0_6px_rgba(16,185,129,0.8)]" />
-            Available for Hire · Riyadh, KSA
+            {t('متاح للعمل · الرياض، السعودية', 'Available for Hire · Riyadh, KSA')}
           </div>
 
           <h1 className="text-4xl md:text-6xl font-bold mb-5 leading-tight tracking-tight">
-            <GlitchText text="Security Services" />
+            <GlitchText text={t('خدمات الأمن السيبراني', 'Security Services')} />
           </h1>
 
           <p className="text-base text-zinc-500 max-w-xl mb-8 leading-relaxed">
-            Certified cybersecurity professional based in Riyadh. I help Saudi and GCC businesses find
-            vulnerabilities, achieve compliance, and stay protected — in Arabic and English.
+            {t(
+              'مختص معتمد في الأمن السيبراني مقرّه الرياض. أساعد الشركات السعودية والخليجية على اكتشاف الثغرات وتحقيق الامتثال والبقاء محميّة — بالعربية والإنجليزية.',
+              'Certified cybersecurity professional based in Riyadh. I help Saudi and GCC businesses find vulnerabilities, achieve compliance, and stay protected — in Arabic and English.',
+            )}
           </p>
 
           {/* Cert tags */}
           <div className="flex flex-wrap gap-2 mb-10">
-            {['CEH (pursuing)', 'CompTIA Security+', 'Microsoft Azure Security', 'NCA / SAMA Familiar'].map(cert => (
+            {[
+              t('CEH (قيد الإنجاز)', 'CEH (pursuing)'),
+              'CompTIA Security+',
+              'Microsoft Azure Security',
+              t('ملمّ بـ NCA / SAMA', 'NCA / SAMA Familiar'),
+            ].map(cert => (
               <span
                 key={cert}
                 className="inline-flex items-center gap-1.5 font-mono text-[11px] text-zinc-400 border border-zinc-800 rounded px-2.5 py-1 bg-zinc-900/50 hover:border-zinc-700 transition-colors"
@@ -290,7 +338,7 @@ export default function ServicesPage() {
               href="#inquiry"
               className="inline-flex items-center justify-center gap-2 rounded bg-emerald-500 hover:bg-emerald-400 text-black font-bold px-5 py-3 text-sm transition-all duration-200 hover:shadow-[0_0_28px_rgba(16,185,129,0.35)]"
             >
-              <Mail className="h-4 w-4" /> Get a Free Quote
+              <Mail className="h-4 w-4" /> {t('احصل على عرض سعر مجاني', 'Get a Free Quote')}
             </a>
             <a
               href="tel:+966508501717"
@@ -302,14 +350,14 @@ export default function ServicesPage() {
         </section>
 
         {/* ── Separator stat row ────────────────────────────────────────── */}
-        <div className="border-y border-zinc-900 bg-zinc-950/50 relative z-10">
+        <div dir={dir} className="border-y border-zinc-900 bg-zinc-950/50 relative z-10">
           <div className="container mx-auto px-4 max-w-6xl">
             <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-zinc-900">
               {[
-                { value: '6', label: 'Service types' },
-                { value: 'KSA + GCC', label: 'Coverage' },
-                { value: 'Arabic / EN', label: 'Languages' },
-                { value: '24 h', label: 'Response SLA' },
+                { value: t('6', '6'), label: t('أنواع الخدمات', 'Service types') },
+                { value: t('السعودية + الخليج', 'KSA + GCC'), label: t('التغطية', 'Coverage') },
+                { value: t('عربي / إنجليزي', 'Arabic / EN'), label: t('اللغات', 'Languages') },
+                { value: t('24 ساعة', '24 h'), label: t('زمن الاستجابة', 'Response SLA') },
               ].map(s => (
                 <div key={s.label} className="px-6 py-4 text-center">
                   <div className="font-mono text-base font-bold text-zinc-200 mb-0.5">{s.value}</div>
@@ -321,15 +369,15 @@ export default function ServicesPage() {
         </div>
 
         {/* ── Services Grid ─────────────────────────────────────────────── */}
-        <section className="container mx-auto px-4 py-16 max-w-6xl">
+        <section dir={dir} className="container mx-auto px-4 py-16 max-w-6xl">
           <div className="flex items-center gap-4 mb-10">
             <div>
-              <p className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest mb-1">Engagements</p>
-              <h2 className="text-2xl font-bold text-zinc-100"><GlitchText text="What I Offer" /></h2>
+              <p className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest mb-1">{t('المهام', 'Engagements')}</p>
+              <h2 className="text-2xl font-bold text-zinc-100"><GlitchText text={t('ما أقدّمه', 'What I Offer')} /></h2>
             </div>
             <span className="h-px flex-1 bg-zinc-900 hidden sm:block" />
             <p className="text-[11px] text-zinc-700 font-mono shrink-0 hidden sm:block">
-              clear scope · fixed timeline · real deliverables
+              {t('نطاق واضح · جدول زمني ثابت · مخرجات حقيقية', 'clear scope · fixed timeline · real deliverables')}
             </p>
           </div>
 
@@ -367,28 +415,28 @@ export default function ServicesPage() {
                         {s.icon}
                       </div>
                       <span className={`font-mono text-[9px] border rounded px-2 py-0.5 uppercase tracking-widest ${s.badge}`}>
-                        {s.tag}
+                        {t(...s.tag)}
                       </span>
                     </div>
 
                     {/* title + subtitle */}
                     <h3 className={`text-sm font-semibold text-zinc-100 mb-1 group-hover:${s.color.replace('text-', 'text-')} transition-colors leading-snug`}>
-                      {s.title}
+                      {t(...s.title)}
                     </h3>
-                    <p className="font-mono text-[11px] text-zinc-600 mb-3 leading-snug">{s.subtitle}</p>
+                    <p className="font-mono text-[11px] text-zinc-600 mb-3 leading-snug">{t(...s.subtitle)}</p>
 
                     {/* description */}
-                    <p className="text-zinc-500 text-xs mb-4 leading-relaxed flex-1">{s.description}</p>
+                    <p className="text-zinc-500 text-xs mb-4 leading-relaxed flex-1">{t(...s.description)}</p>
 
                     {/* deliverables */}
                     <ul className="space-y-1.5 mb-5">
                       {s.deliverables.map((d) => (
-                        <li key={d} className="flex items-start gap-2 text-xs text-zinc-600">
+                        <li key={d[1]} className="flex items-start gap-2 text-xs text-zinc-600">
                           <span
                             className="mt-1.5 h-1 w-1 rounded-full shrink-0"
                             style={{ background: accent.hex, opacity: 0.7 }}
                           />
-                          {d}
+                          {t(...d)}
                         </li>
                       ))}
                     </ul>
@@ -396,13 +444,13 @@ export default function ServicesPage() {
                     {/* footer row */}
                     <div className="flex items-center justify-between pt-4 border-t border-zinc-800/50">
                       <span className="flex items-center gap-1.5 font-mono text-[10px] text-zinc-700">
-                        <Clock className="h-3 w-3 shrink-0" />{s.duration}
+                        <Clock className="h-3 w-3 shrink-0" />{t(...s.duration)}
                       </span>
                       <a
                         href="#inquiry"
                         className={`inline-flex items-center gap-1 font-mono text-[11px] ${s.color} border ${s.borderIdle} rounded px-2.5 py-1 transition-all duration-200 hover:opacity-80`}
                       >
-                        Inquire <ChevronRight className="h-3 w-3" />
+                        {t('استفسر', 'Inquire')} <ChevronRight className="h-3 w-3" />
                       </a>
                     </div>
                   </div>
@@ -419,17 +467,17 @@ export default function ServicesPage() {
         </section>
 
         {/* ── Inquiry / Booking Form ────────────────────────────────────── */}
-        <section id="inquiry" className="container mx-auto px-4 pb-20 max-w-2xl">
+        <section dir={dir} id="inquiry" className="container mx-auto px-4 pb-20 max-w-2xl">
 
           <div className="mb-8">
             <div className="inline-flex items-center gap-2 rounded border border-emerald-800/50 bg-emerald-950/20 px-3 py-1.5 font-mono text-[10px] text-emerald-500 uppercase tracking-widest mb-4">
-              <FileText className="w-3 h-3" /> Free Consultation
+              <FileText className="w-3 h-3" /> {t('استشارة مجانية', 'Free Consultation')}
             </div>
             <h2 className="text-3xl font-bold mb-2 tracking-tight">
-              <GlitchText text="Request a Quote" />
+              <GlitchText text={t('اطلب عرض سعر', 'Request a Quote')} />
             </h2>
             <p className="text-zinc-600 text-sm font-mono">
-              Tell me what you need. I'll respond within 24 hours with a scoped proposal.
+              {t('أخبرني بما تحتاجه. سأرد خلال 24 ساعة بعرض محدّد النطاق.', "Tell me what you need. I'll respond within 24 hours with a scoped proposal.")}
             </p>
           </div>
 
@@ -458,10 +506,11 @@ export default function ServicesPage() {
                       <CheckCircle2 className="h-8 w-8 text-emerald-400" />
                     </div>
                   </div>
-                  <h3 className="text-xl font-bold text-white">Meeting Booked</h3>
+                  <h3 className="text-xl font-bold text-white">{t('تم حجز الاجتماع', 'Meeting Booked')}</h3>
                   <p className="text-zinc-400 text-sm max-w-xs mx-auto">
-                    A calendar invite with a Google Meet link has been sent to your email.
-                    Please <strong className="text-white">accept the invite</strong> to confirm your slot.
+                    {t('تم إرسال دعوة تقويم تتضمّن رابط Google Meet إلى بريدك الإلكتروني. يرجى ', 'A calendar invite with a Google Meet link has been sent to your email. Please ')}
+                    <strong className="text-white">{t('قبول الدعوة', 'accept the invite')}</strong>
+                    {t(' لتأكيد موعدك.', ' to confirm your slot.')}
                   </p>
                   {meetLink && (
                     <a
@@ -470,7 +519,7 @@ export default function ServicesPage() {
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-2 bg-emerald-500 text-black font-bold px-6 py-3 rounded text-sm hover:bg-emerald-400 transition-colors"
                     >
-                      <Phone className="h-4 w-4" /> Open Meeting Link
+                      <Phone className="h-4 w-4" /> {t('فتح رابط الاجتماع', 'Open Meeting Link')}
                     </a>
                   )}
                   <div>
@@ -478,7 +527,7 @@ export default function ServicesPage() {
                       onClick={() => { setSubmitState('idle'); setMeetLink('') }}
                       className="text-xs text-zinc-600 hover:text-zinc-400 transition-colors font-mono mt-2"
                     >
-                      Book another session
+                      {t('حجز جلسة أخرى', 'Book another session')}
                     </button>
                   </div>
                 </div>
@@ -487,20 +536,20 @@ export default function ServicesPage() {
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                        Your Name <span className="text-emerald-600">*</span>
+                        {t('اسمك', 'Your Name')} <span className="text-emerald-600">*</span>
                       </label>
                       <input
                         type="text"
                         value={form.name}
                         onChange={set('name')}
-                        placeholder="Your full name"
+                        placeholder={t('اسمك الكامل', 'Your full name')}
                         className={inputCls}
                         required
                       />
                     </div>
                     <div>
                       <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                        Email <span className="text-emerald-600">*</span>
+                        {t('البريد الإلكتروني', 'Email')} <span className="text-emerald-600">*</span>
                       </label>
                       <input
                         type="email"
@@ -515,20 +564,20 @@ export default function ServicesPage() {
 
                   <div>
                     <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                      Company / Organization
+                      {t('الشركة / المؤسسة', 'Company / Organization')}
                     </label>
                     <input
                       type="text"
                       value={form.company}
                       onChange={set('company')}
-                      placeholder="Acme Corp Ltd."
+                      placeholder={t('شركة المثال المحدودة', 'Acme Corp Ltd.')}
                       className={inputCls}
                     />
                   </div>
 
                   <div>
                     <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                      Service Needed <span className="text-emerald-600">*</span>
+                      {t('الخدمة المطلوبة', 'Service Needed')} <span className="text-emerald-600">*</span>
                     </label>
                     <select
                       value={form.service}
@@ -536,21 +585,21 @@ export default function ServicesPage() {
                       className={inputCls}
                       required
                     >
-                      <option value="">Select a service...</option>
-                      <option value="Penetration Testing">Penetration Testing</option>
-                      <option value="Security Audit (NCA/SAMA/ISO)">Security Audit (NCA/SAMA/ISO)</option>
-                      <option value="Microsoft Security Setup (Azure/M365)">Microsoft Security Setup (Azure/M365)</option>
-                      <option value="Security Monitoring Retainer">Security Monitoring Retainer</option>
-                      <option value="Security Awareness Training">Security Awareness Training</option>
-                      <option value="Incident Response">Incident Response</option>
-                      <option value="Other / Not Sure">Other / Not Sure</option>
+                      <option value="">{t('اختر خدمة...', 'Select a service...')}</option>
+                      <option value="Penetration Testing">{t('اختبار الاختراق', 'Penetration Testing')}</option>
+                      <option value="Security Audit (NCA/SAMA/ISO)">{t('تدقيق أمني (NCA/SAMA/ISO)', 'Security Audit (NCA/SAMA/ISO)')}</option>
+                      <option value="Microsoft Security Setup (Azure/M365)">{t('إعداد أمن Microsoft (Azure/M365)', 'Microsoft Security Setup (Azure/M365)')}</option>
+                      <option value="Security Monitoring Retainer">{t('اشتراك المراقبة الأمنية', 'Security Monitoring Retainer')}</option>
+                      <option value="Security Awareness Training">{t('التوعية الأمنية', 'Security Awareness Training')}</option>
+                      <option value="Incident Response">{t('الاستجابة للحوادث', 'Incident Response')}</option>
+                      <option value="Other / Not Sure">{t('أخرى / غير متأكد', 'Other / Not Sure')}</option>
                     </select>
                   </div>
 
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                        Preferred Date <span className="text-emerald-600">*</span>
+                        {t('التاريخ المفضّل', 'Preferred Date')} <span className="text-emerald-600">*</span>
                       </label>
                       <input
                         type="date"
@@ -563,7 +612,7 @@ export default function ServicesPage() {
                     </div>
                     <div>
                       <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                        Preferred Time (AST)
+                        {t('الوقت المفضّل (بتوقيت السعودية)', 'Preferred Time (AST)')}
                       </label>
                       <select
                         value={form.preferredTime}
@@ -571,25 +620,25 @@ export default function ServicesPage() {
                         className={inputCls}
                       >
                         {['09:00','09:30','10:00','10:30','11:00','11:30','12:00',
-                          '13:00','13:30','14:00','14:30','15:00','15:30','16:00','16:30','17:00'].map(t => (
-                          <option key={t} value={t}>{t} AST</option>
+                          '13:00','13:30','14:00','14:30','15:00','15:30','16:00','16:30','17:00'].map(time => (
+                          <option key={time} value={time}>{time} {t('بتوقيت السعودية', 'AST')}</option>
                         ))}
                       </select>
                     </div>
                   </div>
                   <p className="font-mono text-[10px] text-zinc-700 -mt-2">
-                    45-min session · Google Meet link sent to your email
+                    {t('جلسة 45 دقيقة · يُرسل رابط Google Meet إلى بريدك الإلكتروني', '45-min session · Google Meet link sent to your email')}
                   </p>
 
                   <div>
                     <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">
-                      Situation Brief
+                      {t('موجز عن وضعك', 'Situation Brief')}
                     </label>
                     <textarea
                       value={form.message}
                       onChange={set('message')}
                       rows={4}
-                      placeholder="Brief description of your environment, what you're worried about, any compliance requirements, timeline..."
+                      placeholder={t('وصف موجز لبيئتك، وما الذي يقلقك، وأي متطلبات امتثال، والجدول الزمني...', "Brief description of your environment, what you're worried about, any compliance requirements, timeline...")}
                       className={`${inputCls} resize-none`}
                     />
                   </div>
@@ -602,18 +651,18 @@ export default function ServicesPage() {
                     {submitState === 'sending' ? (
                       <>
                         <span className="w-4 h-4 border-2 border-black/30 border-t-black rounded-full animate-spin" />
-                        Booking meeting...
+                        {t('جارٍ حجز الاجتماع...', 'Booking meeting...')}
                       </>
                     ) : (
                       <>
                         <Zap className="h-4 w-4" />
-                        Book Free Consultation
+                        {t('احجز استشارة مجانية', 'Book Free Consultation')}
                       </>
                     )}
                   </button>
 
                   <p className="text-center font-mono text-[10px] text-zinc-700">
-                    Google Calendar invite sent immediately · No spam · No obligation
+                    {t('تُرسل دعوة Google Calendar فوراً · بلا إزعاج · بلا التزام', 'Google Calendar invite sent immediately · No spam · No obligation')}
                   </p>
                 </form>
               )}
@@ -623,17 +672,17 @@ export default function ServicesPage() {
           {/* Trust signals */}
           <div className="mt-5 grid grid-cols-3 gap-3">
             {[
-              { icon: <Clock className="h-3.5 w-3.5" />, label: '24h Response', sub: 'Guaranteed' },
-              { icon: <Users className="h-3.5 w-3.5" />, label: 'AR + EN', sub: 'Bilingual' },
-              { icon: <Shield className="h-3.5 w-3.5" />, label: 'NDA Available', sub: 'Confidential' },
-            ].map(t => (
+              { icon: <Clock className="h-3.5 w-3.5" />, label: t('استجابة خلال 24 ساعة', '24h Response'), sub: t('مضمونة', 'Guaranteed') },
+              { icon: <Users className="h-3.5 w-3.5" />, label: t('عربي + إنجليزي', 'AR + EN'), sub: t('ثنائي اللغة', 'Bilingual') },
+              { icon: <Shield className="h-3.5 w-3.5" />, label: t('اتفاقية سرية متاحة', 'NDA Available'), sub: t('سرّي', 'Confidential') },
+            ].map(item => (
               <div
-                key={t.label}
+                key={item.label}
                 className="rounded border border-zinc-800 bg-zinc-950/60 p-3 text-center hover:border-zinc-700 transition-colors"
               >
-                <div className="text-emerald-500 flex justify-center mb-2">{t.icon}</div>
-                <div className="font-mono text-[11px] font-semibold text-zinc-300">{t.label}</div>
-                <div className="font-mono text-[9px] text-zinc-600 mt-0.5 uppercase tracking-widest">{t.sub}</div>
+                <div className="text-emerald-500 flex justify-center mb-2">{item.icon}</div>
+                <div className="font-mono text-[11px] font-semibold text-zinc-300">{item.label}</div>
+                <div className="font-mono text-[9px] text-zinc-600 mt-0.5 uppercase tracking-widest">{item.sub}</div>
               </div>
             ))}
           </div>
@@ -641,17 +690,17 @@ export default function ServicesPage() {
       </main>
 
       {/* ── Footer ──────────────────────────────────────────────────────── */}
-      <footer className="border-t border-zinc-900 py-6 relative z-10">
+      <footer dir={dir} className="border-t border-zinc-900 py-6 relative z-10">
         <div className="container mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-3">
           <span className="font-mono text-[10px] text-zinc-700 uppercase tracking-widest">
             GOODNBAD.EXE © {new Date().getFullYear()}
           </span>
           <div className="flex gap-5">
             {[
-              { href: '/',          label: 'Portfolio'      },
-              { href: '/security',  label: 'Security Atlas' },
-              { href: '/personnel', label: 'Dossier'        },
-              { href: 'mailto:alramli.hamzah@gmail.com', label: 'Email' },
+              { href: '/',          label: t('الأعمال', 'Portfolio')        },
+              { href: '/security',  label: t('أطلس الأمن', 'Security Atlas') },
+              { href: '/personnel', label: t('الملف', 'Dossier')            },
+              { href: 'mailto:alramli.hamzah@gmail.com', label: t('البريد', 'Email') },
             ].map(({ href, label }) => (
               <Link
                 key={href}

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -11,6 +11,7 @@ import {
   BUILD_STEPS, PLANS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, checkoutUrl, planById, type Plan,
 } from "@/lib/subscribe/config"
 import { MoyasarPayment } from "./MoyasarPayment"
+import { useLanguage } from "@/components/language-provider"
 
 const ICONS: Record<string, LucideIcon> = {
   user: User, zap: Zap, wrench: Wrench, alert: AlertTriangle, layers: Layers, clock: Clock,
@@ -49,15 +50,12 @@ export default function SubscribePage() {
   const [expiresAt, setExpiresAt] = useState<number | null>(null)
   const [selected, setSelected] = useState<Plan["id"]>("monthly")
   const [payResult, setPayResult] = useState<{ status: string; id: string | null; message: string | null } | null>(null)
-  const [lang, setLang] = useState<"ar" | "en">("ar")
+  const { setLang, isAr, t: tr, dir } = useLanguage()
   const topRef = useRef<HTMLDivElement>(null)
 
   const { display: countdown, expired } = useCountdown(expiresAt)
   const name = answers.name ?? ""
   const email = answers.email ?? ""
-  const isAr = lang === "ar"
-  const tr = (ar: string, en: string) => (isAr ? ar : en)
-  const dir = isAr ? "rtl" : "ltr"
 
   const scrollTop = useCallback(() => {
     topRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })

--- a/components/contact-subscribe-cta.tsx
+++ b/components/contact-subscribe-cta.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight, Lock } from "lucide-react"
+import { useLanguage } from "@/components/language-provider"
+
+/**
+ * ContactSubscribeCTA — emerald OS-themed call-to-action that funnels contact
+ * visitors into the /subscribe "Toolkit Vault" flow. Bilingual via useLanguage.
+ */
+export function ContactSubscribeCTA() {
+  const { t, dir } = useLanguage()
+
+  return (
+    <Link
+      href="/subscribe"
+      dir={dir}
+      className="group flex items-center gap-4 rounded-md border border-emerald-700 bg-emerald-950/25 p-5 transition hover:border-emerald-500 hover:bg-emerald-950/50"
+    >
+      <span className="grid h-11 w-11 shrink-0 place-items-center rounded-md border border-emerald-700/70 bg-emerald-950/50 text-emerald-300 transition group-hover:border-emerald-500 group-hover:text-emerald-200">
+        <Lock className="h-5 w-5" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-base font-semibold text-emerald-100">
+          {t("اشترك في خزينة الأدوات", "Subscribe to the Toolkit Vault")}
+        </span>
+        <span className="mt-1 block text-sm leading-6 text-emerald-200/75">
+          {t("أدوات أمن وذكاء اصطناعي أسبوعية", "Weekly security + AI tools")}
+        </span>
+      </span>
+      <ArrowRight className="h-5 w-5 shrink-0 text-emerald-400 transition group-hover:translate-x-0.5 rtl:rotate-180 rtl:group-hover:-translate-x-0.5" />
+    </Link>
+  )
+}

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react"
+
+export type Lang = "ar" | "en"
+
+type LanguageContextValue = {
+  lang: Lang
+  setLang: (l: Lang) => void
+  toggle: () => void
+  isAr: boolean
+  /** Pick the right string for the active language. */
+  t: (ar: string, en: string) => string
+  dir: "rtl" | "ltr"
+}
+
+const STORAGE_KEY = "gnb_language"
+const LanguageContext = createContext<LanguageContextValue | null>(null)
+
+/**
+ * Site-wide language state. SSR renders English (matching <html lang="en">);
+ * the client corrects to the stored preference or the browser language on mount,
+ * then reflects the choice to <html lang/dir> and localStorage. This is the single
+ * source of truth so the main site and the /subscribe funnel stay in sync.
+ */
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLangState] = useState<Lang>("en")
+
+  // Mount: restore stored choice, else fall back to browser Arabic detection.
+  useEffect(() => {
+    let initial: Lang | null = null
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored === "ar" || stored === "en") initial = stored
+    } catch {}
+    if (!initial && typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("ar")) {
+      initial = "ar"
+    }
+    if (initial && initial !== lang) setLangState(initial)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Reflect to <html lang/dir> + persist on every change.
+  useEffect(() => {
+    const el = document.documentElement
+    el.lang = lang
+    el.dir = lang === "ar" ? "rtl" : "ltr"
+    try { localStorage.setItem(STORAGE_KEY, lang) } catch {}
+  }, [lang])
+
+  const setLang = useCallback((l: Lang) => setLangState(l), [])
+  const toggle = useCallback(() => setLangState((p) => (p === "ar" ? "en" : "ar")), [])
+
+  const isAr = lang === "ar"
+  const value: LanguageContextValue = {
+    lang,
+    setLang,
+    toggle,
+    isAr,
+    t: (ar, en) => (isAr ? ar : en),
+    dir: isAr ? "rtl" : "ltr",
+  }
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
+}
+
+/** Read the active language. Safe outside the provider (defaults to English). */
+export function useLanguage(): LanguageContextValue {
+  const ctx = useContext(LanguageContext)
+  if (!ctx) {
+    return { lang: "en", setLang: () => {}, toggle: () => {}, isAr: false, t: (_ar, en) => en, dir: "ltr" }
+  }
+  return ctx
+}

--- a/components/language-toggle.tsx
+++ b/components/language-toggle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useLanguage } from "@/components/language-provider"
+import { cn } from "@/lib/utils"
+
+/**
+ * Compact EN ⇄ العربية pill. Drops into the taskbar (and anywhere site-wide).
+ * Writes to the shared language context, so the choice follows the visitor
+ * across every page — including the /subscribe funnel.
+ */
+export function LanguageToggle({ className }: { className?: string }) {
+  const { lang, setLang } = useLanguage()
+  const isAr = lang === "ar"
+  return (
+    <div
+      className={cn(
+        "inline-flex shrink-0 rounded-full border border-zinc-700 bg-zinc-900/70 p-0.5 font-mono text-[10px] leading-none",
+        className,
+      )}
+      role="group"
+      aria-label="Language"
+    >
+      <button
+        type="button"
+        onClick={() => setLang("ar")}
+        aria-pressed={isAr}
+        className={cn(
+          "rounded-full px-2 py-1 transition-colors",
+          isAr ? "bg-emerald-500 font-semibold text-emerald-950" : "text-zinc-400 hover:text-zinc-200",
+        )}
+      >
+        ع
+      </button>
+      <button
+        type="button"
+        onClick={() => setLang("en")}
+        aria-pressed={!isAr}
+        className={cn(
+          "rounded-full px-2 py-1 transition-colors",
+          !isAr ? "bg-emerald-500 font-semibold text-emerald-950" : "text-zinc-400 hover:text-zinc-200",
+        )}
+      >
+        EN
+      </button>
+    </div>
+  )
+}

--- a/components/os/OSTaskbar.tsx
+++ b/components/os/OSTaskbar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { useState, useEffect } from "react"
 import { OS_APPS } from "./types"
+import { LanguageToggle } from "@/components/language-toggle"
 
 // Home entry + all registered OS apps
 const NAV_ITEMS = [
@@ -130,6 +131,7 @@ export function OSTaskbar({ className }: OSTaskbarProps) {
 
       {/* System status — right side */}
       <div className="ml-auto flex items-center gap-3">
+        <LanguageToggle />
         <span className="hidden sm:flex items-center gap-1.5">
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_4px_theme(colors.emerald.500)] animate-pulse" />
           <span className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest select-none">

--- a/lib/content/contact.ts
+++ b/lib/content/contact.ts
@@ -1,46 +1,129 @@
 import { personnelIdentity, resumeHref } from "@/lib/content/personnel"
 
-export const contactProfile = {
-  title: "Start a conversation",
-  description:
-    "For cybersecurity, IT systems, automation, software projects, recruiter outreach, and collaboration requests.",
-  responseNote: "Best first contact: email or LinkedIn. Include the role, project, timeline, and preferred next step.",
+/** Bilingual user-facing string. URLs/emails/hrefs stay outside this shape. */
+export type Bilingual = { ar: string; en: string }
+
+export const contactProfile: {
+  title: Bilingual
+  description: Bilingual
+  responseNote: Bilingual
+} = {
+  title: {
+    ar: "لنبدأ محادثة",
+    en: "Start a conversation",
+  },
+  description: {
+    ar: "للأمن السيبراني وأنظمة تقنية المعلومات والأتمتة ومشاريع البرمجيات وتواصل جهات التوظيف وطلبات التعاون.",
+    en: "For cybersecurity, IT systems, automation, software projects, recruiter outreach, and collaboration requests.",
+  },
+  responseNote: {
+    ar: "أفضل وسيلة للتواصل الأول: البريد الإلكتروني أو LinkedIn. اذكر الدور والمشروع والجدول الزمني والخطوة التالية المفضلة.",
+    en: "Best first contact: email or LinkedIn. Include the role, project, timeline, and preferred next step.",
+  },
 }
 
-export const contactActions = [
+export type ContactAction = {
+  /** Stable key — also used to map icons in the UI. */
+  key: string
+  label: Bilingual
+  description: Bilingual
+  href: string
+  value: string
+  primary: boolean
+}
+
+export const contactActions: ContactAction[] = [
   {
-    label: "Email Hamzah",
-    description: "Best for direct opportunities, project details, and recruiter outreach.",
+    key: "Email Hamzah",
+    label: {
+      ar: "راسل حمزة",
+      en: "Email Hamzah",
+    },
+    description: {
+      ar: "الأنسب للفرص المباشرة وتفاصيل المشاريع وتواصل جهات التوظيف.",
+      en: "Best for direct opportunities, project details, and recruiter outreach.",
+    },
     href: `mailto:${personnelIdentity.contact.email}?subject=Opportunity%20or%20collaboration%20for%20Hamzah%20Al-Ramli`,
     value: personnelIdentity.contact.email,
     primary: true,
   },
   {
-    label: "LinkedIn",
-    description: "Best for professional introductions and hiring conversations.",
+    key: "LinkedIn",
+    label: {
+      ar: "LinkedIn",
+      en: "LinkedIn",
+    },
+    description: {
+      ar: "الأنسب للتعارف المهني ومحادثات التوظيف.",
+      en: "Best for professional introductions and hiring conversations.",
+    },
     href: personnelIdentity.contact.linkedin,
     value: "linkedin.com/in/hamzah-al-ramli-505",
     primary: false,
   },
   {
-    label: "GitHub",
-    description: "Best for reviewing public code and project activity.",
+    key: "GitHub",
+    label: {
+      ar: "GitHub",
+      en: "GitHub",
+    },
+    description: {
+      ar: "الأنسب لمراجعة الكود العام ونشاط المشاريع.",
+      en: "Best for reviewing public code and project activity.",
+    },
     href: personnelIdentity.contact.github,
     value: "github.com/Goodnbadexe",
     primary: false,
   },
   {
-    label: "Resume",
-    description: "Download the current resume as a PDF.",
+    key: "Resume",
+    label: {
+      ar: "السيرة الذاتية",
+      en: "Resume",
+    },
+    description: {
+      ar: "حمّل السيرة الذاتية الحالية بصيغة PDF.",
+      en: "Download the current resume as a PDF.",
+    },
     href: resumeHref,
     value: "hamzah-al-ramli-resume.pdf",
     primary: false,
   },
 ]
 
-export const contactTopics = [
-  "Cybersecurity and IT systems roles",
-  "Automation and workflow engineering",
-  "Next.js, React, and web platform work",
-  "Security demos, labs, and technical collaborations",
+export const contactTopics: Bilingual[] = [
+  {
+    ar: "أدوار الأمن السيبراني وأنظمة تقنية المعلومات",
+    en: "Cybersecurity and IT systems roles",
+  },
+  {
+    ar: "الأتمتة وهندسة سير العمل",
+    en: "Automation and workflow engineering",
+  },
+  {
+    ar: "أعمال Next.js وReact ومنصات الويب",
+    en: "Next.js, React, and web platform work",
+  },
+  {
+    ar: "عروض الأمن والمختبرات والتعاون التقني",
+    en: "Security demos, labs, and technical collaborations",
+  },
 ]
+
+/** Copy for the make-outreach-easy panel header. */
+export const contactResponseHeader: { eyebrow: Bilingual; title: Bilingual } = {
+  eyebrow: {
+    ar: "أفضل صيغة رسالة",
+    en: "Best message format",
+  },
+  title: {
+    ar: "أرسل التفاصيل المفيدة أولاً",
+    en: "Send the useful details first",
+  },
+}
+
+/** Eyebrow label above the page title. */
+export const contactEyebrow: Bilingual = {
+  ar: "تواصل",
+  en: "Contact",
+}


### PR DESCRIPTION
Adds a shared language system: a global EN/العربية toggle (taskbar, every page) backed by LanguageProvider (localStorage + <html lang/dir>). /subscribe now inherits the site language. Homepage, services, and contact translated to bilingual; Subscribe-to-Toolkit-Vault CTA added to contact. tsc + next build both clean. Phases 2-4 (threat-page merge, globe, FAQ assistant, remaining pages) to follow.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a site-wide EN/AR language system backed by a `LanguageProvider` React context with `localStorage` persistence and `<html lang/dir>` reflection. Key pages (homepage, services, contact) are translated using a `t(ar, en)` helper, and the `/subscribe` funnel is unified with the global language state instead of carrying its own isolated `useState`.

- `LanguageProvider` is SSR-safe (defaults to English, corrects to stored/browser preference on mount) and wraps the entire app in `layout.tsx`.
- Contact page is split into a `\"use client\"` `ContactContent` component to allow hook usage, and a new `ContactSubscribeCTA` bridges the contact and subscribe flows.
- `lib/content/contact.ts` data is migrated to a `Bilingual` shape with a stable `key` field decoupled from translated labels, which is the right approach.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the language system is correctly wired and the build is clean.

The implementation is solid overall — SSR defaulting, localStorage persistence, and html dir/lang sync are all handled correctly. Two spots use translated strings as React key props (stat row and trust-signal cards in services, credential chips on the homepage), which causes unnecessary unmount/remount of those elements on every language toggle. The context value object is also created inline on every render without useMemo, though the practical impact is low since the provider only re-renders on an explicit language change. Neither issue produces wrong output, but both are worth cleaning up before the pattern propagates to phases 2–4.

app/services/page.tsx (stat row and trust-signal keys) and app/page.tsx (credential chip keys)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/language-provider.tsx | New shared language context with localStorage persistence, SSR-safe English default, and html lang/dir sync; context value created inline without useMemo. |
| components/language-toggle.tsx | New EN/AR pill toggle that delegates to the shared context; accessible with aria-pressed and role=group. |
| app/services/page.tsx | Full bilingual conversion using Bi tuple type and t(...spread) pattern; stat row and trust-signal keys are unstable (translated strings). |
| app/page.tsx | Homepage converted to bilingual; MODULE_ITEMS extended with ar/subAr fields; credential chip keys are unstable (translated strings). |
| app/subscribe/page.tsx | Replaced local lang state with global useLanguage(); subscribe's own EN/AR buttons now write to the shared context and localStorage, which is the intended behavior. |
| app/contact/contact-content.tsx | Contact page extracted to a client component; actionIcons keyed by stable English key strings; all user-facing copy routed through the language provider. |
| lib/content/contact.ts | Contact content refactored to Bilingual shape; new ContactAction type with stable key field separates icon lookup from translated labels. |
| components/contact-subscribe-cta.tsx | New bilingual CTA linking to /subscribe; correctly applies rtl:rotate-180 and rtl:group-hover:-translate-x-0.5 for the arrow. |
| app/layout.tsx | LanguageProvider added inside ThemeProvider, wrapping all children; straightforward integration. |
| components/os/OSTaskbar.tsx | LanguageToggle pill added to the taskbar system-status row; no other changes. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User toggles language] --> B[LanguageToggle or subscribe buttons]
    B --> C[setLang called on LanguageContext]
    C --> D[setLangState updates lang state]
    D --> E["useEffect: html lang/dir updated\nlocalStorage persisted"]
    D --> F[Context value recomputed\nt, dir, isAr, lang updated]
    F --> G[All consumers re-render]
    G --> H[app/page.tsx Homepage]
    G --> I[app/services/page.tsx]
    G --> J[app/contact/contact-content.tsx]
    G --> K[app/subscribe/page.tsx]
    G --> L[components/contact-subscribe-cta.tsx]
    M[Initial mount] --> N["useEffect: read localStorage\nor navigator.language"]
    N --> O{Stored preference?}
    O -- ar --> D
    O -- en/none --> P[Stay English default SSR-safe]
    O -- none browser=AR --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User toggles language] --> B[LanguageToggle or subscribe buttons]
    B --> C[setLang called on LanguageContext]
    C --> D[setLangState updates lang state]
    D --> E["useEffect: html lang/dir updated\nlocalStorage persisted"]
    D --> F[Context value recomputed\nt, dir, isAr, lang updated]
    F --> G[All consumers re-render]
    G --> H[app/page.tsx Homepage]
    G --> I[app/services/page.tsx]
    G --> J[app/contact/contact-content.tsx]
    G --> K[app/subscribe/page.tsx]
    G --> L[components/contact-subscribe-cta.tsx]
    M[Initial mount] --> N["useEffect: read localStorage\nor navigator.language"]
    N --> O{Stored preference?}
    O -- ar --> D
    O -- en/none --> P[Stay English default SSR-safe]
    O -- none browser=AR --> D
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/services/page.tsx`, line 355-366 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/c3ace288f5874bc67d4cb3c53cf6f6384ceb1403/app/services/page.tsx#L355-L366)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Translated strings used as React `key` props**

   `key={s.label}` and `key={item.label}` (line 680) resolve to different strings when the language toggles, so React treats them as brand-new elements and unmounts/remounts the nodes on every switch. The same pattern appears in the cert chips (line 324) and in `app/page.tsx` credential chips (line 517). Using a stable, non-translated identifier as the key avoids the unnecessary unmount cycle and any visual flash it produces.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fpage.tsx%0ALine%3A%20355-366%0A%0AComment%3A%0A**Translated%20strings%20used%20as%20React%20%60key%60%20props**%0A%0A%60key%3D%7Bs.label%7D%60%20and%20%60key%3D%7Bitem.label%7D%60%20%28line%20680%29%20resolve%20to%20different%20strings%20when%20the%20language%20toggles%2C%20so%20React%20treats%20them%20as%20brand-new%20elements%20and%20unmounts%2Fremounts%20the%20nodes%20on%20every%20switch.%20The%20same%20pattern%20appears%20in%20the%20cert%20chips%20%28line%20324%29%20and%20in%20%60app%2Fpage.tsx%60%20credential%20chips%20%28line%20517%29.%20Using%20a%20stable%2C%20non-translated%20identifier%20as%20the%20key%20avoids%20the%20unnecessary%20unmount%20cycle%20and%20any%20visual%20flash%20it%20produces.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fi18n-phase1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fi18n-phase1%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fpage.tsx%0ALine%3A%20355-366%0A%0AComment%3A%0A**Translated%20strings%20used%20as%20React%20%60key%60%20props**%0A%0A%60key%3D%7Bs.label%7D%60%20and%20%60key%3D%7Bitem.label%7D%60%20%28line%20680%29%20resolve%20to%20different%20strings%20when%20the%20language%20toggles%2C%20so%20React%20treats%20them%20as%20brand-new%20elements%20and%20unmounts%2Fremounts%20the%20nodes%20on%20every%20switch.%20The%20same%20pattern%20appears%20in%20the%20cert%20chips%20%28line%20324%29%20and%20in%20%60app%2Fpage.tsx%60%20credential%20chips%20%28line%20517%29.%20Using%20a%20stable%2C%20non-translated%20identifier%20as%20the%20key%20avoids%20the%20unnecessary%20unmount%20cycle%20and%20any%20visual%20flash%20it%20produces.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fservices%2Fpage.tsx%3A355-366%0A**Translated%20strings%20used%20as%20React%20%60key%60%20props**%0A%0A%60key%3D%7Bs.label%7D%60%20and%20%60key%3D%7Bitem.label%7D%60%20%28line%20680%29%20resolve%20to%20different%20strings%20when%20the%20language%20toggles%2C%20so%20React%20treats%20them%20as%20brand-new%20elements%20and%20unmounts%2Fremounts%20the%20nodes%20on%20every%20switch.%20The%20same%20pattern%20appears%20in%20the%20cert%20chips%20%28line%20324%29%20and%20in%20%60app%2Fpage.tsx%60%20credential%20chips%20%28line%20517%29.%20Using%20a%20stable%2C%20non-translated%20identifier%20as%20the%20key%20avoids%20the%20unnecessary%20unmount%20cycle%20and%20any%20visual%20flash%20it%20produces.%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Flanguage-provider.tsx%3A60-70%0A**Context%20value%20recreated%20inline%20without%20memoization**%0A%0AThe%20%60value%60%20object%20%28and%20the%20%60t%60%20arrow%20function%20inside%20it%29%20is%20allocated%20on%20every%20render%20of%20%60LanguageProvider%60.%20Since%20%60LanguageProvider%60%20only%20re-renders%20when%20%60lang%60%20changes%2C%20the%20practical%20impact%20is%20low%20%E2%80%94%20but%20if%20the%20provider%20ever%20gains%20a%20prop%20or%20a%20parent%20re-render%20triggers%20it%2C%20every%20consumer%20%28all%20translated%20pages%29%20will%20re-render.%20Wrapping%20%60value%60%20in%20%60useMemo%28%28%29%20%3D%3E%20%28%7B%20...%20%7D%29%2C%20%5Blang%2C%20setLang%2C%20toggle%5D%29%60%20makes%20the%20cost%20proportional%20to%20actual%20language%20changes%20and%20makes%20the%20intent%20explicit.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fi18n-phase1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fi18n-phase1%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fservices%2Fpage.tsx%3A355-366%0A**Translated%20strings%20used%20as%20React%20%60key%60%20props**%0A%0A%60key%3D%7Bs.label%7D%60%20and%20%60key%3D%7Bitem.label%7D%60%20%28line%20680%29%20resolve%20to%20different%20strings%20when%20the%20language%20toggles%2C%20so%20React%20treats%20them%20as%20brand-new%20elements%20and%20unmounts%2Fremounts%20the%20nodes%20on%20every%20switch.%20The%20same%20pattern%20appears%20in%20the%20cert%20chips%20%28line%20324%29%20and%20in%20%60app%2Fpage.tsx%60%20credential%20chips%20%28line%20517%29.%20Using%20a%20stable%2C%20non-translated%20identifier%20as%20the%20key%20avoids%20the%20unnecessary%20unmount%20cycle%20and%20any%20visual%20flash%20it%20produces.%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Flanguage-provider.tsx%3A60-70%0A**Context%20value%20recreated%20inline%20without%20memoization**%0A%0AThe%20%60value%60%20object%20%28and%20the%20%60t%60%20arrow%20function%20inside%20it%29%20is%20allocated%20on%20every%20render%20of%20%60LanguageProvider%60.%20Since%20%60LanguageProvider%60%20only%20re-renders%20when%20%60lang%60%20changes%2C%20the%20practical%20impact%20is%20low%20%E2%80%94%20but%20if%20the%20provider%20ever%20gains%20a%20prop%20or%20a%20parent%20re-render%20triggers%20it%2C%20every%20consumer%20%28all%20translated%20pages%29%20will%20re-render.%20Wrapping%20%60value%60%20in%20%60useMemo%28%28%29%20%3D%3E%20%28%7B%20...%20%7D%29%2C%20%5Blang%2C%20setLang%2C%20toggle%5D%29%60%20makes%20the%20cost%20proportional%20to%20actual%20language%20changes%20and%20makes%20the%20intent%20explicit.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=32&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(i18n): site-wide EN/AR language sys..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/c3ace288f5874bc67d4cb3c53cf6f6384ceb1403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38662646)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->