### PR TITLE
fix(assistant): surface upstream error detail

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -131,10 +131,11 @@ export async function POST(request: Request) {
       return fallbackResponse(lang)
     }
     const status = error instanceof Anthropic.APIError ? error.status ?? 502 : 500
+    const detail = error instanceof Error ? error.message : String(error)
     const message =
       lang === "ar"
         ? "تعذّر الوصول إلى المساعد. حاول مرة أخرى لاحقًا أو تواصل عبر صفحة Contact."
         : "Couldn't reach the assistant. Please try again later or use the Contact page."
-    return NextResponse.json({ error: message }, { status })
+    return NextResponse.json({ error: message, detail }, { status })
   }
 }


### PR DESCRIPTION
Temporary: include the real Anthropic error message in the API response so we can diagnose the 400 the FAQ assistant is hitting.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `detail` field to the error JSON response from the FAQ assistant route, forwarding the raw Anthropic error message back to the client to help diagnose a 400 the assistant is hitting in production.

- The `detail` field is included unconditionally in every non-auth error response, meaning any browser that triggers a failure receives the raw upstream Anthropic error string — which for 400 requests can include system prompt fragments, model configuration details, or account-level context.
- The change is described as \"Temporary\" in the PR description but ships to Vercel production with no TODO comment, issue reference, or feature flag to enforce removal.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is — raw upstream error content is forwarded to clients in production with no removal plan.

The change intentionally ships a temporary debugging mechanism to the live Vercel deployment. Every visitor whose request triggers a non-auth Anthropic failure will receive the raw SDK error string in the response body. For the 400 the team is diagnosing, that message is likely to include details about the request payload (system prompt fragments, model identifier) or Anthropic account context. There is no TODO, issue link, or flag to gate removal, so "temporary" has no enforcement. Server-side logging would capture the same diagnostic data without the exposure.

app/api/assistant/route.ts — the error catch block now forwards upstream error text to clients
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Information disclosure** (`app/api/assistant/route.ts`, line 134–139): Raw Anthropic error messages are forwarded to the client in the `detail` response field. For 400 Bad Request errors, Anthropic SDK messages can include content derived from the request body (system prompt, model name) or account-level error context, exposing internal implementation details to any visitor who triggers the error path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/assistant/route.ts | Adds `detail` (raw Anthropic error message) to the error JSON response for temporary debugging; this leaks upstream error content to every client that hits a non-auth failure path in production. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextRoute as POST /api/assistant
    participant Anthropic as Anthropic API

    Browser->>NextRoute: "POST { messages, lang }"
    NextRoute->>Anthropic: messages.create(...)
    Anthropic-->>NextRoute: 400 Bad Request (with error detail)
    Note over NextRoute: catch(error) branch
    NextRoute-->>Browser: "{ error: "user message", detail: "raw Anthropic message" }"
    Note over Browser: ⚠️ Raw upstream error now visible in client
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextRoute as POST /api/assistant
    participant Anthropic as Anthropic API

    Browser->>NextRoute: "POST { messages, lang }"
    NextRoute->>Anthropic: messages.create(...)
    Anthropic-->>NextRoute: 400 Bad Request (with error detail)
    Note over NextRoute: catch(error) branch
    NextRoute-->>Browser: "{ error: "user message", detail: "raw Anthropic message" }"
    Note over Browser: ⚠️ Raw upstream error now visible in client
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A134-139%0A**Raw%20upstream%20error%20exposed%20to%20every%20client**%0A%0A%60detail%60%20is%20returned%20directly%20in%20the%20JSON%20response%2C%20meaning%20any%20visitor's%20browser%20that%20triggers%20a%20non-auth%20API%20failure%20%28400%2C%20429%2C%205xx%29%20will%20receive%20the%20raw%20Anthropic%20error%20message.%20For%20a%20400%20Bad%20Request%2C%20the%20Anthropic%20SDK%20message%20can%20include%20excerpts%20from%20the%20request%20body%20%28system%20prompt%20fragments%2C%20model%20name%29%20or%20account-level%20context%20%E2%80%94%20information%20that%20shouldn't%20leave%20the%20server.%20Because%20this%20route%20is%20already%20deployed%20on%20Vercel%20and%20the%20PR%20description%20marks%20this%20as%20%22Temporary%22%20without%20a%20TODO%20or%20issue%20reference%20to%20track%20removal%2C%20there%20is%20no%20enforcement%20mechanism%20ensuring%20it%20gets%20cleaned%20up.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A133-139%0AServer-side%20logging%20%28%60console.error%60%29%20captures%20the%20same%20diagnostic%20information%20without%20surfacing%20it%20to%20the%20client.%20This%20is%20the%20standard%20approach%20for%20temporary%20debugging%20in%20production%20Next.js%20routes%2C%20and%20it's%20already%20available%20in%20Vercel's%20log%20drain.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20status%20%3D%20error%20instanceof%20Anthropic.APIError%20%3F%20error.status%20%3F%3F%20502%20%3A%20500%0A%20%20%20%20const%20detail%20%3D%20error%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%0A%20%20%20%20console.error%28%22%5Bassistant%5D%20Anthropic%20error%22%2C%20%7B%20status%2C%20detail%20%7D%29%0A%20%20%20%20const%20message%20%3D%0A%20%20%20%20%20%20lang%20%3D%3D%3D%20%22ar%22%0A%20%20%20%20%20%20%20%20%3F%20%22%D8%AA%D8%B9%D8%B0%D9%91%D8%B1%20%D8%A7%D9%84%D9%88%D8%B5%D9%88%D9%84%20%D8%A5%D9%84%D9%89%20%D8%A7%D9%84%D9%85%D8%B3%D8%A7%D8%B9%D8%AF.%20%D8%AD%D8%A7%D9%88%D9%84%20%D9%85%D8%B1%D8%A9%20%D8%A3%D8%AE%D8%B1%D9%89%20%D9%84%D8%A7%D8%AD%D9%82%D9%8B%D8%A7%20%D8%A3%D9%88%20%D8%AA%D9%88%D8%A7%D8%B5%D9%84%20%D8%B9%D8%A8%D8%B1%20%D8%B5%D9%81%D8%AD%D8%A9%20Contact.%22%0A%20%20%20%20%20%20%20%20%3A%20%22Couldn't%20reach%20the%20assistant.%20Please%20try%20again%20later%20or%20use%20the%20Contact%20page.%22%0A%20%20%20%20return%20NextResponse.json%28%7B%20error%3A%20message%20%7D%2C%20%7B%20status%20%7D%29%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=34&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fassistant-error-detail%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fassistant-error-detail%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A134-139%0A**Raw%20upstream%20error%20exposed%20to%20every%20client**%0A%0A%60detail%60%20is%20returned%20directly%20in%20the%20JSON%20response%2C%20meaning%20any%20visitor's%20browser%20that%20triggers%20a%20non-auth%20API%20failure%20%28400%2C%20429%2C%205xx%29%20will%20receive%20the%20raw%20Anthropic%20error%20message.%20For%20a%20400%20Bad%20Request%2C%20the%20Anthropic%20SDK%20message%20can%20include%20excerpts%20from%20the%20request%20body%20%28system%20prompt%20fragments%2C%20model%20name%29%20or%20account-level%20context%20%E2%80%94%20information%20that%20shouldn't%20leave%20the%20server.%20Because%20this%20route%20is%20already%20deployed%20on%20Vercel%20and%20the%20PR%20description%20marks%20this%20as%20%22Temporary%22%20without%20a%20TODO%20or%20issue%20reference%20to%20track%20removal%2C%20there%20is%20no%20enforcement%20mechanism%20ensuring%20it%20gets%20cleaned%20up.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A133-139%0AServer-side%20logging%20%28%60console.error%60%29%20captures%20the%20same%20diagnostic%20information%20without%20surfacing%20it%20to%20the%20client.%20This%20is%20the%20standard%20approach%20for%20temporary%20debugging%20in%20production%20Next.js%20routes%2C%20and%20it's%20already%20available%20in%20Vercel's%20log%20drain.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20status%20%3D%20error%20instanceof%20Anthropic.APIError%20%3F%20error.status%20%3F%3F%20502%20%3A%20500%0A%20%20%20%20const%20detail%20%3D%20error%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%0A%20%20%20%20console.error%28%22%5Bassistant%5D%20Anthropic%20error%22%2C%20%7B%20status%2C%20detail%20%7D%29%0A%20%20%20%20const%20message%20%3D%0A%20%20%20%20%20%20lang%20%3D%3D%3D%20%22ar%22%0A%20%20%20%20%20%20%20%20%3F%20%22%D8%AA%D8%B9%D8%B0%D9%91%D8%B1%20%D8%A7%D9%84%D9%88%D8%B5%D9%88%D9%84%20%D8%A5%D9%84%D9%89%20%D8%A7%D9%84%D9%85%D8%B3%D8%A7%D8%B9%D8%AF.%20%D8%AD%D8%A7%D9%88%D9%84%20%D9%85%D8%B1%D8%A9%20%D8%A3%D8%AE%D8%B1%D9%89%20%D9%84%D8%A7%D8%AD%D9%82%D9%8B%D8%A7%20%D8%A3%D9%88%20%D8%AA%D9%88%D8%A7%D8%B5%D9%84%20%D8%B9%D8%A8%D8%B1%20%D8%B5%D9%81%D8%AD%D8%A9%20Contact.%22%0A%20%20%20%20%20%20%20%20%3A%20%22Couldn't%20reach%20the%20assistant.%20Please%20try%20again%20later%20or%20use%20the%20Contact%20page.%22%0A%20%20%20%20return%20NextResponse.json%28%7B%20error%3A%20message%20%7D%2C%20%7B%20status%20%7D%29%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=34&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): surface upstream Anthrop..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/fd10346602393f04db2f7f3a68a725525e478efc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38730568)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->