### PR TITLE
fix(assistant): graceful FAQ fallback on any upstream error

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -125,17 +125,9 @@ export async function POST(request: Request) {
     }
 
     return NextResponse.json({ reply })
-  } catch (error) {
-    if (error instanceof Anthropic.AuthenticationError) {
-      // Bad/expired key — treat like "not configured" so the widget stays useful.
-      return fallbackResponse(lang)
-    }
-    const status = error instanceof Anthropic.APIError ? error.status ?? 502 : 500
-    const detail = error instanceof Error ? error.message : String(error)
-    const message =
-      lang === "ar"
-        ? "تعذّر الوصول إلى المساعد. حاول مرة أخرى لاحقًا أو تواصل عبر صفحة Contact."
-        : "Couldn't reach the assistant. Please try again later or use the Contact page."
-    return NextResponse.json({ error: message, detail }, { status })
+  } catch {
+    // Any upstream failure — no credits, bad key, rate limit, transient outage —
+    // degrades to the static FAQ so the widget stays useful instead of erroring.
+    return fallbackResponse(lang)
   }
 }


### PR DESCRIPTION
The Anthropic key authenticates but the account has no credits (400 credit-balance-too-low). Make the assistant degrade to the static FAQ on ANY upstream error so the widget is always useful, and remove the diagnostic error-detail leak.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR widens the assistant's error fallback from auth-only to every upstream failure, so the FAQ widget remains functional when the Anthropic account has no credits, hits a rate limit, or encounters any transient outage. It also removes the `detail` field that was leaking raw SDK error messages to the client.

- **Fallback broadened**: the `catch` block no longer discriminates by error type — all Anthropic API failures now return the static FAQ response instead of a 5xx JSON error.
- **Info leak closed**: the previous `{ error, detail }` response shape that exposed raw SDK error text to callers is removed.
- **Observability gap introduced**: the catch binding is now bare (`catch {}`), discarding the error object before any logging can occur; production failures are invisible in Vercel function logs.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe for the intended UX goal but introduces a blind spot where any error inside the try block is silently swallowed with no trace in logs.

The catch handler uses a bare `catch {}` with no error binding, so nothing is logged when the Anthropic call fails. A future programming bug inside the try block would be completely invisible in production — the route silently returns the FAQ with no trace in Vercel logs.

app/api/assistant/route.ts — specifically the new catch block at the bottom of the POST handler.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/assistant/route.ts | Replaces typed error-handling with a bare `catch {}` that silently swallows all upstream errors; removes client-side error-detail leak (good) but also removes any server-side logging, making production failures undetectable. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /api/assistant
    participant A as Anthropic API

    C->>R: "POST { messages, lang }"
    R->>R: "parse & sanitize body"
    alt no ANTHROPIC_API_KEY
        R-->>C: "200 { fallback: true, message, faq }"
    else key present
        R->>A: messages.create(model, system, messages)
        alt success
            A-->>R: "{ content: TextBlock[] }"
            R-->>C: "200 { reply }"
        else ANY error
            Note over R: catch {} — error silently discarded
            R-->>C: "200 { fallback: true, message, faq }"
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant R as POST /api/assistant
    participant A as Anthropic API

    C->>R: "POST { messages, lang }"
    R->>R: "parse & sanitize body"
    alt no ANTHROPIC_API_KEY
        R-->>C: "200 { fallback: true, message, faq }"
    else key present
        R->>A: messages.create(model, system, messages)
        alt success
            A-->>R: "{ content: TextBlock[] }"
            R-->>C: "200 { reply }"
        else ANY error
            Note over R: catch {} — error silently discarded
            R-->>C: "200 { fallback: true, message, faq }"
        end
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/api/assistant/route.ts`, line 18-19 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/d84d117bb2ea78d73e63ad3f83ee49c28156b2b9/app/api/assistant/route.ts#L18-L19)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The JSDoc still describes the fallback as only occurring when "no API key configured", but after this PR it also fires on any upstream error (bad key, rate limit, outage). The comment should be updated to match the new behaviour so future readers aren't misled.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fassistant%2Froute.ts%0ALine%3A%2018-19%0A%0AComment%3A%0AThe%20JSDoc%20still%20describes%20the%20fallback%20as%20only%20occurring%20when%20%22no%20API%20key%20configured%22%2C%20but%20after%20this%20PR%20it%20also%20fires%20on%20any%20upstream%20error%20%28bad%20key%2C%20rate%20limit%2C%20outage%29.%20The%20comment%20should%20be%20updated%20to%20match%20the%20new%20behaviour%20so%20future%20readers%20aren't%20misled.%0A%0A%60%60%60suggestion%0A%20*%20Live%20answers%20require%20ANTHROPIC_API_KEY%20in%20the%20environment%20%28Vercel%29.%20Without%20it%2C%0A%20*%20or%20on%20any%20upstream%20error%20%28no%20credits%2C%20rate%20limit%2C%20transient%20outage%29%2C%20the%20route%0A%20*%20degrades%20gracefully%20to%20the%20static%20FAQ%20list%20so%20the%20widget%20stays%20useful.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fassistant-graceful-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fassistant-graceful-fallback%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fapi%2Fassistant%2Froute.ts%0ALine%3A%2018-19%0A%0AComment%3A%0AThe%20JSDoc%20still%20describes%20the%20fallback%20as%20only%20occurring%20when%20%22no%20API%20key%20configured%22%2C%20but%20after%20this%20PR%20it%20also%20fires%20on%20any%20upstream%20error%20%28bad%20key%2C%20rate%20limit%2C%20outage%29.%20The%20comment%20should%20be%20updated%20to%20match%20the%20new%20behaviour%20so%20future%20readers%20aren't%20misled.%0A%0A%60%60%60suggestion%0A%20*%20Live%20answers%20require%20ANTHROPIC_API_KEY%20in%20the%20environment%20%28Vercel%29.%20Without%20it%2C%0A%20*%20or%20on%20any%20upstream%20error%20%28no%20credits%2C%20rate%20limit%2C%20transient%20outage%29%2C%20the%20route%0A%20*%20degrades%20gracefully%20to%20the%20static%20FAQ%20list%20so%20the%20widget%20stays%20useful.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A128-132%0ASilent%20catch%20loses%20all%20server-side%20observability.%20The%20bare%20%60catch%20%7B%7D%60%20binding%20discards%20the%20error%20object%20entirely%2C%20so%20Vercel%20function%20logs%20will%20show%20nothing%20when%20the%20Claude%20API%20fails%20for%20any%20reason%20other%20than%20missing%20credits%20%E2%80%94%20including%20real%20programming%20bugs%20inside%20the%20%60try%60%20block%20%28e.g.%2C%20a%20future%20SDK%20response-format%20change%29.%20Without%20a%20log%20statement%20it's%20impossible%20to%20distinguish%20a%20rate-limit%20from%20a%20crash.%0A%0A%60%60%60suggestion%0A%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%2F%2F%20Any%20upstream%20failure%20%E2%80%94%20no%20credits%2C%20bad%20key%2C%20rate%20limit%2C%20transient%20outage%20%E2%80%94%0A%20%20%20%20%2F%2F%20degrades%20to%20the%20static%20FAQ%20so%20the%20widget%20stays%20useful%20instead%20of%20erroring.%0A%20%20%20%20console.error%28%22%5Bassistant%5D%20upstream%20error%3A%22%2C%20error%29%0A%20%20%20%20return%20fallbackResponse%28lang%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A18-19%0AThe%20JSDoc%20still%20describes%20the%20fallback%20as%20only%20occurring%20when%20%22no%20API%20key%20configured%22%2C%20but%20after%20this%20PR%20it%20also%20fires%20on%20any%20upstream%20error%20%28bad%20key%2C%20rate%20limit%2C%20outage%29.%20The%20comment%20should%20be%20updated%20to%20match%20the%20new%20behaviour%20so%20future%20readers%20aren't%20misled.%0A%0A%60%60%60suggestion%0A%20*%20Live%20answers%20require%20ANTHROPIC_API_KEY%20in%20the%20environment%20%28Vercel%29.%20Without%20it%2C%0A%20*%20or%20on%20any%20upstream%20error%20%28no%20credits%2C%20rate%20limit%2C%20transient%20outage%29%2C%20the%20route%0A%20*%20degrades%20gracefully%20to%20the%20static%20FAQ%20list%20so%20the%20widget%20stays%20useful.%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fassistant-graceful-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fassistant-graceful-fallback%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A128-132%0ASilent%20catch%20loses%20all%20server-side%20observability.%20The%20bare%20%60catch%20%7B%7D%60%20binding%20discards%20the%20error%20object%20entirely%2C%20so%20Vercel%20function%20logs%20will%20show%20nothing%20when%20the%20Claude%20API%20fails%20for%20any%20reason%20other%20than%20missing%20credits%20%E2%80%94%20including%20real%20programming%20bugs%20inside%20the%20%60try%60%20block%20%28e.g.%2C%20a%20future%20SDK%20response-format%20change%29.%20Without%20a%20log%20statement%20it's%20impossible%20to%20distinguish%20a%20rate-limit%20from%20a%20crash.%0A%0A%60%60%60suggestion%0A%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%2F%2F%20Any%20upstream%20failure%20%E2%80%94%20no%20credits%2C%20bad%20key%2C%20rate%20limit%2C%20transient%20outage%20%E2%80%94%0A%20%20%20%20%2F%2F%20degrades%20to%20the%20static%20FAQ%20so%20the%20widget%20stays%20useful%20instead%20of%20erroring.%0A%20%20%20%20console.error%28%22%5Bassistant%5D%20upstream%20error%3A%22%2C%20error%29%0A%20%20%20%20return%20fallbackResponse%28lang%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fapi%2Fassistant%2Froute.ts%3A18-19%0AThe%20JSDoc%20still%20describes%20the%20fallback%20as%20only%20occurring%20when%20%22no%20API%20key%20configured%22%2C%20but%20after%20this%20PR%20it%20also%20fires%20on%20any%20upstream%20error%20%28bad%20key%2C%20rate%20limit%2C%20outage%29.%20The%20comment%20should%20be%20updated%20to%20match%20the%20new%20behaviour%20so%20future%20readers%20aren't%20misled.%0A%0A%60%60%60suggestion%0A%20*%20Live%20answers%20require%20ANTHROPIC_API_KEY%20in%20the%20environment%20%28Vercel%29.%20Without%20it%2C%0A%20*%20or%20on%20any%20upstream%20error%20%28no%20credits%2C%20rate%20limit%2C%20transient%20outage%29%2C%20the%20route%0A%20*%20degrades%20gracefully%20to%20the%20static%20FAQ%20list%20so%20the%20widget%20stays%20useful.%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(assistant): degrade to static FAQ on..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/d84d117bb2ea78d73e63ad3f83ee49c28156b2b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38731173)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->