### PR TITLE
feat(subscribe): quiz segmentation + tailored tools + PDF teaser

### DIFF
--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -10,6 +10,7 @@ import { QUIZ, QUIZ_TOTAL } from "@/lib/subscribe/quiz"
 import {
   BUILD_STEPS, PLANS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, checkoutUrl, planById, type Plan,
 } from "@/lib/subscribe/config"
+import { segment } from "@/lib/subscribe/segment"
 import { MoyasarPayment } from "./MoyasarPayment"
 import { useLanguage } from "@/components/language-provider"
 
@@ -155,6 +156,10 @@ export default function SubscribePage() {
   }, [selected, promo, sendLead])
 
   const progressPct = useMemo(() => Math.round((qIndex / QUIZ_TOTAL) * 100), [qIndex])
+
+  // Segment is computed from the visitor's own answers — the paywall now shows a
+  // tool set matched to their niche instead of the same generic list for everyone.
+  const userSegment = useMemo(() => segment(answers), [answers])
 
   return (
     <main className="relative min-h-screen bg-zinc-950 text-zinc-100 pb-24">
@@ -309,6 +314,50 @@ export default function SubscribePage() {
               <h2 className="text-xl font-bold leading-tight text-zinc-100 sm:text-2xl" dir={dir}>
                 {tr(PRODUCT.headlineAr, PRODUCT.headlineEn)}
               </h2>
+            </div>
+
+            {/* Personalized segment — matched from the visitor's OWN answers */}
+            <div className="rounded-xl border border-emerald-900/60 bg-zinc-900/40 p-4 backdrop-blur-sm">
+              <p className="text-center text-sm text-zinc-300" dir={dir}>
+                {tr("خزينتك مضبوطة على: ", "Your vault is tuned for: ")}
+                <span className="font-semibold text-emerald-400">{tr(userSegment.label.ar, userSegment.label.en)}</span>
+              </p>
+              <p className="mt-1 text-center text-xs text-zinc-500" dir={dir}>
+                {tr(userSegment.tagline.ar, userSegment.tagline.en)}
+              </p>
+
+              <div className="mt-3.5 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {userSegment.tools.slice(0, 4).map((tool) => (
+                  <div key={tool.name} className="rounded-lg border border-zinc-800 bg-zinc-950/40 px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <Check className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                      <span className="font-mono text-xs font-semibold text-zinc-200">{tool.name}</span>
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-zinc-500" dir={dir}>
+                      {tr(tool.blurb.ar, tool.blurb.en)}
+                    </p>
+                    <div className="mt-1.5 flex flex-wrap gap-1">
+                      {tool.platforms.map((p) => (
+                        <span
+                          key={p}
+                          className="rounded border border-zinc-700/60 bg-zinc-800/40 px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-wide text-zinc-400"
+                        >
+                          {p}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {userSegment.tools.length > 4 && (
+                <p className="mt-2.5 text-center font-mono text-[10px] text-emerald-600/80" dir={dir}>
+                  {tr(
+                    `+${userSegment.tools.length - 4} أدوات أخرى داخل الحقيبة`,
+                    `+${userSegment.tools.length - 4} more tools inside your vault`,
+                  )}
+                </p>
+              )}
             </div>
 
             {/* Promo + real countdown */}

--- a/deliverables/toolkit-vault/render-pdf-both.mjs
+++ b/deliverables/toolkit-vault/render-pdf-both.mjs
@@ -1,0 +1,44 @@
+import { chromium } from 'playwright';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = pathToFileURL(join(__dirname, 'toolkit-week-01.html')).href;
+
+const browser = await chromium.launch();
+
+// ---- FULL PDF (payers): no teaser class, nothing blurred ----
+{
+  const page = await browser.newPage();
+  await page.goto(src, { waitUntil: 'networkidle' });
+  await page.pdf({
+    path: join(__dirname, 'toolkit-vault-week-01.pdf'),
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '0', bottom: '0', left: '0', right: '0' },
+  });
+  await page.close();
+  console.log('full pdf done -> toolkit-vault-week-01.pdf');
+}
+
+// ---- TEASER PDF (non-payers): add body.teaser so paywall-hidden blurs ----
+{
+  const page = await browser.newPage();
+  await page.goto(src, { waitUntil: 'networkidle' });
+  await page.evaluate(() => document.body.classList.add('teaser'));
+  await page.pdf({
+    path: join(__dirname, 'toolkit-vault-week-01-teaser.pdf'),
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '0', bottom: '0', left: '0', right: '0' },
+  });
+  // Screenshot a tool page (BitNet) to confirm the blur visually.
+  await page.setViewportSize({ width: 794, height: 1123 });
+  const bitnet = page.locator('section.page').nth(2);
+  await bitnet.screenshot({ path: join(__dirname, 'teaser-bitnet.png') });
+  await page.close();
+  console.log('teaser pdf done -> toolkit-vault-week-01-teaser.pdf (+ teaser-bitnet.png)');
+}
+
+await browser.close();
+console.log('all done');

--- a/deliverables/toolkit-vault/toolkit-week-01.html
+++ b/deliverables/toolkit-vault/toolkit-week-01.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><style>
+  *{margin:0;padding:0;box-sizing:border-box}
+  @page{size:A4;margin:0}
+  :root{
+    --bg:#070b12;--panel:#0d1422;--line:#1b2740;--ink:#cdd8e6;--mut:#74879f;
+    --grn:#00ffa3;--red:#ff4d6a;--white:#eef4fb;
+  }
+  html{font-family:'Segoe UI',Arial,sans-serif}
+  .page{position:relative;width:794px;min-height:1123px;background:var(--bg);color:var(--ink);
+    padding:64px 60px;overflow:hidden;break-after:page}
+  .page:last-child{break-after:auto}
+  .grid{position:absolute;inset:0;background-image:linear-gradient(#0e1726 1px,transparent 1px),
+    linear-gradient(90deg,#0e1726 1px,transparent 1px);background-size:40px 40px;opacity:.45}
+  .glow{position:absolute;width:560px;height:560px;border-radius:50%;
+    background:radial-gradient(circle,rgba(0,255,163,.11),transparent 60%);top:-180px;right:-160px}
+  .z{position:relative;z-index:2}
+  .mono{font-family:Consolas,'Courier New',monospace}
+  /* running header */
+  .rh{display:flex;justify-content:space-between;font-family:Consolas,monospace;font-size:12px;
+    letter-spacing:2px;color:var(--mut);border-bottom:1px solid var(--line);padding-bottom:14px;margin-bottom:30px}
+  .rh .g{color:var(--grn)}
+  /* cover */
+  .cov{display:flex;flex-direction:column;justify-content:space-between;min-height:995px}
+  .kick{font-family:Consolas,monospace;color:var(--red);letter-spacing:8px;font-size:18px;margin-bottom:14px}
+  .cov h1{font-size:92px;line-height:.9;font-weight:800;letter-spacing:-3px;color:var(--white)}
+  .cov h1 .v{color:var(--grn);text-shadow:0 0 30px rgba(0,255,163,.4)}
+  .cov .sub{margin-top:22px;font-size:23px;color:#9fb2c9;max-width:600px}
+  .cov .meta{margin-top:30px;font-family:Consolas,monospace;font-size:15px;color:var(--mut);letter-spacing:1px}
+  .cov .picks{font-family:Consolas,monospace;font-size:15px;color:#6b7f99;line-height:2}
+  .cov .picks b{color:var(--grn);font-weight:400}
+  .lock{font-size:30px;color:var(--grn)}
+  .foot{display:flex;justify-content:space-between;align-items:flex-end;font-family:Consolas,monospace;
+    font-size:14px;color:var(--mut)}
+  .foot .s{color:var(--white)}
+  /* intro */
+  h2{font-size:34px;color:var(--white);font-weight:800;letter-spacing:-1px;margin-bottom:8px}
+  .lead{font-size:16px;color:#a9b8cc;line-height:1.65;margin-bottom:22px}
+  .how{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:22px 24px;margin-bottom:22px}
+  .how h3{font-size:13px;letter-spacing:2px;color:var(--grn);font-family:Consolas,monospace;margin-bottom:14px}
+  .how ol{margin-left:18px;font-size:14.5px;line-height:1.9;color:var(--ink)}
+  .ar{direction:rtl;text-align:right;font-size:15px;color:#9fb2c9;line-height:1.9;
+    border-right:2px solid var(--grn);padding-right:14px}
+  .toc{list-style:none}
+  .toc li{display:flex;align-items:baseline;gap:14px;padding:11px 0;border-bottom:1px solid var(--line);font-size:15px}
+  .toc .n{font-family:Consolas,monospace;color:var(--grn);font-size:15px}
+  .toc .t{color:var(--white);font-weight:600}
+  .toc .c{margin-left:auto;font-family:Consolas,monospace;font-size:12px;color:var(--mut)}
+  /* tool page */
+  .num{font-family:Consolas,monospace;font-size:64px;color:#16233a;font-weight:700;line-height:1;float:right}
+  .cat{font-family:Consolas,monospace;font-size:12px;letter-spacing:2px;color:var(--red);margin-bottom:6px}
+  .tname{font-size:42px;color:var(--white);font-weight:800;letter-spacing:-1px}
+  .stars{font-family:Consolas,monospace;font-size:13px;color:var(--mut);margin-top:8px}
+  .stars b{color:var(--grn);font-weight:400}
+  .hook{font-size:19px;color:var(--white);line-height:1.5;font-weight:600;margin:22px 0 14px}
+  .arh{direction:rtl;text-align:right;font-size:15.5px;color:#9fb2c9;line-height:1.85;
+    border-right:2px solid var(--grn);padding-right:14px;margin-bottom:22px}
+  .blk{margin-bottom:18px}
+  .blk h4{font-family:Consolas,monospace;font-size:12px;letter-spacing:2px;color:var(--grn);margin-bottom:8px}
+  .blk p{font-size:14.5px;line-height:1.7;color:var(--ink)}
+  .link{font-family:Consolas,monospace;font-size:14px;color:var(--grn);background:var(--panel);
+    border:1px solid var(--line);border-radius:7px;padding:12px 16px;margin-bottom:16px}
+  .link .a{color:var(--mut)}
+  .prompt{background:#0a1018;border:1px solid var(--line);border-left:3px solid var(--grn);border-radius:7px;padding:16px 18px}
+  .prompt .lbl{font-family:Consolas,monospace;font-size:11px;letter-spacing:2px;color:var(--mut);margin-bottom:10px}
+  .prompt .lbl b{color:var(--grn);font-weight:400}
+  .prompt .txt{font-family:Consolas,monospace;font-size:13px;line-height:1.65;color:#bceede}
+  /* outro */
+  .cta{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:24px;margin:20px 0}
+  .cta b{color:var(--grn)}
+  /* ===== PAYWALL TEASER (only active when body.teaser) ===== */
+  /* Without body.teaser nothing is blurred -> identical to the full payer version. */
+  body.teaser .paywall-hidden{filter:blur(7px);user-select:none;pointer-events:none}
+  .unlock{display:none}
+  body.teaser .unlock{display:flex;align-items:center;gap:8px;font-family:Consolas,monospace;
+    font-size:12.5px;letter-spacing:.5px;color:var(--red);background:rgba(255,77,106,.07);
+    border:1px solid rgba(255,77,106,.35);border-radius:7px;padding:9px 13px;margin:10px 0 4px}
+  body.teaser .unlock b{color:var(--grn);font-weight:400}
+  body.teaser .unlock .lk{font-size:14px}
+</style></head><body>
+
+<!-- ============ COVER ============ -->
+<section class="page"><div class="grid"></div><div class="glow"></div>
+  <div class="z cov">
+    <div>
+      <div class="rh"><span>// THE&nbsp;TOOLKIT&nbsp;VAULT</span><span class="g">ISSUE&nbsp;01</span></div>
+      <div class="kick">SECURITY &nbsp;+&nbsp; AI</div>
+      <h1>WEEK&nbsp;01<br><span class="v">VAULT</span></h1>
+      <div class="sub">Five underground security &amp; AI tools most people never find — with a ready-to-paste prompt for each.</div>
+      <div class="meta">JUNE 2026 &nbsp;·&nbsp; 5 PICKS &nbsp;·&nbsp; EN / AR</div>
+    </div>
+    <div>
+      <div class="picks"><b>&gt;</b> <span class="paywall-hidden">BitNet</span> &nbsp; <b>&gt;</b> <span class="paywall-hidden">context-mode</span> &nbsp; <b>&gt;</b> <span class="paywall-hidden">cmux</span> &nbsp; <b>&gt;</b> <span class="paywall-hidden">Scrapy</span> &nbsp; <b>&gt;</b> <span class="paywall-hidden">mcp-scan</span></div>
+      <div class="unlock"><span class="lk">&#128274;</span> Unlock the actual tools, links &amp; prompts &#8594; <b>goodnbad.info/subscribe</b></div>
+    </div>
+    <div class="foot"><span class="lock">&#9635;</span><span>curated by Hamzah Al-Ramli &nbsp;·&nbsp; <span class="s">goodnbad.info</span></span></div>
+  </div>
+</section>
+
+<!-- ============ INTRO / HOW TO USE ============ -->
+<section class="page"><div class="grid"></div>
+  <div class="z">
+    <div class="rh"><span>// HOW&nbsp;THIS&nbsp;WORKS</span><span class="g">ISSUE 01 · 02</span></div>
+    <h2>Welcome to the Vault.</h2>
+    <p class="lead">Every week you get one short PDF: a handful of genuinely useful security &amp; AI tools —
+      the under-surfaced ones, not the stuff already on every feed. Each pick comes with what it does,
+      why it matters for <i>you</i>, the real GitHub link, and a prompt you paste straight into your AI to actually use it.</p>
+
+    <div class="how">
+      <h3>&#9656; HOW TO USE EACH PICK</h3>
+      <ol>
+        <li>Read the hook — decide in 5 seconds if it's for you.</li>
+        <li>Open the GitHub link.</li>
+        <li>Copy the <b style="color:#00ffa3">&gt;_ DROP THIS INTO YOUR AI</b> prompt into Claude, ChatGPT, or Codex.</li>
+        <li>Let it walk you through setup &amp; first use. No guesswork.</li>
+      </ol>
+    </div>
+
+    <p class="ar">كل أسبوع ملف واحد مختصر: أدوات أمن وذكاء اصطناعي مفيدة فعلاً — السرية منها، مش اللي تشوفها بكل مكان.
+      كل أداة معها شرح، وليش تهمك أنت، ورابط GitHub الحقيقي، وبرومبت جاهز تنسخه في Claude أو ChatGPT أو Codex وتبدأ على طول.</p>
+
+    <h3 style="font-family:Consolas,monospace;font-size:13px;letter-spacing:2px;color:#74879f;margin:26px 0 10px">THIS WEEK</h3>
+    <ul class="toc">
+      <li><span class="n">01</span><span class="t paywall-hidden">BitNet</span><span class="c">LOCAL AI · NO GPU</span></li>
+      <li><span class="n">02</span><span class="t paywall-hidden">context-mode</span><span class="c">AI SESSION INFRA</span></li>
+      <li><span class="n">03</span><span class="t paywall-hidden">cmux</span><span class="c">MULTI-AGENT TERMINAL</span></li>
+      <li><span class="n">04</span><span class="t paywall-hidden">Scrapy</span><span class="c">AUTOMATION BACKBONE</span></li>
+      <li><span class="n">05</span><span class="t paywall-hidden">mcp-scan</span><span class="c">MCP SECURITY</span></li>
+    </ul>
+    <div class="unlock"><span class="lk">&#128274;</span> Tool names, GitHub links &amp; paste-ready prompts are unlocked for subscribers &#8594; <b>goodnbad.info/subscribe</b></div>
+  </div>
+</section>
+
+<!-- ============ 01 BitNet ============ -->
+<section class="page"><div class="grid"></div>
+  <div class="z">
+    <div class="rh"><span>// PICK&nbsp;01</span><span class="g">LOCAL AI · NO GPU</span></div>
+    <div class="num">01</div>
+    <div class="cat">PRIVACY / LOCAL AI · MICROSOFT</div>
+    <div class="tname paywall-hidden">BitNet</div>
+    <div class="stars">&#9733; <b>~22k</b> &nbsp;·&nbsp; Microsoft official &nbsp;·&nbsp; verdict <b>SHARE</b></div>
+
+    <p class="hook">Run real LLMs on any CPU — no GPU, no cloud. Microsoft's 1-bit models are light enough to run interactively on a plain laptop, and your AI never leaves your machine.</p>
+    <p class="arh">ذكاء اصطناعي بدون GPU — مايكروسوفت تطلق نماذج تشتغل على أي جهاز. شغّل نماذج لغوية محليًا على المعالج فقط، بدون كرت شاشة وبدون سحابة، وخصوصيتك محفوظة.</p>
+
+    <div class="blk"><h4>WHAT IT IS</h4><p>bitnet.cpp is Microsoft's official inference framework for 1-bit / 1.58-bit LLMs — weights stored as just -1, 0, or +1 instead of 16–32 bits. That extreme compression means a 2B model runs fast and snappy on plain x86 CPU (2–6× faster than standard llama.cpp), and even 100B-class models can run on a single CPU at reading speed.</p></div>
+    <div class="blk"><h4>WHY IT MATTERS FOR YOU</h4><p>No $2/hr cloud GPU, no VRAM panic — clone it and run a local chatbot today. Perfect for private experiments, offline tools, or anything where data can't leave the device. (The fast GPU path is CUDA-only, so on AMD you stay on the CPU path — which is the point here anyway.)</p></div>
+
+    <div class="link"><span class="a">repo &gt; </span><span class="paywall-hidden">github.com/microsoft/BitNet</span></div>
+    <div class="prompt">
+      <div class="lbl">&gt;_ <b>DROP THIS INTO YOUR AI</b></div>
+      <div class="txt paywall-hidden">Set up Microsoft BitNet (github.com/microsoft/BitNet) to run a 1-bit LLM on my CPU with no GPU. Give me the exact Windows steps: clone the repo, build bitnet.cpp, download the official 2B model from Hugging Face, and run an interactive chat. Flag any prerequisite I'm missing before I start.</div>
+    </div>
+    <div class="unlock"><span class="lk">&#128274;</span> The tool name, GitHub link &amp; paste-ready prompt are blurred &#8594; unlock at <b>goodnbad.info/subscribe</b></div>
+  </div>
+</section>
+
+<!-- ============ 02 context-mode ============ -->
+<section class="page"><div class="grid"></div>
+  <div class="z">
+    <div class="rh"><span>// PICK&nbsp;02</span><span class="g">AI SESSION INFRA</span></div>
+    <div class="num">02</div>
+    <div class="cat">AI TOOLS / CLAUDE CODE · MCP</div>
+    <div class="tname paywall-hidden">context-mode</div>
+    <div class="stars">&#9733; <b>~2.5k</b> &nbsp;·&nbsp; #1 on Hacker News &nbsp;·&nbsp; verdict <b>BOTH</b></div>
+
+    <p class="hook">Stop losing your AI coding session every 30 minutes. context-mode sandboxes tool output and survives context compaction — turning 30-minute sessions into 3-hour ones.</p>
+    <p class="arh">كل ٣٠ دقيقة تشتغل مع كلود والسياق يموت؟ context-mode يخليك تشتغل ٣ ساعات بدون ما تعيد من الأول — طبقة البنية التحتية اللي المحترفون يستخدمونها فعلاً.</p>
+
+    <div class="blk"><h4>WHAT IT IS</h4><p>An MCP server + plugin that stops raw tool output from flooding your context window — a 56 KB Playwright snapshot becomes 299 bytes. It also persists every edit, task, and decision to a local SQLite DB and rebuilds your working state automatically when a session compacts. Works with Claude Code, Cursor, Gemini CLI, Codex, Copilot, Zed.</p></div>
+    <div class="blk"><h4>WHY IT MATTERS FOR YOU</h4><p>If you run real multi-step AI sessions, you hit the context wall constantly. This is the fix — one install, hooks in automatically, no CLAUDE.md edits. Genuinely under-surfaced: ~2.5k stars despite #1 on HN and 240k+ users.</p></div>
+
+    <div class="link"><span class="a">repo &gt; </span><span class="paywall-hidden">github.com/mksglu/context-mode</span></div>
+    <div class="prompt">
+      <div class="lbl">&gt;_ <b>DROP THIS INTO YOUR AI</b></div>
+      <div class="txt paywall-hidden">Install context-mode (github.com/mksglu/context-mode) in my Claude Code setup so sessions stop dying at the context limit. Walk me through adding the plugin marketplace, enabling it, and confirming the PreToolUse/PreCompact hooks are active. Then show me how to read the savings with ctx_stats.</div>
+    </div>
+    <div class="unlock"><span class="lk">&#128274;</span> The tool name, GitHub link &amp; paste-ready prompt are blurred &#8594; unlock at <b>goodnbad.info/subscribe</b></div>
+  </div>
+</section>
+
+<!-- ============ 03 cmux ============ -->
+<section class="page"><div class="grid"></div>
+  <div class="z">
+    <div class="rh"><span>// PICK&nbsp;03</span><span class="g">MULTI-AGENT TERMINAL</span></div>
+    <div class="num">03</div>
+    <div class="cat">AI TOOLS / TERMINAL · macOS</div>
+    <div class="tname paywall-hidden">cmux</div>
+    <div class="stars">&#9733; <b>~20k</b> &nbsp;·&nbsp; native macOS · Ghostty &nbsp;·&nbsp; verdict <b>BOTH</b></div>
+
+    <p class="hook">Running 10 AI agents and babysitting every terminal? cmux gives each Claude / Codex / Gemini session a notification ring, so you know exactly which one needs you.</p>
+    <p class="arh">بدل ما تراقب ١٠ نوافذ ترمينال وتنتظر إشعارات Claude — cmux يحط حلقة إشعار لكل جلسة تعرف منها أيها يحتاجك. مبني من مهندسين يشغّلون agents فعلاً.</p>
+
+    <div class="blk"><h4>WHAT IT IS</h4><p>A native macOS terminal (Swift + libghostty) with vertical sidebar tabs that show each workspace's git branch, ports, and latest agent notification. A built-in scriptable browser pane lets Claude Code click, fill forms, and run JS without leaving the terminal. <code>cmux claude-teams</code> spawns teammate mode as native splits — no tmux.</p></div>
+    <div class="blk"><h4>WHY IT MATTERS FOR YOU</h4><p>The moment you run more than two agents in parallel, generic macOS notifications become useless — they're all identical. cmux solves exactly that. It reads your existing Ghostty config, so zero reconfiguration. (macOS only.)</p></div>
+
+    <div class="link"><span class="a">repo &gt; </span><span class="paywall-hidden">github.com/manaflow-ai/cmux</span></div>
+    <div class="prompt">
+      <div class="lbl">&gt;_ <b>DROP THIS INTO YOUR AI</b></div>
+      <div class="txt paywall-hidden">I run multiple Claude Code / Codex agents at once on macOS and lose track of which needs me. Set up cmux (github.com/manaflow-ai/cmux): install via Homebrew, wire the `cmux notify` ring into my agent hooks, and explain how `cmux claude-teams` works for parallel teammate sessions.</div>
+    </div>
+    <div class="unlock"><span class="lk">&#128274;</span> The tool name, GitHub link &amp; paste-ready prompt are blurred &#8594; unlock at <b>goodnbad.info/subscribe</b></div>
+  </div>
+</section>
+
+<!-- ============ 04 Scrapy ============ -->
+<section class="page"><div class="grid"></div>
+  <div class="z">
+    <div class="rh"><span>// PICK&nbsp;04</span><span class="g">AUTOMATION BACKBONE</span></div>
+    <div class="num">04</div>
+    <div class="cat">AUTOMATION / DATA · PYTHON</div>
+    <div class="tname paywall-hidden">Scrapy</div>
+    <div class="stars">&#9733; <b>~55k</b> &nbsp;·&nbsp; maintained by Zyte &nbsp;·&nbsp; verdict <b>BOTH</b></div>
+
+    <p class="hook">When a scraping script stops being enough, Scrapy is the production backbone — spiders, pipelines, throttling, and scheduling built in. The data layer behind serious AI datasets and market intel.</p>
+    <p class="arh">Scrapy مش مجرد أداة تسحب بيانات — هو الإطار اللي تبني فوقه أي مشروع automation جاد: من جمع leads، لمراقبة الأسعار، لبناء datasets لتدريب الـ AI. لو لسه تكتب requests يدوية، أنت خسران وقت كل يوم.</p>
+
+    <div class="blk"><h4>WHAT IT IS</h4><p>A battle-tested Python framework that extracts structured data from any site with a clean spider architecture — concurrency, middleware, item pipelines, and export to JSON/CSV/XML out of the box, from the CLI or as a library. Pair it with rotating proxies + a scheduler and it covers ~80% of data-collection jobs without paying for SaaS.</p></div>
+    <div class="blk"><h4>WHY IT MATTERS FOR YOU</h4><p>Any content aggregator, price monitor, lead-gen pipeline, or AI training set eventually outgrows one-off scripts. Positioned right — not "a scraper" but "the automation backbone" — this is foundational, high-leverage infrastructure.</p></div>
+
+    <div class="link"><span class="a">repo &gt; </span><span class="paywall-hidden">github.com/scrapy/scrapy</span></div>
+    <div class="prompt">
+      <div class="lbl">&gt;_ <b>DROP THIS INTO YOUR AI</b></div>
+      <div class="txt paywall-hidden">I'm outgrowing one-off `requests` scripts. Scaffold a production Scrapy project (github.com/scrapy/scrapy) for the site I'll name: a spider, an item pipeline that exports JSON, polite throttling + auto-throttle, and how to schedule recurring runs. Explain each piece as you build it.</div>
+    </div>
+    <div class="unlock"><span class="lk">&#128274;</span> The tool name, GitHub link &amp; paste-ready prompt are blurred &#8594; unlock at <b>goodnbad.info/subscribe</b></div>
+  </div>
+</section>
+
+<!-- ============ 05 mcp-scan ============ -->
+<section class="page"><div class="grid"></div>
+  <div class="z">
+    <div class="rh"><span>// PICK&nbsp;05</span><span class="g">MCP SECURITY</span></div>
+    <div class="num">05</div>
+    <div class="cat">SECURITY / MCP · INVARIANT → SNYK</div>
+    <div class="tname paywall-hidden">mcp-scan</div>
+    <div class="stars">&#9733; <b>~2.6k</b> &nbsp;·&nbsp; coined "Tool Poisoning" · acq. by Snyk &nbsp;·&nbsp; verdict <b>BOTH</b></div>
+
+    <p class="hook">That MCP server you just installed can read your SSH keys — and your agent will never tell you. mcp-scan catches "Tool Poisoning": hidden instructions inside tool descriptions the model silently obeys.</p>
+    <p class="arh">أي MCP server تركّبه على Claude أو Cursor ممكن يكون مفخّخ — يقرأ مفاتيحك بصمت والـ agent يرجّعلك إجابة عادية. mcp-scan يكشف هجمات Tool Poisoning قبل ما تثق بأي سيرفر، ومكتشفوه أثبتوا الهجوم على سيرفرات WhatsApp و GitHub نفسها.</p>
+
+    <div class="blk"><h4>WHAT IT IS</h4><p>A security scanner for the Model Context Protocol — the plumbing that lets agents call external tools. It auto-finds your MCP configs (Claude Desktop, Cursor, VS Code…), pulls each server's tool descriptions, and flags tool poisoning, tool shadowing, rug pulls, and cross-origin escalations. Invariant Labs named the attack class and was acquired by Snyk in 2025.</p></div>
+    <div class="blk"><h4>WHY IT MATTERS FOR YOU</h4><p>Every MCP server you add is an unvetted trust boundary. A 30-second scan over your config catches a poisoned tool before it ever reaches a session. The security bookend to picks 02 &amp; 03 — those run your agents; this keeps them from getting hijacked.</p></div>
+
+    <div class="link"><span class="a">repo &gt; </span><span class="paywall-hidden">github.com/invariantlabs-ai/mcp-scan</span></div>
+    <div class="prompt">
+      <div class="lbl">&gt;_ <b>DROP THIS INTO YOUR AI</b></div>
+      <div class="txt paywall-hidden">Audit my MCP servers for security before I trust them. Walk me through using mcp-scan (github.com/invariantlabs-ai/mcp-scan) to scan my Claude Desktop / Cursor config for tool poisoning and rug pulls — the exact command to run, what each finding type means, and what to do if it flags one of my servers.</div>
+    </div>
+    <div class="unlock"><span class="lk">&#128274;</span> The tool name, GitHub link &amp; paste-ready prompt are blurred &#8594; unlock at <b>goodnbad.info/subscribe</b></div>
+  </div>
+</section>
+
+<!-- ============ OUTRO ============ -->
+<section class="page"><div class="grid"></div><div class="glow"></div>
+  <div class="z">
+    <div class="rh"><span>// THAT'S&nbsp;WEEK&nbsp;01</span><span class="g">ISSUE 01 · END</span></div>
+    <h2>That's the Vault for this week.</h2>
+    <p class="lead">Five tools, five prompts. Try even one of them this week — that's the whole point. Real tools you actually run, not another feed to scroll.</p>
+
+    <div class="cta">
+      <p style="font-size:15px;line-height:1.7;color:#cdd8e6">
+        <b>Next week:</b> more under-surfaced security &amp; AI picks — local agents, OSINT tooling, and the automation layer most people miss.<br><br>
+        Found one of these useful? Forward this to one person who'd get it. That's how the Vault grows.</p>
+    </div>
+
+    <p class="ar">جرّب ولو أداة واحدة هالأسبوع — هذا كل الهدف. أدوات حقيقية تشغّلها فعلاً، مش محتوى تتصفحه بس.
+      عجبتك وحدة منها؟ ابعثها لشخص واحد يستفيد. هكذا تكبر الخزينة.</p>
+
+    <div class="foot" style="margin-top:60px">
+      <span class="lock">&#9635;</span>
+      <span>The Toolkit Vault &nbsp;·&nbsp; curated by Hamzah Al-Ramli &nbsp;·&nbsp; <span class="s">goodnbad.info</span></span>
+    </div>
+  </div>
+</section>
+
+</body></html>

--- a/lib/subscribe/quiz.ts
+++ b/lib/subscribe/quiz.ts
@@ -5,6 +5,9 @@
 //          → micro-commitments → name + email. The order matters: each easy tap
 //          is a small commitment that makes the next one (and the paywall) feel
 //          like a natural continuation rather than a cold ask.
+// Routing: `niche` is the PRIMARY segmentation signal, supported by `role`,
+//          `goal`, `level`, `apply`. See lib/subscribe/segment.ts — these answers
+//          now actually pick the tailored tool set shown on the paywall.
 // Author:  @Goodnbad.exe
 // === END METADATA ===
 
@@ -44,11 +47,11 @@ export const QUIZ: QuizQuestion[] = [
     ar: "وش يوصفك أكثر؟",
     en: "What best describes you?",
     options: [
-      { value: "student", ar: "طالب / متعلّم", en: "Student / learner" },
-      { value: "dev", ar: "مطوّر / مبرمج", en: "Developer" },
+      { value: "dev", ar: "مطوّر / مبرمج", en: "Developer / engineer" },
+      { value: "security", ar: "أمن سيبراني", en: "Security / hacker" },
       { value: "founder", ar: "صاحب مشروع / مستقل", en: "Founder / freelancer" },
       { value: "creator", ar: "صانع محتوى / تسويق", en: "Creator / marketer" },
-      { value: "other", ar: "غير ذلك", en: "Something else" },
+      { value: "student", ar: "طالب / متعلّم", en: "Student / still exploring" },
     ],
   },
   {
@@ -56,9 +59,9 @@ export const QUIZ: QuizQuestion[] = [
     type: "single",
     icon: "zap",
     ar: "كم تستخدم أدوات الذكاء الاصطناعي حالياً؟",
-    en: "How often do you use AI tools today?",
+    en: "How deep are you with AI tools today?",
     options: [
-      { value: "daily", ar: "كل يوم", en: "Every day" },
+      { value: "daily", ar: "كل يوم — جزء من شغلي", en: "Daily — part of my workflow" },
       { value: "weekly", ar: "كم مرة بالأسبوع", en: "A few times a week" },
       { value: "rarely", ar: "نادراً", en: "Rarely" },
       { value: "new", ar: "لسّا بادي", en: "Just getting started" },
@@ -71,8 +74,8 @@ export const QUIZ: QuizQuestion[] = [
     ar: "أكثر أداة تعتمد عليها؟",
     en: "Which AI tool do you lean on most?",
     options: [
-      { value: "chatgpt", ar: "ChatGPT", en: "ChatGPT" },
       { value: "claude", ar: "Claude", en: "Claude" },
+      { value: "chatgpt", ar: "ChatGPT", en: "ChatGPT" },
       { value: "code", ar: "Cursor / Codex / Copilot", en: "Cursor / Codex / Copilot" },
       { value: "mix", ar: "خليط منهم", en: "A mix of them" },
       { value: "none", ar: "ولا واحد لين الحين", en: "None yet" },
@@ -89,7 +92,7 @@ export const QUIZ: QuizQuestion[] = [
     options: [
       { value: "repeat", ar: "أعيد شرح نفسي للـ AI كل مرة", en: "Repeating myself to the AI every time" },
       { value: "messy", ar: "ملفاتي ومساحات عملي مبعثرة", en: "Messy, scattered workspaces" },
-      { value: "tools", ar: "ما أعرف وش أفضل الأدوات", en: "Don't know the best tools" },
+      { value: "tools", ar: "ما أعرف وش أفضل الأدوات لمجالي", en: "Don't know the best tools for my field" },
       { value: "slow", ar: "النتائج بطيئة", en: "Results come too slow" },
       { value: "lost", ar: "ما أعرف وش الممكن أصلاً", en: "Not sure what's even possible" },
     ],
@@ -120,19 +123,6 @@ export const QUIZ: QuizQuestion[] = [
       { value: "15+", ar: "أكثر من ١٥ ساعة", en: "15+ hours" },
     ],
   },
-  {
-    id: "missing_out",
-    type: "single",
-    icon: "eye",
-    ar: "تحس إن فيه أدوات يستخدمها غيرك وأنت فايتك؟",
-    en: "Feel others use tools that put you behind?",
-    options: [
-      { value: "yes", ar: "أكيد", en: "Definitely" },
-      { value: "probably", ar: "على الأغلب", en: "Probably" },
-      { value: "maybe", ar: "يمكن", en: "Maybe" },
-      { value: "no", ar: "لا", en: "Not really" },
-    ],
-  },
 
   // ── C · Desire / goals (paint the outcome) ─────────────────────────────────
   {
@@ -142,10 +132,10 @@ export const QUIZ: QuizQuestion[] = [
     ar: "وش تبي توصل له؟",
     en: "What are you trying to achieve?",
     options: [
-      { value: "income", ar: "دخل إضافي", en: "Extra income" },
       { value: "ship", ar: "أنجز مشاريعي أسرع", en: "Ship projects faster" },
       { value: "master", ar: "أتقن workflow الـ AI", en: "Master AI workflows" },
       { value: "automate", ar: "أتمتة شغلي", en: "Automate my work" },
+      { value: "income", ar: "دخل إضافي", en: "Extra income" },
       { value: "career", ar: "وظيفة / فرصة أفضل", en: "A better role" },
     ],
   },
@@ -160,20 +150,6 @@ export const QUIZ: QuizQuestion[] = [
       { value: "3-5k", ar: "٣-٥ آلاف شهرياً", en: "3–5k SAR/mo" },
       { value: "6-10k", ar: "٦-١٠ آلاف شهرياً", en: "6–10k SAR/mo" },
       { value: "10k+", ar: "+١٠ آلاف / أستقل بشغلي", en: "10k+ / replace my job" },
-    ],
-  },
-  {
-    id: "outcome",
-    type: "single",
-    icon: "sparkles",
-    ar: "لو صار شغلك نخبوي، وش أول شي يتغيّر؟",
-    en: "If your workflow went elite, what changes first?",
-    options: [
-      { value: "money", ar: "فلوس أكثر", en: "More money" },
-      { value: "time", ar: "وقت فراغ أكثر", en: "More free time" },
-      { value: "output", ar: "إنتاجية أعلى", en: "More output" },
-      { value: "stress", ar: "توتر أقل", en: "Less stress" },
-      { value: "standout", ar: "أتميّز عن الكل", en: "I stand out" },
     ],
   },
   {
@@ -192,29 +168,30 @@ export const QUIZ: QuizQuestion[] = [
 
   // ── D · Qualify / personalize (so the plan feels tailored) ─────────────────
   {
+    id: "niche",
+    type: "single",
+    icon: "compass",
+    ar: "مجالك الأساسي؟ (اللي راح نبني حقيبتك حوله)",
+    en: "Your main focus area?",
+    subEn: "This is what we tune your toolkit around.",
+    options: [
+      { value: "dev", ar: "البرمجة / التطوير", en: "Dev / coding" },
+      { value: "security", ar: "الأمن السيبراني", en: "Cybersecurity" },
+      { value: "automation", ar: "الأتمتة وسير العمل", en: "Automation / workflows" },
+      { value: "content", ar: "المحتوى / التسويق", en: "Content / marketing" },
+      { value: "business", ar: "ريادة / أعمال", en: "Business / startup" },
+    ],
+  },
+  {
     id: "level",
     type: "single",
     icon: "gauge",
-    ar: "مستواك مع هالأدوات؟",
-    en: "Your level with these tools?",
+    ar: "مستواك في مجالك؟",
+    en: "Your level in that field?",
     options: [
       { value: "beginner", ar: "مبتدئ", en: "Beginner" },
       { value: "intermediate", ar: "متوسط", en: "Intermediate" },
       { value: "advanced", ar: "متقدّم", en: "Advanced" },
-    ],
-  },
-  {
-    id: "niche",
-    type: "single",
-    icon: "compass",
-    ar: "مجالك الأساسي؟",
-    en: "Your main focus area?",
-    options: [
-      { value: "security", ar: "الأمن السيبراني", en: "Cybersecurity" },
-      { value: "dev", ar: "البرمجة / التطوير", en: "Dev / coding" },
-      { value: "automation", ar: "الأتمتة", en: "Automation" },
-      { value: "content", ar: "المحتوى / التسويق", en: "Content / marketing" },
-      { value: "business", ar: "ريادة / أعمال", en: "Business / startup" },
     ],
   },
   {
@@ -257,18 +234,6 @@ export const QUIZ: QuizQuestion[] = [
       { value: "30m", ar: "٣٠ دقيقة", en: "30 minutes" },
       { value: "1h", ar: "ساعة", en: "1 hour" },
       { value: "2h+", ar: "ساعتين أو أكثر", en: "2+ hours" },
-    ],
-  },
-  {
-    id: "tried_before",
-    type: "single",
-    icon: "history",
-    ar: "حاولت من قبل تحسّن إعدادك مع الـ AI؟",
-    en: "Tried to upgrade your AI setup before?",
-    options: [
-      { value: "stuck", ar: "إي، بس ما استمريت", en: "Yes — it didn't stick" },
-      { value: "some", ar: "إي، وطلعت بنتائج", en: "Yes — got some wins" },
-      { value: "first", ar: "لا، أول مرة", en: "No — first time" },
     ],
   },
   {

--- a/lib/subscribe/segment.ts
+++ b/lib/subscribe/segment.ts
@@ -1,0 +1,329 @@
+// === METADATA ===
+// Purpose: Turn the quiz answers into ONE tailored segment + tool set, so the
+//          paywall stops being one-size-fits-all. `niche` is the primary signal;
+//          `role`, `goal`, `level`, `apply` nudge the score. Pure + deterministic
+//          — no side effects, no I/O — so it's trivially testable and safe to run
+//          on every render.
+//
+// Hard rule: tool sets NEVER cross domains. A developer is shown dev/AI tooling,
+//            a security person is shown security tooling — full stop. The scoring
+//            is biased so that whoever's niche says "security" lands on the
+//            security set even if a supporting answer leans elsewhere.
+//
+// Platforms: every tool carries a `platforms` tag. We prefer genuinely
+//            cross-platform tools (Windows + Linux + macOS). A few legitimately
+//            mac-only tools (e.g. cmux) are tagged macOS-only so the UI can show
+//            an honest platform badge instead of implying universal support.
+// === END METADATA ===
+
+export type Bilingual = { ar: string; en: string }
+
+export type Platform = "Windows" | "Linux" | "macOS"
+
+export type SegmentTool = {
+  name: string
+  blurb: Bilingual
+  platforms: Platform[]
+}
+
+export type SegmentId =
+  | "developer"
+  | "security"
+  | "ai-builder"
+  | "founder-automation"
+  | "creator"
+
+export type SegmentDef = {
+  id: SegmentId
+  label: Bilingual
+  /** one-line "your vault is tuned for…" tagline */
+  tagline: Bilingual
+  tools: SegmentTool[]
+}
+
+export type SegmentResult = SegmentDef & {
+  /** confidence-ish score that won the match (debug / analytics only) */
+  score: number
+}
+
+const ALL: Platform[] = ["Windows", "Linux", "macOS"]
+
+// ── Tool sets ────────────────────────────────────────────────────────────────
+// Each set is self-contained to its domain. Cross-platform first; mac-only flagged.
+
+const DEVELOPER_TOOLS: SegmentTool[] = [
+  {
+    name: "Cursor",
+    blurb: { ar: "محرّر أكواد مبني على الـ AI لإنجاز أسرع", en: "AI-native code editor for shipping faster" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Claude Code",
+    blurb: { ar: "وكيل برمجي بالـ terminal يكتب ويصلح كودك", en: "Terminal coding agent that writes and fixes your code" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Aider",
+    blurb: { ar: "زوج برمجة بالـ AI داخل git مباشرة", en: "AI pair-programmer wired straight into git" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Zed",
+    blurb: { ar: "محرّر فائق السرعة بتعاون AI مدمج", en: "Blazing-fast editor with built-in AI collab" },
+    platforms: ["Linux", "macOS"],
+  },
+  {
+    name: "cmux",
+    blurb: { ar: "مدير جلسات terminal موجّه للوكلاء (macOS فقط)", en: "Agent-oriented terminal multiplexer (macOS only)" },
+    platforms: ["macOS"],
+  },
+  {
+    name: "Repomix",
+    blurb: { ar: "يحزم الريبو كامل في prompt واحد للـ AI", en: "Packs a whole repo into one AI-ready prompt" },
+    platforms: [...ALL],
+  },
+]
+
+const SECURITY_TOOLS: SegmentTool[] = [
+  {
+    name: "Nuclei",
+    blurb: { ar: "ماسح ثغرات سريع بقوالب مجتمعية", en: "Fast template-driven vulnerability scanner" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Caido",
+    blurb: { ar: "بروكسي اعتراض حديث لاختبار الويب", en: "Modern intercept proxy for web app testing" },
+    platforms: [...ALL],
+  },
+  {
+    name: "PentestGPT",
+    blurb: { ar: "مساعد AI يوجّه اختبار الاختراق خطوة بخطوة", en: "AI assistant that guides pentests step by step" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Subfinder",
+    blurb: { ar: "اكتشاف النطاقات الفرعية للاستطلاع", en: "Subdomain discovery for recon" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Trivy",
+    blurb: { ar: "فحص ثغرات الحاويات والكود والإعدادات", en: "Scans containers, code & configs for vulns" },
+    platforms: [...ALL],
+  },
+]
+
+const AI_BUILDER_TOOLS: SegmentTool[] = [
+  {
+    name: "LangGraph",
+    blurb: { ar: "بناء وكلاء AI بحالة وتفرّعات معقّدة", en: "Build stateful, branching AI agents" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Ollama",
+    blurb: { ar: "تشغيل نماذج LLM محلياً على جهازك", en: "Run open LLMs locally on your machine" },
+    platforms: [...ALL],
+  },
+  {
+    name: "LiteLLM",
+    blurb: { ar: "بوابة موحّدة لكل مزوّدي النماذج", en: "One gateway across every model provider" },
+    platforms: [...ALL],
+  },
+  {
+    name: "LlamaIndex",
+    blurb: { ar: "ربط بياناتك بالنماذج عبر RAG", en: "Wire your data into models with RAG" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Langfuse",
+    blurb: { ar: "تتبّع وتقييم استدعاءات الـ LLM", en: "Trace and evaluate your LLM calls" },
+    platforms: [...ALL],
+  },
+]
+
+const FOUNDER_AUTOMATION_TOOLS: SegmentTool[] = [
+  {
+    name: "n8n",
+    blurb: { ar: "أتمتة سير العمل مفتوحة المصدر تستضيفها بنفسك", en: "Self-hostable open-source workflow automation" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Activepieces",
+    blurb: { ar: "أتمتة بالـ AI بديلة لـ Zapier", en: "AI-first, open Zapier alternative" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Windmill",
+    blurb: { ar: "تحويل السكربتات إلى سير عمل وداخليات", en: "Turn scripts into workflows & internal tools" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Browser Use",
+    blurb: { ar: "وكلاء يتصفّحون وينفّذون المهام نيابةً عنك", en: "Agents that browse and do tasks for you" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Trigger.dev",
+    blurb: { ar: "مهام خلفية طويلة موثوقة لمنتجك", en: "Reliable long-running background jobs" },
+    platforms: [...ALL],
+  },
+]
+
+const CREATOR_TOOLS: SegmentTool[] = [
+  {
+    name: "ComfyUI",
+    blurb: { ar: "خطوط إنتاج صور AI بالعقد والتحكّم الكامل", en: "Node-based AI image pipelines, full control" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Whisper",
+    blurb: { ar: "تفريغ صوتي دقيق محلي للمحتوى", en: "Accurate local transcription for content" },
+    platforms: [...ALL],
+  },
+  {
+    name: "Descript",
+    blurb: { ar: "تحرير فيديو وبودكاست بالنص", en: "Edit video & podcasts by editing text" },
+    platforms: ["Windows", "macOS"],
+  },
+  {
+    name: "CapCut",
+    blurb: { ar: "تحرير مقاطع قصيرة سريع بميزات AI", en: "Fast short-form editing with AI features" },
+    platforms: ["Windows", "macOS"],
+  },
+  {
+    name: "Kling / Runway",
+    blurb: { ar: "توليد فيديو بالـ AI للريلز والإعلانات", en: "AI video generation for reels & ads" },
+    platforms: [...ALL],
+  },
+]
+
+// ── Segment definitions ──────────────────────────────────────────────────────
+
+export const SEGMENTS: Record<SegmentId, SegmentDef> = {
+  developer: {
+    id: "developer",
+    label: { ar: "المطوّرين", en: "Developers" },
+    tagline: {
+      ar: "أدوات وأكواد ووكلاء برمجة تنقلك من فكرة إلى شحن أسرع.",
+      en: "Coding tools, repos & agents that take you from idea to shipped, faster.",
+    },
+    tools: DEVELOPER_TOOLS,
+  },
+  security: {
+    id: "security",
+    label: { ar: "الأمن السيبراني", en: "Security & Hacking" },
+    tagline: {
+      ar: "ترسانة استطلاع وفحص واختبار اختراق مبنية حول الـ AI.",
+      en: "A recon, scanning & pentest arsenal built around AI.",
+    },
+    tools: SECURITY_TOOLS,
+  },
+  "ai-builder": {
+    id: "ai-builder",
+    label: { ar: "بُناة الذكاء الاصطناعي", en: "AI Builders" },
+    tagline: {
+      ar: "أطر بناء الوكلاء و RAG وتشغيل النماذج محلياً.",
+      en: "Frameworks for agents, RAG, and running models locally.",
+    },
+    tools: AI_BUILDER_TOOLS,
+  },
+  "founder-automation": {
+    id: "founder-automation",
+    label: { ar: "المؤسّسين والأتمتة", en: "Founders & Automation" },
+    tagline: {
+      ar: "أتمتة سير العمل والمهام لتشغّل عملك على الطيّار الآلي.",
+      en: "Workflow & task automation to run your business on autopilot.",
+    },
+    tools: FOUNDER_AUTOMATION_TOOLS,
+  },
+  creator: {
+    id: "creator",
+    label: { ar: "صنّاع المحتوى", en: "Creators" },
+    tagline: {
+      ar: "أدوات صوت وصورة وفيديو بالـ AI تضاعف إنتاجك.",
+      en: "AI audio, image & video tools that multiply your output.",
+    },
+    tools: CREATOR_TOOLS,
+  },
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────────────
+// `niche` is dominant (weight 5) so domains never bleed. Supporting answers add
+// small nudges to break ties between adjacent segments (e.g. dev vs ai-builder).
+
+const NICHE_TO_SEGMENT: Record<string, SegmentId> = {
+  dev: "developer",
+  security: "security",
+  automation: "founder-automation",
+  content: "creator",
+  business: "founder-automation",
+}
+
+const ROLE_TO_SEGMENT: Record<string, SegmentId> = {
+  dev: "developer",
+  security: "security",
+  founder: "founder-automation",
+  creator: "creator",
+  // `student` is intentionally unmapped — too ambiguous to add weight.
+}
+
+const GOAL_TO_SEGMENT: Record<string, SegmentId> = {
+  ship: "developer",
+  master: "ai-builder",
+  automate: "founder-automation",
+  // `income` / `career` are segment-neutral.
+}
+
+const APPLY_TO_SEGMENT: Partial<Record<string, SegmentId>> = {
+  side: "founder-automation",
+}
+
+const NICHE_WEIGHT = 5
+const ROLE_WEIGHT = 2
+const GOAL_WEIGHT = 2
+const APPLY_WEIGHT = 1
+// Advanced + "master AI workflows" tips a developer toward the AI-builder set.
+const LEVEL_AI_BUILDER_WEIGHT = 2
+
+const FALLBACK: SegmentId = "developer"
+
+function bump(scores: Record<SegmentId, number>, seg: SegmentId | undefined, by: number) {
+  if (seg) scores[seg] += by
+}
+
+/**
+ * Pure, deterministic segmentation. Returns the single best-matched segment with
+ * its tailored tool set. Unknown/empty answers degrade gracefully to a sensible
+ * default rather than throwing.
+ */
+export function segment(answers: Record<string, string>): SegmentResult {
+  const scores: Record<SegmentId, number> = {
+    developer: 0,
+    security: 0,
+    "ai-builder": 0,
+    "founder-automation": 0,
+    creator: 0,
+  }
+
+  bump(scores, NICHE_TO_SEGMENT[answers.niche], NICHE_WEIGHT)
+  bump(scores, ROLE_TO_SEGMENT[answers.role], ROLE_WEIGHT)
+  bump(scores, GOAL_TO_SEGMENT[answers.goal], GOAL_WEIGHT)
+  bump(scores, APPLY_TO_SEGMENT[answers.apply], APPLY_WEIGHT)
+
+  // Nudge experienced AI tinkerers (advanced + master goal) into ai-builder,
+  // but only as a supporting signal — niche still dominates.
+  if (answers.level === "advanced" && answers.goal === "master") {
+    bump(scores, "ai-builder", LEVEL_AI_BUILDER_WEIGHT)
+  }
+
+  let winner: SegmentId = FALLBACK
+  let best = -1
+  // Stable tie-break by following the declared key order.
+  for (const id of Object.keys(scores) as SegmentId[]) {
+    if (scores[id] > best) {
+      best = scores[id]
+      winner = id
+    }
+  }
+
+  return { ...SEGMENTS[winner], score: best }
+}


### PR DESCRIPTION
Quiz tightened to 18 questions; new segment() engine routes each visitor to a domain-isolated tailored tool set (dev never gets security tools); cross-platform tags + mac-only flags; personalized paywall panel. Plus a body.teaser paywall mode in the toolkit PDF source + a both-renders script (free teaser blurs tools/links/prompts). tsc + next build clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces quiz-driven visitor segmentation: a new `segment()` engine maps quiz answers to one of five tailored tool sets displayed on the paywall, the quiz is trimmed from 21 to 18 questions, and a new Playwright script renders both the full and blurred-teaser PDFs from a single HTML source.

- **`lib/subscribe/segment.ts`**: New pure, deterministic segmentation function — scores five segments from quiz answers using weighted signals (`niche` dominant at weight 5) and returns the winning segment's tool set for display on the paywall.
- **`app/subscribe/page.tsx`**: Adds a `useMemo`-wrapped `segment(answers)` call and renders the personalised tool panel (label, tagline, up to 4 tools with platform badges, overflow count) in the plan phase.
- **`deliverables/toolkit-vault/`**: New HTML source for the Week 01 toolkit PDF with a CSS `body.teaser` paywall mode, plus a Playwright script that renders both the full and teaser variants in one pass.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The page renders correctly and the quiz changes are safe, but the central new feature — personalised segmentation — silently routes all users away from the AI Builder tool set, which is never shown.

The ai-builder segment has a complete tool set (LangGraph, Ollama, LiteLLM, LlamaIndex, Langfuse) and is the intended destination for users who pick 'Master AI workflows' as their goal at an advanced level. However, no niche quiz option maps to it, and the niche weight (5) permanently outscores the maximum ai-builder accumulation (4). Every visitor who completes the quiz will be routed to one of the four other segments regardless of how strong their AI-builder profile is. The rest of the PR — quiz trimming, PDF rendering, HTML teaser — is clean.

lib/subscribe/segment.ts — specifically the NICHE_TO_SEGMENT mapping and weight constants that together make ai-builder unreachable.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/subscribe/segment.ts | New pure segmentation engine — well-structured and testable — but the ai-builder segment is permanently unreachable: no niche option maps to it, and the niche weight (5) always exceeds the maximum ai-builder score (4), so the full AI-builder tool set is never surfaced to any visitor. |
| app/subscribe/page.tsx | Adds a useMemo-wrapped segment(answers) call and renders the personalised tool panel on the paywall. Integration with segment.ts is correct; answer keys (niche, role, goal, level, apply) match quiz IDs. |
| lib/subscribe/quiz.ts | Three questions removed (missing_out, outcome, tried_before), reducing the quiz from 21 to 18; niche moved before level with a subEn hint; option labels and ordering updated. All segmentation-relevant question IDs remain present and unchanged. |
| deliverables/toolkit-vault/render-pdf-both.mjs | New Playwright script that renders the HTML source twice — once clean (full payer PDF) and once with body.teaser injected (blurred free preview). Logic is correct; minor fragility in using a hardcoded .nth(2) index for the BitNet screenshot. |
| deliverables/toolkit-vault/toolkit-week-01.html | New self-contained HTML source for the Week 01 PDF with a CSS teaser mode (body.teaser) that blurs .paywall-hidden elements. Structure and teaser mechanism are clean. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User starts quiz] --> B[Answers 18 questions\nniche · role · goal · level · apply · ...]
    B --> C[segment answers]
    C --> D{Score each segment\nNICHE_WEIGHT=5\nROLE_WEIGHT=2\nGOAL_WEIGHT=2}
    D --> E[developer]
    D --> F[security]
    D --> G[ai-builder\n⚠️ unreachable\nno niche maps here]
    D --> H[founder-automation]
    D --> I[creator]
    E & F & G & H & I --> J[Winner = highest score\nfallback = developer]
    J --> K[Plan phase: show\npersonalised tool panel\nlabel · tagline · tools 0–3]
    K --> L[User selects plan\n& goes to checkout]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User starts quiz] --> B[Answers 18 questions\nniche · role · goal · level · apply · ...]
    B --> C[segment answers]
    C --> D{Score each segment\nNICHE_WEIGHT=5\nROLE_WEIGHT=2\nGOAL_WEIGHT=2}
    D --> E[developer]
    D --> F[security]
    D --> G[ai-builder\n⚠️ unreachable\nno niche maps here]
    D --> H[founder-automation]
    D --> I[creator]
    E & F & G & H & I --> J[Winner = highest score\nfallback = developer]
    J --> K[Plan phase: show\npersonalised tool panel\nlabel · tagline · tools 0–3]
    K --> L[User selects plan\n& goes to checkout]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/subscribe/segment.ts`, line 847-881 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/9d111dac89edcde86a6da7d6d4b15df250549716/lib/subscribe/segment.ts#L847-L881)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`ai-builder` segment is permanently unreachable**

   No quiz `niche` option maps to `"ai-builder"` — every option routes to another segment — and `NICHE_WEIGHT` (5) always exceeds the maximum score `ai-builder` can accumulate from supporting signals: `GOAL_WEIGHT` ("master") + `LEVEL_AI_BUILDER_WEIGHT` ("advanced" + "master") = 2 + 2 = **4**. Since the `niche` question is a mandatory single-choice step (auto-advances on click, no skip path), every user session will always deliver +5 to some non-`ai-builder` segment, making that segment's score permanently lower. A user who is an AI infrastructure builder but naturally selects `niche="dev"` will be routed to "Developers" and see Cursor/Aider instead of LangGraph/LiteLLM/Langfuse — the segment you defined specifically for them.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsubscribe%2Fsegment.ts%0ALine%3A%20847-881%0A%0AComment%3A%0A**%60ai-builder%60%20segment%20is%20permanently%20unreachable**%0A%0ANo%20quiz%20%60niche%60%20option%20maps%20to%20%60%22ai-builder%22%60%20%E2%80%94%20every%20option%20routes%20to%20another%20segment%20%E2%80%94%20and%20%60NICHE_WEIGHT%60%20%285%29%20always%20exceeds%20the%20maximum%20score%20%60ai-builder%60%20can%20accumulate%20from%20supporting%20signals%3A%20%60GOAL_WEIGHT%60%20%28%22master%22%29%20%2B%20%60LEVEL_AI_BUILDER_WEIGHT%60%20%28%22advanced%22%20%2B%20%22master%22%29%20%3D%202%20%2B%202%20%3D%20**4**.%20Since%20the%20%60niche%60%20question%20is%20a%20mandatory%20single-choice%20step%20%28auto-advances%20on%20click%2C%20no%20skip%20path%29%2C%20every%20user%20session%20will%20always%20deliver%20%2B5%20to%20some%20non-%60ai-builder%60%20segment%2C%20making%20that%20segment's%20score%20permanently%20lower.%20A%20user%20who%20is%20an%20AI%20infrastructure%20builder%20but%20naturally%20selects%20%60niche%3D%22dev%22%60%20will%20be%20routed%20to%20%22Developers%22%20and%20see%20Cursor%2FAider%20instead%20of%20LangGraph%2FLiteLLM%2FLangfuse%20%E2%80%94%20the%20segment%20you%20defined%20specifically%20for%20them.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fquiz-segmentation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fquiz-segmentation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsubscribe%2Fsegment.ts%0ALine%3A%20847-881%0A%0AComment%3A%0A**%60ai-builder%60%20segment%20is%20permanently%20unreachable**%0A%0ANo%20quiz%20%60niche%60%20option%20maps%20to%20%60%22ai-builder%22%60%20%E2%80%94%20every%20option%20routes%20to%20another%20segment%20%E2%80%94%20and%20%60NICHE_WEIGHT%60%20%285%29%20always%20exceeds%20the%20maximum%20score%20%60ai-builder%60%20can%20accumulate%20from%20supporting%20signals%3A%20%60GOAL_WEIGHT%60%20%28%22master%22%29%20%2B%20%60LEVEL_AI_BUILDER_WEIGHT%60%20%28%22advanced%22%20%2B%20%22master%22%29%20%3D%202%20%2B%202%20%3D%20**4**.%20Since%20the%20%60niche%60%20question%20is%20a%20mandatory%20single-choice%20step%20%28auto-advances%20on%20click%2C%20no%20skip%20path%29%2C%20every%20user%20session%20will%20always%20deliver%20%2B5%20to%20some%20non-%60ai-builder%60%20segment%2C%20making%20that%20segment's%20score%20permanently%20lower.%20A%20user%20who%20is%20an%20AI%20infrastructure%20builder%20but%20naturally%20selects%20%60niche%3D%22dev%22%60%20will%20be%20routed%20to%20%22Developers%22%20and%20see%20Cursor%2FAider%20instead%20of%20LangGraph%2FLiteLLM%2FLangfuse%20%E2%80%94%20the%20segment%20you%20defined%20specifically%20for%20them.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fsubscribe%2Fsegment.ts%3A847-881%0A**%60ai-builder%60%20segment%20is%20permanently%20unreachable**%0A%0ANo%20quiz%20%60niche%60%20option%20maps%20to%20%60%22ai-builder%22%60%20%E2%80%94%20every%20option%20routes%20to%20another%20segment%20%E2%80%94%20and%20%60NICHE_WEIGHT%60%20%285%29%20always%20exceeds%20the%20maximum%20score%20%60ai-builder%60%20can%20accumulate%20from%20supporting%20signals%3A%20%60GOAL_WEIGHT%60%20%28%22master%22%29%20%2B%20%60LEVEL_AI_BUILDER_WEIGHT%60%20%28%22advanced%22%20%2B%20%22master%22%29%20%3D%202%20%2B%202%20%3D%20**4**.%20Since%20the%20%60niche%60%20question%20is%20a%20mandatory%20single-choice%20step%20%28auto-advances%20on%20click%2C%20no%20skip%20path%29%2C%20every%20user%20session%20will%20always%20deliver%20%2B5%20to%20some%20non-%60ai-builder%60%20segment%2C%20making%20that%20segment's%20score%20permanently%20lower.%20A%20user%20who%20is%20an%20AI%20infrastructure%20builder%20but%20naturally%20selects%20%60niche%3D%22dev%22%60%20will%20be%20routed%20to%20%22Developers%22%20and%20see%20Cursor%2FAider%20instead%20of%20LangGraph%2FLiteLLM%2FLangfuse%20%E2%80%94%20the%20segment%20you%20defined%20specifically%20for%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Adeliverables%2Ftoolkit-vault%2Frender-pdf-both.mjs%3A37%0AThe%20screenshot%20targets%20%60section.page%60%20by%20zero-based%20index%20%282%20%3D%20third%20page%29%20and%20names%20it%20%22BitNet%22%2C%20but%20if%20pages%20are%20ever%20reordered%20or%20a%20new%20page%20is%20inserted%20before%20pick%2001%2C%20the%20screenshot%20silently%20captures%20the%20wrong%20section%20with%20no%20error.%20A%20label-based%20selector%20is%20more%20resilient.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Use%20a%20content-based%20selector%20so%20page%20reordering%20never%20silently%20captures%20the%20wrong%20section.%0A%20%20const%20bitnet%20%3D%20page.locator%28'section.page%3Ahas%28.tname%29'%2C%20%7B%20hasText%3A%20'BitNet'%20%7D%29.first%28%29%3B%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fquiz-segmentation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fquiz-segmentation%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fsubscribe%2Fsegment.ts%3A847-881%0A**%60ai-builder%60%20segment%20is%20permanently%20unreachable**%0A%0ANo%20quiz%20%60niche%60%20option%20maps%20to%20%60%22ai-builder%22%60%20%E2%80%94%20every%20option%20routes%20to%20another%20segment%20%E2%80%94%20and%20%60NICHE_WEIGHT%60%20%285%29%20always%20exceeds%20the%20maximum%20score%20%60ai-builder%60%20can%20accumulate%20from%20supporting%20signals%3A%20%60GOAL_WEIGHT%60%20%28%22master%22%29%20%2B%20%60LEVEL_AI_BUILDER_WEIGHT%60%20%28%22advanced%22%20%2B%20%22master%22%29%20%3D%202%20%2B%202%20%3D%20**4**.%20Since%20the%20%60niche%60%20question%20is%20a%20mandatory%20single-choice%20step%20%28auto-advances%20on%20click%2C%20no%20skip%20path%29%2C%20every%20user%20session%20will%20always%20deliver%20%2B5%20to%20some%20non-%60ai-builder%60%20segment%2C%20making%20that%20segment's%20score%20permanently%20lower.%20A%20user%20who%20is%20an%20AI%20infrastructure%20builder%20but%20naturally%20selects%20%60niche%3D%22dev%22%60%20will%20be%20routed%20to%20%22Developers%22%20and%20see%20Cursor%2FAider%20instead%20of%20LangGraph%2FLiteLLM%2FLangfuse%20%E2%80%94%20the%20segment%20you%20defined%20specifically%20for%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Adeliverables%2Ftoolkit-vault%2Frender-pdf-both.mjs%3A37%0AThe%20screenshot%20targets%20%60section.page%60%20by%20zero-based%20index%20%282%20%3D%20third%20page%29%20and%20names%20it%20%22BitNet%22%2C%20but%20if%20pages%20are%20ever%20reordered%20or%20a%20new%20page%20is%20inserted%20before%20pick%2001%2C%20the%20screenshot%20silently%20captures%20the%20wrong%20section%20with%20no%20error.%20A%20label-based%20selector%20is%20more%20resilient.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Use%20a%20content-based%20selector%20so%20page%20reordering%20never%20silently%20captures%20the%20wrong%20section.%0A%20%20const%20bitnet%20%3D%20page.locator%28'section.page%3Ahas%28.tname%29'%2C%20%7B%20hasText%3A%20'BitNet'%20%7D%29.first%28%29%3B%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(subscribe): quiz segmentation engin..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/9d111dac89edcde86a6da7d6d4b15df250549716) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38733710)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->