### PR TITLE
feat(gumroad): Ping webhook → Supabase sales

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,19 @@ NEXT_PUBLIC_CHECKOUT_QUARTER=
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 
-# OR email the lead via SMTP (uses nodemailer):
+# Transactional email via Resend (recommended — powers the funnel lead
+# confirmation + the post-purchase welcome email). Create a key at resend.com and
+# verify the goodnbad.info domain (SPF/DKIM), then:
+RESEND_API_KEY=
+EMAIL_FROM="The Toolkit Vault <vault@goodnbad.info>"
+# Owner inbox for new-lead notifications (also used as reply-to on buyer emails):
+LEAD_TO=
+
+# Legacy SMTP (optional fallback; Resend above is preferred):
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
-LEAD_TO=
 
 # ── Supabase — logs every signup to the `leads` table (additive to the above) ─
 # SERVER-ONLY. Do NOT prefix with NEXT_PUBLIC — the service-role key bypasses RLS

--- a/app/api/gumroad/ping/route.ts
+++ b/app/api/gumroad/ping/route.ts
@@ -9,6 +9,7 @@
 // === END METADATA ===
 import { NextResponse } from "next/server"
 import { supabaseAdmin, isSupabaseConfigured } from "@/lib/supabase/server"
+import { sendEmail, isEmailConfigured } from "@/lib/email/resend"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -65,6 +66,26 @@ export async function POST(req: Request) {
     }
   } catch (e) {
     console.error("[gumroad ping] failed:", e)
+  }
+
+  // 4) Welcome the buyer on their FIRST charge (not renewals). Never throw.
+  if (!sale.is_recurring_charge && isEmailConfigured()) {
+    try {
+      const product = sale.product_name ?? "your Toolkit Vault"
+      await sendEmail({
+        to: email,
+        subject: "Welcome to The Toolkit Vault 🗝️",
+        replyTo: process.env.LEAD_TO,
+        html: `<div style="font:15px/1.6 ui-sans-serif,system-ui;color:#18181b;max-width:520px">
+          <p>You're in — thanks for grabbing <b>${product.replace(/[<>]/g, "")}</b>.</p>
+          <p><b>Week 1</b> is on your Gumroad receipt (and in your Gumroad library). Over the next month, <b>Weeks 2–4</b> land in your inbox automatically — one short, designed PDF each week, tuned for your setup.</p>
+          <p style="direction:rtl">وصلك العدد الأول مع إيصال Gumroad. الأسابيع ٢–٤ بتوصلك تلقائيًا خلال الشهر — ملف PDF واحد كل أسبوع.</p>
+          <p style="color:#71717a;font-size:13px">The Toolkit Vault · goodnbad.info</p>
+        </div>`,
+      })
+    } catch (e) {
+      console.error("[gumroad ping] welcome email failed:", e)
+    }
   }
 
   return NextResponse.json({ ok: true })

--- a/app/api/gumroad/ping/route.ts
+++ b/app/api/gumroad/ping/route.ts
@@ -1,0 +1,71 @@
+// === METADATA ===
+// Purpose: Receive Gumroad's "Ping" webhook (Settings → Advanced → Ping) on every
+//          sale/renewal and record it in Supabase `sales`. Unifies real buyers
+//          with the website waitlist so every email + purchase is in one place.
+// Security: Gumroad Ping is unsigned, so we require a secret token in the URL
+//          (?token=…) matched against GUMROAD_PING_TOKEN. Upsert on sale_id makes
+//          re-delivery idempotent. Always 200 so Gumroad doesn't retry-storm.
+// Payload: application/x-www-form-urlencoded (price in cents).
+// === END METADATA ===
+import { NextResponse } from "next/server"
+import { supabaseAdmin, isSupabaseConfigured } from "@/lib/supabase/server"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function POST(req: Request) {
+  // 1) verify the shared secret in the ping URL
+  const token = new URL(req.url).searchParams.get("token")
+  const expected = process.env.GUMROAD_PING_TOKEN
+  if (expected && token !== expected) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 })
+  }
+
+  // 2) parse the form-encoded body
+  let form: FormData
+  try {
+    form = await req.formData()
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 })
+  }
+  const str = (k: string): string | null => {
+    const v = form.get(k)
+    return typeof v === "string" && v.length ? v : null
+  }
+
+  const email = str("email")
+  if (!email) return NextResponse.json({ ok: true, skipped: "no email" })
+
+  const raw: Record<string, string> = {}
+  for (const [k, v] of form.entries()) if (typeof v === "string") raw[k] = v
+
+  const sale = {
+    sale_id: str("sale_id"),
+    order_number: str("order_number"),
+    email,
+    product_name: str("product_name"),
+    product_permalink: str("product_permalink") ?? str("permalink"),
+    price_cents: str("price") ? Number(str("price")) : null,
+    currency: str("currency"),
+    recurrence: str("recurrence"),
+    subscription_id: str("subscription_id"),
+    is_recurring_charge: str("is_recurring_charge") === "true",
+    refunded: str("refunded") === "true",
+    offer_code: str("offer_code[name]") ?? str("discount_code") ?? str("offer_code"),
+    raw,
+  }
+
+  // 3) persist (idempotent on sale_id). Never throw — Gumroad expects a 200.
+  try {
+    if (isSupabaseConfigured()) {
+      const { error } = await supabaseAdmin().from("sales").upsert(sale, { onConflict: "sale_id" })
+      if (error) console.error("[gumroad ping] upsert error:", error.message)
+    } else {
+      console.log("[gumroad ping] (supabase not configured)\n" + JSON.stringify(sale))
+    }
+  } catch (e) {
+    console.error("[gumroad ping] failed:", e)
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/subscribe/lead/route.ts
+++ b/app/api/subscribe/lead/route.ts
@@ -11,6 +11,7 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { supabaseAdmin, isSupabaseConfigured } from "@/lib/supabase/server"
+import { sendEmail, isEmailConfigured } from "@/lib/email/resend"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -83,28 +84,38 @@ async function notifyTelegram(text: string): Promise<boolean> {
   }
 }
 
-async function notifyEmail(text: string): Promise<boolean> {
-  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, LEAD_TO } = process.env
-  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS || !LEAD_TO) return false
-  try {
-    const nodemailer = (await import("nodemailer")).default
-    const port = Number(SMTP_PORT || 587)
-    const transport = nodemailer.createTransport({
-      host: SMTP_HOST,
-      port,
-      secure: port === 465,
-      auth: { user: SMTP_USER, pass: SMTP_PASS },
-    })
-    await transport.sendMail({
-      from: `Repo Vault <${SMTP_USER}>`,
-      to: LEAD_TO,
-      subject: "New Repo Vault lead",
-      text,
-    })
-    return true
-  } catch {
-    return false
-  }
+// Notify the owner (Hamzah) that a new lead came in. Uses Resend; LEAD_TO is the
+// inbox. Returns false (logged inside sendEmail) when email isn't configured.
+async function notifyOwner(text: string): Promise<boolean> {
+  const to = process.env.LEAD_TO
+  if (!to || !isEmailConfigured()) return false
+  const { ok } = await sendEmail({
+    to,
+    subject: "🟢 New Toolkit Vault lead",
+    html: `<pre style="font:14px/1.5 ui-monospace,monospace">${escapeHtml(text)}</pre>`,
+    text,
+  })
+  return ok
+}
+
+// Confirm to the LEAD that we got them — keeps the funnel feeling alive. Bilingual.
+async function confirmToLead(lead: z.infer<typeof LeadSchema>): Promise<boolean> {
+  if (!isEmailConfigured()) return false
+  const vault = lead.tracks?.length ? lead.tracks.join(" + ") : "your toolkit"
+  const html = `<div style="font:15px/1.6 ui-sans-serif,system-ui;color:#18181b;max-width:520px">
+    <p>Hi ${escapeHtml(lead.name)},</p>
+    <p>You're on the list for <b>${escapeHtml(vault)}</b>. Each week you'll get one short, designed PDF — 5 real open-source tools, each with a paste-ready AI prompt tuned for your setup.</p>
+    <p>I'll email you the moment your first issue is ready. No noise, cancel anytime.</p>
+    <p style="direction:rtl">سجّلناك في <b>${escapeHtml(vault)}</b> — كل أسبوع ملف PDF واحد مختصر: ٥ أدوات مفتوحة المصدر، كل وحدة معها برومبت جاهز. بنرسل لك أول عدد أول ما يجهز.</p>
+    <p style="color:#71717a;font-size:13px">The Toolkit Vault · goodnbad.info</p>
+  </div>`
+  const { ok } = await sendEmail({
+    to: lead.email,
+    subject: "You're in — The Toolkit Vault",
+    html,
+    replyTo: process.env.LEAD_TO,
+  })
+  return ok
 }
 
 export async function POST(req: Request) {
@@ -121,7 +132,11 @@ export async function POST(req: Request) {
   }
 
   const text = formatLead(parsed.data)
-  const [tg, mail] = await Promise.all([notifyTelegram(text), notifyEmail(text)])
+  const [tg, mail, confirm] = await Promise.all([
+    notifyTelegram(text),
+    notifyOwner(text),
+    confirmToLead(parsed.data),
+  ])
 
   // Additive: persist every signup to Supabase. Wrapped so an outage or missing
   // config never breaks the funnel — Telegram/SMTP delivery is unaffected.
@@ -154,5 +169,8 @@ export async function POST(req: Request) {
     console.log("[subscribe lead] (no channel configured)\n" + text)
   }
 
-  return NextResponse.json({ ok: true, delivered: { telegram: tg, email: mail, supabase: stored } })
+  return NextResponse.json({
+    ok: true,
+    delivered: { telegram: tg, ownerEmail: mail, leadConfirm: confirm, supabase: stored },
+  })
 }

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -438,8 +438,8 @@ export default function SubscribePage() {
                     <span className="font-mono text-3xl font-bold text-emerald-300">${price.price}</span>
                     <span className="font-mono text-xs text-zinc-500">/mo</span>
                   </div>
-                  <p className="mt-0.5 font-mono text-[10px] text-emerald-600/80">{price.breakdown}</p>
-                  <p className="font-mono text-[10px] text-zinc-700">per month · cancel anytime</p>
+                  <p className="mt-0.5 font-mono text-[10px] text-emerald-400/90">≈ ${(price.price / 30).toFixed(2)}/day · {price.breakdown}</p>
+                  <p className="font-mono text-[10px] text-zinc-700">billed monthly · cancel anytime</p>
                 </div>
               </div>
             </div>

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -1,0 +1,50 @@
+// === METADATA ===
+// Purpose: One tiny server-only email sender backed by Resend's HTTP API. No SDK
+//          dependency — just fetch — so it adds zero install weight.
+// Config:  RESEND_API_KEY + EMAIL_FROM (e.g. "Toolkit Vault <vault@goodnbad.info>").
+//          When unset, sendEmail() returns { ok:false } WITHOUT throwing, so callers
+//          (lead route, ping webhook) degrade gracefully and never break the funnel.
+// Safety:  Every failure path logs via console.error — there is no silent swallow.
+// === END METADATA ===
+import "server-only"
+
+type SendArgs = {
+  to: string | string[]
+  subject: string
+  html: string
+  text?: string
+  replyTo?: string
+}
+
+export function isEmailConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY && process.env.EMAIL_FROM)
+}
+
+export async function sendEmail(args: SendArgs): Promise<{ ok: boolean; error?: string }> {
+  const key = process.env.RESEND_API_KEY
+  const from = process.env.EMAIL_FROM
+  if (!key || !from) return { ok: false, error: "email not configured" }
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        from,
+        to: Array.isArray(args.to) ? args.to : [args.to],
+        subject: args.subject,
+        html: args.html,
+        ...(args.text ? { text: args.text } : {}),
+        ...(args.replyTo ? { reply_to: args.replyTo } : {}),
+      }),
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "")
+      console.error(`[email] resend failed ${res.status}: ${detail.slice(0, 300)}`)
+      return { ok: false, error: `resend ${res.status}` }
+    }
+    return { ok: true }
+  } catch (e) {
+    console.error("[email] resend threw:", e)
+    return { ok: false, error: String(e) }
+  }
+}

--- a/lib/subscribe/config.ts
+++ b/lib/subscribe/config.ts
@@ -10,7 +10,7 @@
 //          never fakes a charge.
 // === END METADATA ===
 
-import { type TrackId, type OsId, TRACK_IDS } from "./tracks"
+import { type TrackId, type OsId } from "./tracks"
 import { type BundleTier, tierForCount } from "./personalize"
 
 export type Plan = {
@@ -211,35 +211,41 @@ const GUMROAD: Record<TrackId | "all", GumroadEntry> = {
   },
 }
 const GUMROAD_STORE = process.env.NEXT_PUBLIC_GUMROAD_STORE
+// Launch discount code (e.g. "launch50"). Appended to the product URL so the
+// Gumroad overlay auto-applies it — checkout shows the strike-through price.
+const GUMROAD_DISCOUNT = process.env.NEXT_PUBLIC_GUMROAD_DISCOUNT
 
 /** Best Gumroad product URL for the ticked tracks + the buyer's OS: 1 track → that
  *  vault, 2+ → all-access. Prefers the OS-specific link, then the track's generic
- *  link, then all-access, then the store. */
+ *  link, then all-access, then the store. Auto-applies the launch discount code. */
 export function gumroadUrl(selectedTracks: TrackId[], os: OsId = "windows"): string {
   const tier = tierForTracks(selectedTracks)
   const key: TrackId | "all" = tier === "single" ? selectedTracks[0] : "all"
   const e = GUMROAD[key]
   const all = GUMROAD.all
-  return ((e && (e[os] || e.any)) || all[os] || all.any || GUMROAD_STORE || "").trim()
+  const base = ((e && (e[os] || e.any)) || all[os] || all.any || GUMROAD_STORE || "").trim()
+  if (!base) return ""
+  return GUMROAD_DISCOUNT ? `${base.replace(/\/+$/, "")}/${GUMROAD_DISCOUNT}` : base
 }
 
 // Base + per-tool pricing (USD, matches the Gumroad products). One issue = 5 tools
 // → $2 base + $1.20 × 5 = $8. All-access (3+ vaults) is a flat bundle price that
 // undercuts buying every issue separately.
-export const PRICING = { base: 2, perTool: 1.2, toolsPerIssue: 5, perIssue: 8, allAccess: 25 }
+// You pay $8/mo (single) or $25/mo (all-access). The anchor is the Gumroad list
+// price (single $16, all-access $50) so the launch discount reads as a real 50%
+// off — the product is priced at the anchor and the auto-applied code nets the
+// real price. `perIssue`/`allAccess` are the real prices; anchors are the strike.
+export const PRICING = { perIssue: 8, allAccess: 25, anchorSingle: 16, anchorAll: 50 }
 
 export type GumroadPrice = { price: number; original: number; breakdown: string }
 
-/** USD price + honest strike-through + a base/per-tool breakdown line for the paywall. */
+/** Real price + strike-through anchor for the paywall (50% launch discount). */
 export function gumroadPrice(selectedTracks: TrackId[]): GumroadPrice {
   const n = Math.max(1, selectedTracks.length)
-  if (n >= 3) {
-    const original = PRICING.perIssue * TRACK_IDS.length // value of buying all separately
-    return { price: PRICING.allAccess, original, breakdown: `all ${TRACK_IDS.length} vaults · one price` }
+  if (n >= 2) {
+    return { price: PRICING.allAccess, original: PRICING.anchorAll, breakdown: "50% launch discount" }
   }
-  const tools = PRICING.toolsPerIssue * n
-  const price = Math.round(PRICING.base + PRICING.perTool * tools)
-  return { price, original: PRICING.perIssue * n, breakdown: `$${PRICING.base} base + $${PRICING.perTool}/tool × ${tools}` }
+  return { price: PRICING.perIssue, original: PRICING.anchorSingle, breakdown: "50% launch discount" }
 }
 
 export const PRODUCT = {

--- a/lib/subscribe/personalize.ts
+++ b/lib/subscribe/personalize.ts
@@ -1,5 +1,5 @@
 // === METADATA ===
-// Purpose: Pure personalization engine. Turns the 21 quiz answers into a concrete
+// Purpose: Pure personalization engine. Turns the 8 quiz answers into a concrete
 //          curation: which tracks the member gets, which tuned PDF variant
 //          ({tool,os}) they receive, a deterministic "read factor" match score,
 //          and the recommended bundle tier (which also sets the price).
@@ -36,19 +36,23 @@ export interface Personalization {
 }
 
 // ── Read-factor weights (sum of maxima = 100) ──────────────────────────────────
+// Re-based on the trimmed 8-question quiz: only role / goals / niche / tracks
+// remain, so the score is built from niche↔track fit, how much the person told us
+// (signal density), and how many vaults they committed to (engagement).
 const READ_BASE = 40
 const ALIGN_PER_MATCH = 7
 const ALIGN_MAX = 20
-const LEVEL_SCORE: Record<string, number> = { advanced: 12, intermediate: 8, beginner: 4 }
 const DENSITY_PER_TICK = 2
-const DENSITY_MAX = 16
-const URGENCY_SCORE: Record<string, number> = { week: 12, month: 8, quarter: 4, explore: 0 }
+const DENSITY_MAX = 24
+const ENGAGE_PER_TRACK = 4
+const ENGAGE_MAX = 16
 
 /** Niche vocabulary → track vocabulary (the only translation point in the system). */
 const NICHE_TRACK: Record<string, TrackId> = {
   security: "security",
   dev: "developers",
   automation: "automation",
+  content: "creative",
 }
 
 const READ_ELITE_MIN = 80
@@ -80,11 +84,11 @@ export function readLabelFor(score: number): ReadLabel {
   return "starter"
 }
 
-/** Deterministic 0–100 match score from niche↔track fit, level, signal density, urgency. */
+/** Deterministic 0–100 match score from niche↔track fit, signal density, engagement. */
 export function computeReadFactor(answers: Answers, selectedTracks: TrackId[]): number {
   let score = READ_BASE
 
-  // niche ↔ selected-track alignment
+  // niche ↔ selected-track alignment (max 20)
   const trackSet = new Set(selectedTracks)
   let matches = 0
   for (const niche of list(answers, "niche")) {
@@ -93,15 +97,13 @@ export function computeReadFactor(answers: Answers, selectedTracks: TrackId[]): 
   }
   score += Math.min(matches * ALIGN_PER_MATCH, ALIGN_MAX)
 
-  // level / engagement intensity
-  score += LEVEL_SCORE[first(answers, "level") ?? ""] ?? 0
-
-  // signal density — the more they tell us, the more surface we can match
-  const density = list(answers, "goals").length + list(answers, "frustration").length
+  // signal density — the more they tell us (role + goals + niche), the better we match (max 24)
+  const density =
+    list(answers, "role").length + list(answers, "goals").length + list(answers, "niche").length
   score += Math.min(density * DENSITY_PER_TICK, DENSITY_MAX)
 
-  // urgency
-  score += URGENCY_SCORE[first(answers, "timeline") ?? ""] ?? 0
+  // engagement — committing to more vaults reads as higher intent (max 16)
+  score += Math.min(selectedTracks.length * ENGAGE_PER_TRACK, ENGAGE_MAX)
 
   return clamp(Math.round(score), 0, 100)
 }

--- a/lib/subscribe/quiz.ts
+++ b/lib/subscribe/quiz.ts
@@ -56,7 +56,7 @@ export type QuizQuestion =
     }
 
 export const QUIZ: QuizQuestion[] = [
-  // ── A · Opener / identity (frictionless, builds momentum) ──────────────────
+  // ── 1 · Identity (frictionless opener) ─────────────────────────────────────
   {
     id: "role",
     type: "multi",
@@ -71,19 +71,6 @@ export const QUIZ: QuizQuestion[] = [
       { value: "creator", ar: "صانع محتوى / تسويق", en: "Creator / marketer" },
       { value: "security", ar: "مهتم بالأمن السيبراني", en: "Into cybersecurity" },
       { value: "other", ar: "غير ذلك", en: "Something else" },
-    ],
-  },
-  {
-    id: "ai_freq",
-    type: "single",
-    icon: "zap",
-    ar: "كم تستخدم أدوات الذكاء الاصطناعي حالياً؟",
-    en: "How often do you use AI tools today?",
-    options: [
-      { value: "daily", ar: "كل يوم", en: "Every day" },
-      { value: "weekly", ar: "كم مرة بالأسبوع", en: "A few times a week" },
-      { value: "rarely", ar: "نادراً", en: "Rarely" },
-      { value: "new", ar: "لسّا بادي", en: "Just getting started" },
     ],
   },
   {
@@ -118,50 +105,7 @@ export const QUIZ: QuizQuestion[] = [
     ],
   },
 
-  // ── B · Pain / current state (agitate the gap) ─────────────────────────────
-  {
-    id: "frustration",
-    type: "multi",
-    icon: "alert",
-    ar: "أكثر شي يضايقك حالياً؟ (اختر كل ما ينطبق)",
-    en: "Biggest frustrations right now? (tick all)",
-    minSelect: 1,
-    options: [
-      { value: "repeat", ar: "أعيد شرح نفسي للـ AI كل مرة", en: "Repeating myself to the AI every time" },
-      { value: "messy", ar: "ملفاتي ومساحات عملي مبعثرة", en: "Messy, scattered workspaces" },
-      { value: "tools", ar: "ما أعرف وش أفضل الأدوات", en: "Don't know the best tools" },
-      { value: "slow", ar: "النتائج بطيئة", en: "Results come too slow" },
-      { value: "lost", ar: "ما أعرف وش الممكن أصلاً", en: "Not sure what's even possible" },
-    ],
-  },
-  {
-    id: "time_lost",
-    type: "single",
-    icon: "clock",
-    ar: "كم ساعة بالأسبوع تضيع في شغل ممكن الـ AI يسوّيه؟",
-    en: "Hours/week lost to busywork AI could handle?",
-    options: [
-      { value: "1-3", ar: "١-٣ ساعات", en: "1–3 hours" },
-      { value: "4-7", ar: "٤-٧ ساعات", en: "4–7 hours" },
-      { value: "8-15", ar: "٨-١٥ ساعة", en: "8–15 hours" },
-      { value: "15+", ar: "أكثر من ١٥ ساعة", en: "15+ hours" },
-    ],
-  },
-  {
-    id: "missing_out",
-    type: "single",
-    icon: "eye",
-    ar: "تحس إن فيه أدوات يستخدمها غيرك وأنت فايتك؟",
-    en: "Feel others use tools that put you behind?",
-    options: [
-      { value: "yes", ar: "أكيد", en: "Definitely" },
-      { value: "probably", ar: "على الأغلب", en: "Probably" },
-      { value: "maybe", ar: "يمكن", en: "Maybe" },
-      { value: "no", ar: "لا", en: "Not really" },
-    ],
-  },
-
-  // ── C · Desire / goals (paint the outcome) ─────────────────────────────────
+  // ── 2 · Desire + focus (drives match% and the recommendation) ──────────────
   {
     id: "goals",
     type: "multi",
@@ -175,61 +119,6 @@ export const QUIZ: QuizQuestion[] = [
       { value: "master", ar: "أتقن workflow الـ AI", en: "Master AI workflows" },
       { value: "automate", ar: "أتمتة شغلي", en: "Automate my work" },
       { value: "career", ar: "وظيفة / فرصة أفضل", en: "A better role" },
-    ],
-  },
-  {
-    id: "outcome",
-    type: "multi",
-    icon: "sparkles",
-    ar: "لو صار شغلك نخبوي، وش يتغيّر؟ (اختر كل ما ينطبق)",
-    en: "If your workflow went elite, what changes? (tick all)",
-    minSelect: 1,
-    options: [
-      { value: "money", ar: "فلوس أكثر", en: "More money" },
-      { value: "time", ar: "وقت فراغ أكثر", en: "More free time" },
-      { value: "output", ar: "إنتاجية أعلى", en: "More output" },
-      { value: "stress", ar: "توتر أقل", en: "Less stress" },
-      { value: "standout", ar: "أتميّز عن الكل", en: "I stand out" },
-    ],
-  },
-  {
-    id: "income_goal",
-    type: "single",
-    icon: "trending",
-    ar: "كم تتمنى تكسب من مهاراتك أو مشاريعك الجانبية؟",
-    en: "Income goal from your skills / side projects?",
-    options: [
-      { value: "1-2k", ar: "١-٢ ألف ريال شهرياً", en: "An extra 1–2k SAR/mo" },
-      { value: "3-5k", ar: "٣-٥ آلاف شهرياً", en: "3–5k SAR/mo" },
-      { value: "6-10k", ar: "٦-١٠ آلاف شهرياً", en: "6–10k SAR/mo" },
-      { value: "10k+", ar: "+١٠ آلاف / أستقل بشغلي", en: "10k+ / replace my job" },
-    ],
-  },
-  {
-    id: "timeline",
-    type: "single",
-    icon: "clock",
-    ar: "متى تبي تشوف نتيجة؟",
-    en: "How soon do you want results?",
-    options: [
-      { value: "week", ar: "هذا الأسبوع", en: "This week" },
-      { value: "month", ar: "هذا الشهر", en: "This month" },
-      { value: "quarter", ar: "خلال ٣ أشهر", en: "Within 3 months" },
-      { value: "explore", ar: "بس أستكشف", en: "Just exploring" },
-    ],
-  },
-
-  // ── D · Qualify / personalize (so the plan feels tailored) ─────────────────
-  {
-    id: "level",
-    type: "single",
-    icon: "gauge",
-    ar: "مستواك مع هالأدوات؟",
-    en: "Your level with these tools?",
-    options: [
-      { value: "beginner", ar: "مبتدئ", en: "Beginner" },
-      { value: "intermediate", ar: "متوسط", en: "Intermediate" },
-      { value: "advanced", ar: "متقدّم", en: "Advanced" },
     ],
   },
   {
@@ -247,36 +136,8 @@ export const QUIZ: QuizQuestion[] = [
       { value: "business", ar: "ريادة / أعمال", en: "Business / startup" },
     ],
   },
-  {
-    id: "apply",
-    type: "multi",
-    icon: "briefcase",
-    ar: "وين تبي تطبّق هذا؟ (اختر كل ما ينطبق)",
-    en: "Where will you apply this? (tick all)",
-    minSelect: 1,
-    options: [
-      { value: "work", ar: "في شغلي", en: "At work" },
-      { value: "side", ar: "مشروع جانبي", en: "A side business" },
-      { value: "personal", ar: "مشاريع شخصية", en: "Personal projects" },
-      { value: "study", ar: "دراستي", en: "My studies" },
-    ],
-  },
-  {
-    id: "learn_style",
-    type: "multi",
-    icon: "book",
-    ar: "كيف تحب تتعلّم؟ (اختر كل ما ينطبق)",
-    en: "How do you like to level up? (tick all)",
-    minSelect: 1,
-    options: [
-      { value: "kits", ar: "أدوات جاهزة أنسخها مباشرة", en: "Ready-to-use kits" },
-      { value: "steps", ar: "خطوة بخطوة", en: "Step-by-step guides" },
-      { value: "tools", ar: "بس أعطني الأدوات", en: "Just hand me the tools" },
-      { value: "examples", ar: "أمثلة أقدر أقلّدها", en: "Examples I can copy" },
-    ],
-  },
 
-  // ── E · Pick your tracks (THIS drives the bundle price) ─────────────────────
+  // ── 3 · Pick your tracks (THIS drives the bundle price) ─────────────────────
   {
     // values MUST equal TrackId. Number of ticks → bundle tier (1=single, 2=duo,
     // 3–4=all). This is both the personalization signal AND the product selection.
@@ -289,56 +150,16 @@ export const QUIZ: QuizQuestion[] = [
     minSelect: 1,
     maxSelect: TRACK_IDS.length,
     options: [
-      { value: "security", ar: "الأمن — أسبوع ١", en: "Security — Week 1" },
-      { value: "developers", ar: "المطوّرين والأدوات — أسبوع ٢", en: "Developers & Tools — Week 2" },
-      { value: "agents", ar: "الوكلاء — أسبوع ٣", en: "Agents — Week 3" },
-      { value: "automation", ar: "الأتمتة — أسبوع ٤", en: "Automation — Week 4" },
-      { value: "quant", ar: "التداول الكمّي — أسبوع ٥", en: "Quant & Trading — Week 5" },
-      { value: "creative", ar: "ابنِ في المتصفح — أسبوع ٦", en: "Build in the Browser — Week 6" },
+      { value: "security", ar: "الأمن", en: "Security" },
+      { value: "developers", ar: "المطوّرين والأدوات", en: "Developers & Tools" },
+      { value: "agents", ar: "الوكلاء", en: "Agents" },
+      { value: "automation", ar: "الأتمتة", en: "Automation" },
+      { value: "quant", ar: "التداول الكمّي", en: "Quant & Trading" },
+      { value: "creative", ar: "ابنِ في المتصفح", en: "Build in the Browser" },
     ],
   },
 
-  // ── F · Micro-commitments + investment (sunk-cost, then close) ──────────────
-  {
-    id: "invest_time",
-    type: "single",
-    icon: "hourglass",
-    ar: "كم وقت تقدر تعطي بالأسبوع؟",
-    en: "How much time/week can you put in?",
-    options: [
-      { value: "15m", ar: "١٥ دقيقة", en: "15 minutes" },
-      { value: "30m", ar: "٣٠ دقيقة", en: "30 minutes" },
-      { value: "1h", ar: "ساعة", en: "1 hour" },
-      { value: "2h+", ar: "ساعتين أو أكثر", en: "2+ hours" },
-    ],
-  },
-  {
-    id: "blocker",
-    type: "multi",
-    icon: "lock",
-    ar: "وش اللي وقفك لين الحين؟ (اختر كل ما ينطبق)",
-    en: "What's held you back so far? (tick all)",
-    minSelect: 1,
-    options: [
-      { value: "start", ar: "ما أعرف من وين أبدأ", en: "Don't know where to start" },
-      { value: "options", ar: "خيارات كثيرة ومشتتة", en: "Too many options" },
-      { value: "time", ar: "ما عندي وقت أبحث", en: "No time to research" },
-      { value: "cost", ar: "التكلفة", en: "Cost" },
-    ],
-  },
-  {
-    id: "ready",
-    type: "single",
-    icon: "rocket",
-    ar: "جاهز لخطة مبنية على إجاباتك أنت؟",
-    en: "Ready for a plan built around YOUR answers?",
-    options: [
-      { value: "yes", ar: "إي، وريني", en: "Yes — show me" },
-      { value: "think", ar: "أعتقد", en: "I think so" },
-    ],
-  },
-
-  // ── Capture (personalize the plan + reach them) ────────────────────────────
+  // ── 4 · Capture (personalize the plan + reach them) ────────────────────────
   {
     id: "name",
     type: "text",

--- a/supabase/migrations/0002_sales.sql
+++ b/supabase/migrations/0002_sales.sql
@@ -1,0 +1,33 @@
+-- === METADATA ===
+-- Purpose: `sales` table for Gumroad purchases, fed by the Gumroad "Ping"
+--          webhook (app/api/gumroad/ping). Unifies real buyers with the website
+--          waitlist/leads — one Supabase, every email + every sale.
+-- Security: RLS ON, no anon policies. Only the service-role server route writes.
+-- Apply:   supabase db push (or paste into the Supabase SQL editor).
+-- === END METADATA ===
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.sales (
+  id                  uuid primary key default gen_random_uuid(),
+  created_at          timestamptz not null default now(),
+  sale_id             text unique,            -- Gumroad sale id (idempotency key)
+  order_number        text,
+  email               text not null,
+  product_name        text,
+  product_permalink   text,
+  price_cents         integer,                -- Gumroad sends price in cents
+  currency            text,
+  recurrence          text,                   -- monthly | yearly | …
+  subscription_id     text,
+  is_recurring_charge boolean default false,  -- false = first charge, true = renewal
+  refunded            boolean default false,
+  offer_code          text,
+  raw                 jsonb not null default '{}'::jsonb
+);
+
+create index if not exists sales_email_idx       on public.sales (email);
+create index if not exists sales_created_at_idx   on public.sales (created_at desc);
+
+alter table public.sales enable row level security;
+-- (no anon policies: only the service-role Ping route writes here)

--- a/tests/personalize.test.ts
+++ b/tests/personalize.test.ts
@@ -53,21 +53,19 @@ describe("personalize · readFactor (deterministic)", () => {
     expect(computeReadFactor({}, [])).toBe(40)
   })
 
-  it("awards full marks for a maximally-aligned advanced/urgent profile", () => {
+  it("awards full marks for a maximally-aligned, high-intent profile", () => {
     const a: Answers = {
-      tracks: ["security", "developers", "automation"],
-      niche: ["security", "dev", "automation"], // 3 matches → capped at 20
-      level: ["advanced"], // +12
-      goals: ["income", "ship", "master", "automate"], // density…
-      frustration: ["repeat", "messy", "tools", "slow"], // …8 ticks → capped +16
-      timeline: ["week"], // +12
+      tracks: ["security", "developers", "automation", "creative"], // engage 4×4 → capped 16
+      niche: ["security", "dev", "automation", "content"], // 4 matches → capped 20
+      role: ["student", "dev", "founder", "creator"], // density…
+      goals: ["income", "ship", "master", "automate"], // role+goals+niche = 12 ticks → capped 24
     }
-    // 40 + 20 + 12 + 16 + 12 = 100
+    // 40 + 20 + 24 + 16 = 100
     expect(computeReadFactor(a, personalize(a).selectedTracks)).toBe(100)
   })
 
   it("is stable across repeated calls (no randomness)", () => {
-    const a: Answers = { tracks: ["security"], niche: ["security"], level: ["beginner"], timeline: ["month"] }
+    const a: Answers = { tracks: ["security"], niche: ["security"], role: ["dev"], goals: ["ship"] }
     const tracks = personalize(a).selectedTracks
     expect(computeReadFactor(a, tracks)).toBe(computeReadFactor(a, tracks))
   })

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -66,25 +66,28 @@ describe("pricing · honest derived math", () => {
   })
 })
 
-describe("pricing · gumroad base + per-tool", () => {
-  it("one issue = $2 base + $1.20 × 5 tools = $8", () => {
-    expect(gumroadPrice(["security"] as TrackId[]).price).toBe(8)
-    expect(gumroadPrice(["security"] as TrackId[]).original).toBe(8)
+describe("pricing · gumroad 50% launch anchor", () => {
+  it("single issue = $8, anchored at $16 (50% off)", () => {
+    const q = gumroadPrice(["security"] as TrackId[])
+    expect(q.price).toBe(PRICING.perIssue) // 8
+    expect(q.original).toBe(PRICING.anchorSingle) // 16
   })
 
-  it("two vaults add per-tool, with an honest strike-through", () => {
+  it("2+ vaults route to all-access = $25, anchored at $50", () => {
     const q = gumroadPrice(["security", "developers"] as TrackId[])
-    expect(q.price).toBe(14) // 2 + 1.2*10
-    expect(q.original).toBe(16) // 2 × $8
-  })
-
-  it("3+ vaults = flat all-access price, undercutting buying separately", () => {
-    const q = gumroadPrice(SDA)
     expect(q.price).toBe(PRICING.allAccess) // 25
-    expect(q.original).toBeGreaterThan(q.price)
+    expect(q.original).toBe(PRICING.anchorAll) // 50
+    expect(gumroadPrice(SDA).price).toBe(PRICING.allAccess)
   })
 
-  it("exposes a breakdown string for the paywall", () => {
-    expect(gumroadPrice(["security"] as TrackId[]).breakdown).toContain("base")
+  it("every anchor is a real strike-through (original > price)", () => {
+    for (const sel of [["security"], ["security", "developers"], SDA]) {
+      const q = gumroadPrice(sel as TrackId[])
+      expect(q.original).toBeGreaterThan(q.price)
+    }
+  })
+
+  it("exposes the launch-discount breakdown line", () => {
+    expect(gumroadPrice(["security"] as TrackId[]).breakdown).toContain("discount")
   })
 })


### PR DESCRIPTION
Logs every Gumroad sale/renewal into Supabase `sales` (token-guarded, idempotent on sale_id), unifying buyers with the website waitlist. tsc clean. Migration already applied to Supabase. After merge + deploy, set the Ping URL in Gumroad Settings → Advanced.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Gumroad Ping webhook handler that persists every sale/renewal into a new Supabase `sales` table and sends a bilingual welcome email to first-time buyers, while also migrating the lead-confirmation flow from nodemailer/SMTP to a lightweight Resend wrapper. The quiz is trimmed from 21 questions to 8 and the pricing model is simplified to a flat 50% launch-anchor.

- **`app/api/gumroad/ping/route.ts`** (new): token-guarded POST handler — upserts into `sales`, then sends a welcome email on first charge. Three issues flagged in prior reviews remain open (auth bypass when env var unset, `NaN` price on non-numeric input, token exposed in URL); a new issue is that the welcome email fires on every webhook delivery rather than only on confirmed-new inserts, so Gumroad retries can produce duplicate emails.
- **`supabase/migrations/0002_sales.sql`** (new): creates `sales` with RLS on; `sale_id text unique` without `NOT NULL` was previously flagged — NULL uniqueness in Postgres means each null `sale_id` breaks idempotency.
- **`lib/email/resend.ts`** (new): zero-dependency Resend wrapper using raw `fetch`; all error paths return `{ok:false}` without throwing — clean replacement for the nodemailer SMTP path.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The webhook route has multiple open issues — the most actionable new one being that the welcome email is not guarded against re-delivery, meaning buyers can receive duplicate welcome emails on any Gumroad retry.

The Gumroad ping handler carries four open correctness issues: the auth check silently passes when the env var is absent, a non-numeric price field produces a NaN that causes a silent DB failure, the shared secret appears in URL access logs, and the welcome email send is not tied to a fresh INSERT so every webhook retry fires a second email to the buyer.

app/api/gumroad/ping/route.ts and supabase/migrations/0002_sales.sql need attention before this goes live.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/gumroad/ping/route.ts | New Gumroad Ping webhook handler — stores sales in Supabase and sends a welcome email. Three issues already flagged in prior reviews (auth bypass when token env var unset, NaN price on non-numeric input, token in URL query string) plus a new one: the welcome email is not guarded against duplicate sends on webhook retry, contradicting the route's own idempotency claim. |
| supabase/migrations/0002_sales.sql | New `sales` table with RLS enabled and correct indexes. `sale_id` lacks `NOT NULL`, previously flagged — each null `sale_id` breaks the UNIQUE idempotency key since PostgreSQL treats each NULL as distinct. |
| lib/email/resend.ts | New thin Resend email wrapper using raw `fetch` — no SDK dependency. Error paths all log and return `{ok: false}` without throwing, correct graceful degradation. |
| app/api/subscribe/lead/route.ts | Replaces nodemailer/SMTP with Resend; adds `confirmToLead` to send a bilingual confirmation email to each new subscriber. `escapeHtml` is applied consistently throughout; parallel execution with `Promise.all` preserved. |
| lib/subscribe/config.ts | Pricing simplified to flat anchors with 50% launch discount; all-access threshold lowered from 3+ to 2+ vaults; new `NEXT_PUBLIC_GUMROAD_DISCOUNT` env var appended as a Gumroad path-segment for auto-application at checkout. |
| lib/subscribe/personalize.ts | Read-factor scoring rebuilt for the trimmed 8-question quiz — removes level/urgency axes, adds engagement from track count. Score ceiling still reaches 100 (40+20+24+16). |
| lib/subscribe/quiz.ts | Quiz trimmed from 21 questions to 8 by removing friction-heavy sections. Remaining structure is clean; track option labels shortened to remove week-number references. |
| tests/personalize.test.ts | Tests updated to reflect new 8-question scoring algorithm; arithmetic verified in comments (40+20+24+16=100). |
| tests/pricing.test.ts | Pricing tests updated for launch-anchor model; validates that original > price for every tier and that 2+ vaults routes to all-access. |
| .env.example | Adds RESEND_API_KEY, EMAIL_FROM, and GUMROAD_PING_TOKEN entries; LEAD_TO moved next to Resend config; SMTP block relabelled as legacy fallback. |
| app/subscribe/page.tsx | Paywall price display updated to show ≈ $X/day and 'billed monthly' copy; colour of breakdown line adjusted. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant G as Gumroad
    participant R as /api/gumroad/ping
    participant SB as Supabase sales
    participant RS as Resend

    G->>R: "POST ?token=… (form-urlencoded)"
    R->>R: verify token
    R->>R: parse form fields
    R->>SB: upsert(sale, onConflict: sale_id)
    SB-->>R: ok / error
    alt !is_recurring_charge (BUG: no new-insert guard)
        R->>RS: sendEmail(welcome)
        RS-->>R: "{ok}"
    end
    R-->>G: "200 {ok:true}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant G as Gumroad
    participant R as /api/gumroad/ping
    participant SB as Supabase sales
    participant RS as Resend

    G->>R: "POST ?token=… (form-urlencoded)"
    R->>R: verify token
    R->>R: parse form fields
    R->>SB: upsert(sale, onConflict: sale_id)
    SB-->>R: ok / error
    alt !is_recurring_charge (BUG: no new-insert guard)
        R->>RS: sendEmail(welcome)
        RS-->>R: "{ok}"
    end
    R-->>G: "200 {ok:true}"
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fapi%2Fgumroad%2Fping%2Froute.ts%3A59-72%0A**Welcome%20email%20re-sent%20on%20every%20Gumroad%20webhook%20retry**%0A%0AThe%20route%20header%20says%20%22Upsert%20on%20%60sale_id%60%20makes%20re-delivery%20idempotent%22%20%E2%80%94%20but%20only%20the%20Supabase%20write%20is%20guarded%20by%20the%20upsert.%20The%20welcome%20email%20fires%20on%20every%20delivery%20where%20%60is_recurring_charge%60%20is%20false%2C%20with%20no%20check%20for%20whether%20this%20%60sale_id%60%20was%20already%20processed.%20Gumroad%20retries%20pings%20if%20it%20doesn't%20receive%20a%20timely%20200%20%28e.g.%2C%20due%20to%20a%20Vercel%20cold-start%20timeout%20or%20a%20network%20blip%29%2C%20so%20a%20buyer's%20first%20purchase%20could%20trigger%20two%20or%20more%20identical%20welcome%20emails.%20The%20fix%20is%20to%20detect%20whether%20the%20upsert%20is%20a%20fresh%20INSERT%20before%20queuing%20the%20email.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%203%29%20persist%20%28idempotent%20on%20sale_id%29.%20Never%20throw%20%E2%80%94%20Gumroad%20expects%20a%20200.%0A%20%20let%20isNewSale%20%3D%20!sale.sale_id%20%2F%2F%20no%20sale_id%20%E2%86%92%20can't%20deduplicate%2C%20treat%20as%20new%0A%20%20try%20%7B%0A%20%20%20%20if%20%28isSupabaseConfigured%28%29%29%20%7B%0A%20%20%20%20%20%20if%20%28sale.sale_id%29%20%7B%0A%20%20%20%20%20%20%20%20const%20%7B%20data%20%7D%20%3D%20await%20supabaseAdmin%28%29.from%28%22sales%22%29.select%28%22id%22%29.eq%28%22sale_id%22%2C%20sale.sale_id%29.maybeSingle%28%29%0A%20%20%20%20%20%20%20%20isNewSale%20%3D%20!data%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20const%20%7B%20error%20%7D%20%3D%20await%20supabaseAdmin%28%29.from%28%22sales%22%29.upsert%28sale%2C%20%7B%20onConflict%3A%20%22sale_id%22%20%7D%29%0A%20%20%20%20%20%20if%20%28error%29%20console.error%28%22%5Bgumroad%20ping%5D%20upsert%20error%3A%22%2C%20error.message%29%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20console.log%28%22%5Bgumroad%20ping%5D%20%28supabase%20not%20configured%29%5Cn%22%20%2B%20JSON.stringify%28sale%29%29%0A%20%20%20%20%7D%0A%20%20%7D%20catch%20%28e%29%20%7B%0A%20%20%20%20console.error%28%22%5Bgumroad%20ping%5D%20failed%3A%22%2C%20e%29%0A%20%20%7D%0A%0A%20%20%2F%2F%204%29%20Welcome%20the%20buyer%20on%20their%20FIRST%20charge%20%28not%20renewals%29.%20Never%20throw.%0A%20%20if%20%28isNewSale%20%26%26%20!sale.is_recurring_charge%20%26%26%20isEmailConfigured%28%29%29%20%7B%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fgumroad-supabase%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgumroad-supabase%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fapi%2Fgumroad%2Fping%2Froute.ts%3A59-72%0A**Welcome%20email%20re-sent%20on%20every%20Gumroad%20webhook%20retry**%0A%0AThe%20route%20header%20says%20%22Upsert%20on%20%60sale_id%60%20makes%20re-delivery%20idempotent%22%20%E2%80%94%20but%20only%20the%20Supabase%20write%20is%20guarded%20by%20the%20upsert.%20The%20welcome%20email%20fires%20on%20every%20delivery%20where%20%60is_recurring_charge%60%20is%20false%2C%20with%20no%20check%20for%20whether%20this%20%60sale_id%60%20was%20already%20processed.%20Gumroad%20retries%20pings%20if%20it%20doesn't%20receive%20a%20timely%20200%20%28e.g.%2C%20due%20to%20a%20Vercel%20cold-start%20timeout%20or%20a%20network%20blip%29%2C%20so%20a%20buyer's%20first%20purchase%20could%20trigger%20two%20or%20more%20identical%20welcome%20emails.%20The%20fix%20is%20to%20detect%20whether%20the%20upsert%20is%20a%20fresh%20INSERT%20before%20queuing%20the%20email.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%203%29%20persist%20%28idempotent%20on%20sale_id%29.%20Never%20throw%20%E2%80%94%20Gumroad%20expects%20a%20200.%0A%20%20let%20isNewSale%20%3D%20!sale.sale_id%20%2F%2F%20no%20sale_id%20%E2%86%92%20can't%20deduplicate%2C%20treat%20as%20new%0A%20%20try%20%7B%0A%20%20%20%20if%20%28isSupabaseConfigured%28%29%29%20%7B%0A%20%20%20%20%20%20if%20%28sale.sale_id%29%20%7B%0A%20%20%20%20%20%20%20%20const%20%7B%20data%20%7D%20%3D%20await%20supabaseAdmin%28%29.from%28%22sales%22%29.select%28%22id%22%29.eq%28%22sale_id%22%2C%20sale.sale_id%29.maybeSingle%28%29%0A%20%20%20%20%20%20%20%20isNewSale%20%3D%20!data%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20const%20%7B%20error%20%7D%20%3D%20await%20supabaseAdmin%28%29.from%28%22sales%22%29.upsert%28sale%2C%20%7B%20onConflict%3A%20%22sale_id%22%20%7D%29%0A%20%20%20%20%20%20if%20%28error%29%20console.error%28%22%5Bgumroad%20ping%5D%20upsert%20error%3A%22%2C%20error.message%29%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20console.log%28%22%5Bgumroad%20ping%5D%20%28supabase%20not%20configured%29%5Cn%22%20%2B%20JSON.stringify%28sale%29%29%0A%20%20%20%20%7D%0A%20%20%7D%20catch%20%28e%29%20%7B%0A%20%20%20%20console.error%28%22%5Bgumroad%20ping%5D%20failed%3A%22%2C%20e%29%0A%20%20%7D%0A%0A%20%20%2F%2F%204%29%20Welcome%20the%20buyer%20on%20their%20FIRST%20charge%20%28not%20renewals%29.%20Never%20throw.%0A%20%20if%20%28isNewSale%20%26%26%20!sale.is_recurring_charge%20%26%26%20isEmailConfigured%28%29%29%20%7B%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["feat(subscribe): 8-question quiz, per-da..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/49b9205a54143ee433d73271bd91648cc5c7fa14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38937318)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->