### PR TITLE
fix(build): restore missing faq + reconciled ThreatGlobe (fixes Vercel build)

### DIFF
--- a/components/signal/ThreatGlobe.tsx
+++ b/components/signal/ThreatGlobe.tsx
@@ -45,8 +45,10 @@ export const IOC_COLOR: Record<IocType, string> = {
   ransomware:    "rgba(168,85,247,0.92)",  // violet
 }
 
+// Dot radii in degrees of arc — sized up for legibility on the large hero globe
+// (a dot must read as a target, not a speck). Severity drives the hierarchy.
 const SEV_R: Record<ThreatIoc["severity"], number> = {
-  critical: 0.50, high: 0.38, medium: 0.27, low: 0.19,
+  critical: 0.72, high: 0.54, medium: 0.40, low: 0.30,
 }
 
 const SEV_RING: Record<ThreatIoc["severity"], string> = {
@@ -62,6 +64,71 @@ const SEV_RING: Record<ThreatIoc["severity"], string> = {
 const DRIP_MS_BACKGROUND  = 900
 const DRIP_MS_INTERACTIVE = 1400
 const POLL_MS = 5 * 60 * 1000 // route caches 10 min; poll every 5
+
+// ---------------------------------------------------------------------------
+// Day/Night terminator — real solar terminator shader
+// ---------------------------------------------------------------------------
+// Blends a day (blue-marble) and night (city-lights) texture across the actual
+// solar terminator. Lighting is computed in VIEW space and the sun direction is
+// rotated by the live camera POV (globeRotation), so the lit hemisphere stays
+// pinned to real geography even while the globe auto-rotates. Ported from the
+// official globe.gl day-night-cycle example.
+const DAY_TEXTURE_URL   = "https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
+const NIGHT_TEXTURE_URL = "https://unpkg.com/three-globe/example/img/earth-night.jpg"
+
+const DAY_NIGHT_VERT = `
+  varying vec3 vNormal;
+  varying vec2 vUv;
+  void main() {
+    vNormal = normalize(normalMatrix * normal);
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`
+
+const DAY_NIGHT_FRAG = `
+  #define PI 3.141592653589793
+  uniform sampler2D dayTexture;
+  uniform sampler2D nightTexture;
+  uniform vec2 sunPosition;
+  uniform vec2 globeRotation;
+  varying vec3 vNormal;
+  varying vec2 vUv;
+
+  float toRad(in float a) { return a * PI / 180.0; }
+
+  vec3 Polar2Cartesian(in vec2 c) { // [lng, lat]
+    float theta = toRad(90.0 - c.x);
+    float phi = toRad(90.0 - c.y);
+    return vec3(sin(phi) * cos(theta), cos(phi), sin(phi) * sin(theta));
+  }
+
+  void main() {
+    float invLon = toRad(globeRotation.x);
+    float invLat = -toRad(globeRotation.y);
+    mat3 rotX = mat3(1, 0, 0, 0, cos(invLat), -sin(invLat), 0, sin(invLat), cos(invLat));
+    mat3 rotY = mat3(cos(invLon), 0, sin(invLon), 0, 1, 0, -sin(invLon), 0, cos(invLon));
+    vec3 rotatedSunDirection = rotX * rotY * Polar2Cartesian(sunPosition);
+    float intensity = dot(normalize(vNormal), normalize(rotatedSunDirection));
+    vec4 dayColor = texture2D(dayTexture, vUv);
+    vec4 nightColor = texture2D(nightTexture, vUv);
+    // soft terminator band; night side lights stay warm, day stays natural
+    float blendFactor = smoothstep(-0.12, 0.12, intensity);
+    gl_FragColor = mix(nightColor, dayColor, blendFactor);
+  }
+`
+
+/** Subsolar point (longitude, declination) in degrees for a given instant. */
+function sunPosLngLat(date: Date): [number, number] {
+  const sec = date.getUTCHours() * 3600 + date.getUTCMinutes() * 60 + date.getUTCSeconds()
+  let lng = 180 - (sec / 86400) * 360 // subsolar longitude: noon UTC ⇒ 0°, midnight ⇒ ±180°
+  if (lng > 180) lng -= 360
+  if (lng < -180) lng += 360
+  const startOfYear = Date.UTC(date.getUTCFullYear(), 0, 0)
+  const dayOfYear = Math.floor((date.getTime() - startOfYear) / 86_400_000)
+  const declination = -23.44 * Math.cos((2 * Math.PI / 365) * (dayOfYear + 10)) // seasonal tilt
+  return [lng, declination]
+}
 
 // ---------------------------------------------------------------------------
 // World-monitor layers (retained from the world-layers feature)
@@ -158,14 +225,16 @@ interface Props {
   interactive?: boolean
   /** Fired on a drip cadence so parents can stream a live IOC feed. */
   onIoc?: (ioc: ThreatIoc) => void
-  /** Fired on hover/click of a dot (null on leave) — for the inspector. */
+  /** Fired on hover of a dot (null on leave) — drives the inspector preview. */
   onIocSelect?: (ioc: ThreatIoc | null) => void
+  /** Fired on click of a dot — pins the inspector card (vs. the hover preview). */
+  onIocClick?: (ioc: ThreatIoc) => void
   onGlobeClick?: () => void
   showWorldLayers?: boolean
   /** Per-layer filtering — set of layer labels that are active. */
   activeLayers?: Set<string>
-  /** Night mode — use city-lights texture instead of blue marble. */
-  nightMode?: boolean
+  /** Day/Night terminator — blend day + city-lights night across a real solar terminator. */
+  terminator?: boolean
   /**
    * Background-mode horizontal anchor. "center" (default) keeps the globe
    * dead-centre; "right" pushes it to ~71% width, partly off-canvas, so a
@@ -178,8 +247,8 @@ interface Props {
 }
 
 export function ThreatGlobe({
-  interactive = false, onIoc, onIocSelect, onGlobeClick,
-  showWorldLayers = false, activeLayers, nightMode = false, align = "center", width, height,
+  interactive = false, onIoc, onIocSelect, onIocClick, onGlobeClick,
+  showWorldLayers = false, activeLayers, terminator = false, align = "center", width, height,
 }: Props) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const globeRef = useRef<any>(null)
@@ -191,6 +260,12 @@ export function ThreatGlobe({
   const [dayPhase, setDayPhase] = useState(0)
   const dripRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const dripIdxRef = useRef(0)
+
+  // Day/Night terminator: globe.gl's `globeMaterial` is a PROP (not a ref
+  // method), and passing null restores its default material. So we build a
+  // ShaderMaterial lazily and hand it over via the prop — never imperatively.
+  const [globeReady, setGlobeReady] = useState(false)
+  const [shaderMat, setShaderMat] = useState<THREE.ShaderMaterial | null>(null)
 
   const dripMs = interactive ? DRIP_MS_INTERACTIVE : DRIP_MS_BACKGROUND
   const cyberActive = !activeLayers || activeLayers.has("Cyber Threats")
@@ -244,14 +319,9 @@ export function ThreatGlobe({
     // camera distance d = 100·(1+a); apparent Ø = (2·asin(100/d)/fov50)·canvasH.
     const bgAltitude = align === "right" ? 2.0 : 1.72
     globeRef.current.pointOfView({ lat: 29, lng: 44, altitude: interactive ? 1.85 : bgAltitude }, 1200)
-    const material = globeRef.current.globeMaterial?.()
-    if (material) {
-      material.color = new THREE.Color("#132033")
-      material.emissive = new THREE.Color("#030712")
-      material.emissiveIntensity = 0.65
-      material.shininess = 3
-      material.needsUpdate = true
-    }
+    // globeMaterial is a prop, not a ref method — the terminator shader is
+    // supplied via the globeMaterial prop below; just flag readiness here.
+    setGlobeReady(true)
     const ctrl = globeRef.current.controls()
     if (!ctrl) return
     ctrl.autoRotate = true
@@ -281,12 +351,59 @@ export function ThreatGlobe({
   }, [])
 
   useEffect(() => {
+    if (terminator) return // shader owns the material; don't poke emissive
     const material = globeRef.current?.globeMaterial?.()
-    if (!material) return
+    if (!material || (material as THREE.Material).type === "ShaderMaterial") return
     const pulse = 0.48 + Math.sin(dayPhase * Math.PI * 2) * 0.12
-    material.emissiveIntensity = interactive ? pulse : pulse + 0.1
+    ;(material as THREE.MeshPhongMaterial).emissiveIntensity = interactive ? pulse : pulse + 0.1
     material.needsUpdate = true
-  }, [dayPhase, interactive])
+  }, [dayPhase, interactive, terminator])
+
+  // ---- Day/Night terminator -----------------------------------------------
+  // Build the shader material the first time the terminator is switched on:
+  // load day + night textures, then expose it via the globeMaterial prop.
+  useEffect(() => {
+    if (!terminator || shaderMat) return
+    let alive = true
+    const loader = new THREE.TextureLoader()
+    loader.setCrossOrigin("anonymous")
+    const load = (url: string) =>
+      new Promise<THREE.Texture>((resolve, reject) =>
+        loader.load(url, (tex) => { tex.colorSpace = THREE.SRGBColorSpace; resolve(tex) }, undefined, reject),
+      )
+    Promise.all([load(DAY_TEXTURE_URL), load(NIGHT_TEXTURE_URL)])
+      .then(([day, night]) => {
+        if (!alive) return
+        setShaderMat(new THREE.ShaderMaterial({
+          uniforms: {
+            dayTexture:    { value: day },
+            nightTexture:  { value: night },
+            sunPosition:   { value: new THREE.Vector2() },
+            globeRotation: { value: new THREE.Vector2() },
+          },
+          vertexShader: DAY_NIGHT_VERT,
+          fragmentShader: DAY_NIGHT_FRAG,
+        }))
+      })
+      .catch(() => { /* network/cosmetic — globe still renders without it */ })
+    return () => { alive = false }
+  }, [terminator, shaderMat])
+
+  // Drive the sun + camera uniforms every frame while the terminator is live,
+  // so the lit hemisphere tracks real geography even as the globe auto-rotates.
+  useEffect(() => {
+    if (!terminator || !shaderMat || !globeReady) return
+    let raf = 0
+    const tick = () => {
+      const [lng, lat] = sunPosLngLat(new Date())
+      shaderMat.uniforms.sunPosition.value.set(lng, lat)
+      const pov = globeRef.current?.pointOfView?.()
+      if (pov) shaderMat.uniforms.globeRotation.value.set(pov.lng, pov.lat)
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [terminator, shaderMat, globeReady])
 
   // ---- Derived datasets ----------------------------------------------------
   const iocPoints = useMemo<ThreatIoc[]>(
@@ -330,22 +447,22 @@ export function ThreatGlobe({
         width={w}
         height={h}
 
-        globeImageUrl={
-          nightMode
-            ? "//unpkg.com/three-globe/example/img/earth-night.jpg"
-            : "//unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
-        }
+        // Day texture always loads the lib's default material; when the
+        // terminator layer is on, an effect swaps in the day/night shader.
+        globeImageUrl="//unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
         bumpImageUrl="//unpkg.com/three-globe/example/img/earth-topology.png"
         backgroundImageUrl="//unpkg.com/three-globe/example/img/night-sky.png"
         backgroundColor="rgba(0,0,0,0)"
-        atmosphereColor={nightMode ? "#f59e0b" : "#22d3ee"}
+        atmosphereColor={terminator ? "#7dd3fc" : "#22d3ee"}
         atmosphereAltitude={interactive ? 0.18 : 0.16}
+        // Day/Night terminator shader; null ⇒ globe.gl keeps its default material
+        globeMaterial={terminator && shaderMat ? shaderMat : null}
 
         // IOC scatter dots (honest — no arcs)
         pointsData={iocPoints}
         pointLat="lat"
         pointLng="lng"
-        pointAltitude={0.02}
+        pointAltitude={0.025}
         pointRadius={(d: ThreatIoc) => SEV_R[d.severity] * (interactive ? zoomScale : 1)}
         pointColor={(d: ThreatIoc) => IOC_COLOR[d.type]}
         pointResolution={8}
@@ -357,14 +474,14 @@ export function ThreatGlobe({
           </div>`
         }
         onPointHover={(d: ThreatIoc | null) => onIocSelect?.(d ?? null)}
-        onPointClick={(d: ThreatIoc) => onIocSelect?.(d)}
+        onPointClick={(d: ThreatIoc) => (onIocClick ?? onIocSelect)?.(d)}
 
         // Severity pulse rings (critical / high only)
         ringsData={iocRings}
         ringLat="lat"
         ringLng="lng"
         ringColor={(d: ThreatIoc) => SEV_RING[d.severity]}
-        ringMaxRadius={(d: ThreatIoc) => (d.severity === "critical" ? 5.5 : 3.4)}
+        ringMaxRadius={(d: ThreatIoc) => (d.severity === "critical" ? 6.5 : 4.2)}
         ringPropagationSpeed={interactive ? 2.0 : 3.4}
         ringRepeatPeriod={interactive ? 1100 : 620}
 
@@ -404,7 +521,7 @@ export function ThreatGlobe({
         }}
 
         rendererConfig={{ antialias: true, alpha: true, powerPreference: "high-performance" }}
-        enablePointerInteraction={interactive || Boolean(onGlobeClick) || Boolean(onIocSelect)}
+        enablePointerInteraction={interactive || Boolean(onGlobeClick) || Boolean(onIocSelect) || Boolean(onIocClick)}
         onGlobeReady={handleReady}
         onGlobeClick={onGlobeClick}
         onZoom={(pov: { altitude: number }) => {

--- a/lib/assistant/faq.ts
+++ b/lib/assistant/faq.ts
@@ -1,0 +1,359 @@
+/**
+ * Portfolio Assistant — knowledge base + deterministic matcher.
+ *
+ * SECURITY MODEL (important): this is a *rule-based* responder, not an LLM.
+ * Input is treated purely as a lookup key against a fixed intent table — there
+ * is no instruction-following layer, so it cannot be prompt-injected or
+ * jailbroken. Guardrails are evaluated FIRST and SEPARATELY from knowledge
+ * intents, so adversarial input can only ever route to a refusal/hint, never to
+ * data. The site's real secrets (hidden routes, terminal easter eggs, CTF
+ * flags) are deliberately NOT present in this file — the assistant physically
+ * cannot leak what it does not know. It only ever *hints* that a game exists.
+ *
+ * Every fact below is sourced from lib/content/personnel.ts + contact.ts — no
+ * invented claims.
+ */
+
+export interface FaqReply {
+  text: string
+  /** Quick-reply chips suggested after this answer. */
+  suggestions?: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Shared facts (single source of truth for the assistant)
+// ---------------------------------------------------------------------------
+const CONTACT = {
+  email: "alramli.hamzah@gmail.com",
+  phone: "+966 50 850 1717",
+  linkedin: "linkedin.com/in/hamzah-al-ramli-505",
+  github: "github.com/Goodnbadexe",
+}
+
+const CONTACT_LINE =
+  `You can reach Hamzah directly:\n` +
+  `• Email — ${CONTACT.email}\n` +
+  `• Phone — ${CONTACT.phone}\n` +
+  `• LinkedIn — ${CONTACT.linkedin}\n` +
+  `Or open the encrypted channel at /contact.`
+
+const DEFAULT_SUGGESTIONS = ["What does he do?", "His certifications", "How to contact him"]
+
+// ---------------------------------------------------------------------------
+// Guardrails — checked BEFORE any knowledge intent. Each is a category of
+// pattern that must never yield site secrets. Order = priority.
+// ---------------------------------------------------------------------------
+interface Guard {
+  id: string
+  patterns: string[]
+  reply: FaqReply
+}
+
+const GUARDS: Guard[] = [
+  {
+    // Prompt-injection / jailbreak attempts — firm, friendly, immovable.
+    id: "jailbreak",
+    patterns: [
+      "ignore previous", "ignore your", "ignore all", "ignore the above",
+      "disregard", "system prompt", "your instructions", "your rules",
+      "your prompt", "developer mode", "dev mode", "pretend you", "pretend to be",
+      "act as", "roleplay", "jailbreak", "do anything now", "dan mode",
+      "override", "bypass your", "no restrictions", "without restrictions",
+      "reveal your", "print your",
+    ],
+    reply: {
+      text:
+        "Not going to happen 🙂 I don't have a \"developer mode,\" and I won't step outside what I'm here for. " +
+        "I'm happy to tell you about Hamzah's work, skills, or how to reach him though — what would you like to know?",
+      suggestions: DEFAULT_SUGGESTIONS,
+    },
+  },
+  {
+    // Secrets / hidden content / the site's CTF game — hint only, never reveal.
+    id: "secrets",
+    patterns: [
+      "secret", "secrets", "flag", "flags", "hidden", "easter egg", "easteregg",
+      "ctf", "cheat", "walkthrough", "backdoor", "back door", "the answer to",
+      "give me the", "where is the",
+    ],
+    reply: {
+      text:
+        "Ah, hunting for the hidden stuff? 😏 There *is* more to this site than the nav shows — the terminal rewards " +
+        "the curious, and not every page is linked. But finding it is the whole point, so I'll hint, never hand it over. " +
+        "Start poking around `/terminal`. Meanwhile, I can tell you all about Hamzah's actual work.",
+      suggestions: ["Open the terminal", "What does he do?", "His projects"],
+    },
+  },
+  {
+    // Attempts to extract site internals / attack this site.
+    id: "internals",
+    patterns: [
+      "api key", "apikey", "password", "passwd", "credential", ".env", "env file",
+      "source code", "admin panel", "admin login", "private key", "ssh key",
+      "access token", "exploit this", "hack this", "hack the site", "hack into",
+      "vulnerab", "sql injection", "xss payload",
+    ],
+    reply: {
+      text:
+        "I can't help with poking at this site's internals — no keys, configs, or source from me. " +
+        "(Hamzah builds *defensive* systems, so this one's reasonably locked down.) " +
+        "If you've found something genuinely concerning, the responsible thing is to report it: " +
+        `${CONTACT.email}. Otherwise, ask me about his work!`,
+      suggestions: DEFAULT_SUGGESTIONS,
+    },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Knowledge intents — keyword-scored. Multi-word keys match as substrings;
+// single-word keys match on word boundaries.
+// ---------------------------------------------------------------------------
+interface Intent {
+  id: string
+  keywords: string[]
+  reply: FaqReply | (() => FaqReply)
+}
+
+const INTENTS: Intent[] = [
+  {
+    id: "greeting",
+    keywords: ["hi", "hello", "hey", "yo", "good morning", "good evening", "salam", "howdy"],
+    reply: {
+      text:
+        "Hey 👋 I'm the portfolio assistant. I can tell you about Hamzah Al-Ramli — his cybersecurity work, " +
+        "certifications, projects, and how to get in touch. What would you like to know?",
+      suggestions: DEFAULT_SUGGESTIONS,
+    },
+  },
+  {
+    id: "about",
+    keywords: ["who is", "who's", "about him", "about hamzah", "tell me about", "background", "bio", "introduce"],
+    reply: {
+      text:
+        "Hamzah Al-Ramli is a Cybersecurity & Automation Architect based in Riyadh, Saudi Arabia — and also a " +
+        "creative multimedia designer and full-stack developer. He works across threat analysis and malware " +
+        "investigation, brand identity and design, and full-stack builds. The throughline: making things that matter.",
+      suggestions: ["His skills", "His certifications", "Is he available?"],
+    },
+  },
+  {
+    id: "role",
+    keywords: ["what does he do", "what do you do", "role", "title", "position", "profession", "job", "occupation"],
+    reply: {
+      text:
+        "Core role: Cybersecurity & Automation Architect — he builds defensive systems, threat tooling, and the " +
+        "automation that runs them. Alongside that he's a multimedia designer and full-stack developer.",
+      suggestions: ["His cybersecurity skills", "His projects", "Hire / availability"],
+    },
+  },
+  {
+    id: "skills",
+    keywords: ["skill", "skills", "stack", "tech", "technologies", "languages", "expertise", "capable", "good at", "tools"],
+    reply: {
+      text:
+        "Hamzah works across four domains:\n" +
+        "• Cybersecurity — malware analysis, threat intel & OSINT, network security (CCNA), vuln management, incident response\n" +
+        "• Development — Next.js / React / TypeScript, Python, Java, PHP, iOS (Swift) & Android, full-stack apps\n" +
+        "• Creative & multimedia — graphic design, brand identity, video editing (Premiere, Avid), UI/UX\n" +
+        "• Strategy & tools — workflow automation (n8n, AI agents), analytics, SEO, project management",
+      suggestions: ["His certifications", "His projects", "His cybersecurity focus"],
+    },
+  },
+  {
+    id: "cyber",
+    keywords: ["cybersecurity", "cyber security", "malware", "threat", "soc", "blue team", "incident", "osint", "security skills", "infosec"],
+    reply: {
+      text:
+        "On the security side, Hamzah focuses on malware analysis & dynamic investigation, threat intelligence & " +
+        "OSINT, network security (CCNA fundamentals), vulnerability management, and incident response & detection. " +
+        "He's earned hands-on LetsDefend credentials (Dynamic Analyst, Malware Analyzer, First Blood).",
+      suggestions: ["His certifications", "His projects", "Contact him"],
+    },
+  },
+  {
+    id: "certs",
+    keywords: ["cert", "certs", "certificate", "certification", "credential", "qualified", "qualification", "letsdefend", "google cybersecurity", "comptia", "ccna"],
+    reply: {
+      text:
+        "Verified credentials (9):\n" +
+        "• LetsDefend — Dynamic Analyst, Malware Analyzer, First Blood (2025)\n" +
+        "• Google — Cybersecurity Professional Certificate\n" +
+        "• IBM — Cybersecurity Assessment (Security+ & CySA+); Generative AI for Cybersecurity\n" +
+        "• Simplilearn — CCNA 200-301 Network Fundamentals\n" +
+        "• Google Analytics; Taylor's University Award 2024; CASUGOL Advanced Python\n" +
+        "CEH and Security+ are also in progress. Full ledger + verify links: /personnel.",
+      suggestions: ["His skills", "His education", "Contact him"],
+    },
+  },
+  {
+    id: "education",
+    keywords: ["education", "degree", "university", "study", "studied", "college", "school", "academic", "taylor", "graduate"],
+    reply: {
+      text:
+        "Hamzah holds a BSc in Computer Science from Taylor's University, and was a Taylor's University Award " +
+        "recipient (2024). The full education and service record is on the dossier at /personnel.",
+      suggestions: ["His certifications", "His experience", "His projects"],
+    },
+  },
+  {
+    id: "experience",
+    keywords: ["experience", "work history", "employment", "career", "worked", "previous", "service record"],
+    reply: {
+      text:
+        "His service record (work history) and roadmap are laid out on the Personnel dossier — the fastest full " +
+        "picture is the resume. See /personnel, or download the CV (below).",
+      suggestions: ["Download resume", "His projects", "Contact him"],
+    },
+  },
+  {
+    id: "projects",
+    keywords: ["project", "projects", "portfolio", "built", "build", "deployment", "deployments", "work samples", "github", "repo", "repos"],
+    reply: {
+      text:
+        "Hamzah's mission files and architecture write-ups live in the Deployments module — open /deployments. " +
+        `Public code and activity are on GitHub: ${CONTACT.github}.`,
+      suggestions: ["His skills", "His certifications", "Contact him"],
+    },
+  },
+  {
+    id: "hire",
+    keywords: ["hire", "available", "availability", "freelance", "work with", "service", "services", "offer", "consult", "recruiter", "opportunity", "open to"],
+    reply: {
+      text:
+        "Yes — Hamzah is open to work: cybersecurity & threat intelligence, automation/workflow engineering, " +
+        "Next.js/React web platform work, and multimedia design. Remote & on-site across the GCC.\n\n" + CONTACT_LINE,
+      suggestions: ["Contact him", "His skills", "Download resume"],
+    },
+  },
+  {
+    id: "contact",
+    keywords: ["contact", "email", "reach", "get in touch", "phone", "call", "message", "talk to", "connect", "linkedin", "how do i reach"],
+    reply: { text: CONTACT_LINE, suggestions: ["Download resume", "Is he available?", "His projects"] },
+  },
+  {
+    id: "resume",
+    keywords: ["resume", "cv", "download", "curriculum"],
+    reply: {
+      text: "You can download Hamzah's current resume (PDF) here: /files/hamzah-al-ramli-resume.pdf",
+      suggestions: ["Contact him", "His certifications", "His experience"],
+    },
+  },
+  {
+    id: "location",
+    keywords: ["location", "where is he", "where's he", "based", "city", "country", "riyadh", "saudi", "gcc", "relocate", "remote"],
+    reply: {
+      text:
+        "Hamzah is based in Riyadh, Saudi Arabia, and is available for both remote and on-site work across the GCC.",
+      suggestions: ["Is he available?", "Contact him", "His skills"],
+    },
+  },
+  {
+    id: "site",
+    keywords: ["what is this", "what's this", "this site", "this website", "goodnbad", "the os", "globe", "threat globe", "ioc", "what is goodnbad", "how does this work"],
+    reply: {
+      text:
+        "This is goodnbad.exe — Hamzah's portfolio built as a little operating system. The globe is a live cyber-threat " +
+        "monitor: every dot is a real indicator of compromise (C2 servers, malware hosts, phishing, ransomware) " +
+        "geolocated from open threat feeds — honest data, no fake attack arcs. Explore the modules from the launcher.",
+      suggestions: ["His cybersecurity skills", "His projects", "Contact him"],
+    },
+  },
+  {
+    id: "self",
+    keywords: ["who are you", "what are you", "are you ai", "are you a bot", "are you real", "are you an llm", "are you human", "chatgpt", "what model"],
+    reply: {
+      text:
+        "I'm the portfolio assistant — a small, built-in guide to Hamzah's work. I'm not a general AI and I don't " +
+        "browse or run commands; I just answer questions about Hamzah, his skills, and how to reach him. Ask away!",
+      suggestions: DEFAULT_SUGGESTIONS,
+    },
+  },
+  {
+    id: "thanks",
+    keywords: ["thank", "thanks", "thx", "appreciate", "cheers"],
+    reply: {
+      text: "Anytime! If you want, I can point you to his projects or the best way to get in touch.",
+      suggestions: ["His projects", "Contact him"],
+    },
+  },
+  {
+    id: "bye",
+    keywords: ["bye", "goodbye", "see ya", "cya", "later", "good night"],
+    reply: { text: "Take care 👋 Come back anytime — and don't forget to explore the site." },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+function normalize(input: string): string {
+  return ` ${input.toLowerCase().replace(/[^a-z0-9'\s]/g, " ").replace(/\s+/g, " ").trim()} `
+}
+
+/**
+ * True if `key` matches the (space-padded, normalized) text.
+ * Multi-word keys match as substrings. Single words match on word boundaries,
+ * with simple singular/plural tolerance for keys of length >= 4 (so "skill"
+ * matches "skills" and "certification" matches "certifications", while short
+ * tokens like "hi"/"yo" stay exact and don't match "his"/"yos").
+ */
+function hits(norm: string, key: string): boolean {
+  if (key.includes(" ")) return norm.includes(key)
+  if (norm.includes(` ${key} `)) return true
+  if (key.length >= 4) {
+    if (norm.includes(` ${key}s `)) return true // plural of key
+    if (key.endsWith("s") && norm.includes(` ${key.slice(0, -1)} `)) return true // singular of key
+  }
+  return false
+}
+
+const FALLBACK: FaqReply = {
+  text:
+    "I'm not sure I caught that — I keep things simple on purpose. I can tell you about Hamzah's background, " +
+    "skills, certifications, projects, or the best way to reach him. For anything specific, email " +
+    `${CONTACT.email} or open /contact.`,
+  suggestions: DEFAULT_SUGGESTIONS,
+}
+
+/**
+ * answerFor — the single entry point. Guardrails first, then best-scoring
+ * knowledge intent, then a safe fallback. Pure & deterministic (easy to test).
+ */
+export function answerFor(rawInput: string): FaqReply {
+  const norm = normalize(rawInput)
+  if (norm.trim().length === 0) return FALLBACK
+
+  // 1) Guardrails win, in priority order.
+  for (const guard of GUARDS) {
+    if (guard.patterns.some((p) => hits(norm, p))) return guard.reply
+  }
+
+  // 2) Highest-scoring knowledge intent.
+  let best: Intent | null = null
+  let bestScore = 0
+  for (const intent of INTENTS) {
+    let score = 0
+    for (const kw of intent.keywords) {
+      if (hits(norm, kw)) score += kw.includes(" ") ? 2 : 1
+    }
+    if (score > bestScore) {
+      bestScore = score
+      best = intent
+    }
+  }
+
+  if (best && bestScore > 0) {
+    return typeof best.reply === "function" ? best.reply() : best.reply
+  }
+
+  // 3) Safe fallback.
+  return FALLBACK
+}
+
+/** Opening message shown when the panel is first opened. */
+export const GREETING: FaqReply = {
+  text:
+    "Hi — I'm Hamzah's portfolio assistant 🛡️ Ask me about his cybersecurity work, certifications, projects, " +
+    "or how to get in touch. (I keep to those topics on purpose.)",
+  suggestions: ["What does he do?", "His certifications", "Is he available?", "How to contact him"],
+}


### PR DESCRIPTION
## Why production build is failing

Commit `4c24112` (current `main` HEAD, the deploy that errored) added `app/page.tsx` and `components/portfolio-assistant.tsx` written against the **newer** globe/assistant API, but the two supporting files were left on the `feat/globe-readability` branch and never made it onto `main`. So `next build` fails on Vercel:

1. `Module not found: Can't resolve '@/lib/assistant/faq'` — `portfolio-assistant.tsx` imports `answerFor`, `GREETING`, `FaqReply`.
2. `Property 'terminator' does not exist on ThreatGlobe Props` — `page.tsx` passes `terminator` **and** `onIocClick`, but main's `ThreatGlobe` has neither.

## Fix (surgical, 2 files)

- **add** `lib/assistant/faq.ts` — self-contained (zero imports), exports exactly the 3 symbols the component needs.
- **update** `components/signal/ThreatGlobe.tsx` — the reconciled version that declares both `terminator` and `onIocClick`.

Both files are taken from the correctly-reconciled sibling commit `7f04b9a`. I deliberately did **not** merge `feat/globe-readability` — it has diverged since PR #26 and *deletes* ~9k lines (vault PDFs, subscribe segmentation, supabase) that `main` legitimately gained in PRs #31–#37.

## Verification

Reproduced the exact Vercel build locally (`npm install --legacy-peer-deps` + `next build`):
- before: exits 1 on both errors above
- after: **`✓ Compiled successfully` + TypeScript passes, exit 0**

## Test plan
- [x] `next build` green locally
- [ ] Vercel preview deploy green
- [ ] Day/Night terminator toggle + IOC pin/click work on preview

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores two files missing from `main` that were causing Vercel build failures: a new `lib/assistant/faq.ts` (deterministic FAQ matcher for the portfolio assistant) and a reconciled `components/signal/ThreatGlobe.tsx` that adds the `terminator` and `onIocClick` props expected by `app/page.tsx`.

- **`lib/assistant/faq.ts`** — self-contained, zero-import FAQ engine with guardrail-first matching; exports exactly the three symbols (`answerFor`, `GREETING`, `FaqReply`) the consumer component needs.
- **`components/signal/ThreatGlobe.tsx`** — adds a real GLSL day/night terminator shader, replaces `nightMode` with `terminator`, adds a separate `onIocClick` prop, and bumps dot/ring radii for legibility.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the build fix itself, but the FAQ matcher has a word-collision defect that will misdirect real users asking about certifications.

The build-fix goal is achieved and the ThreatGlobe changes are well-structured. However, faq.ts contains a logic defect: the word credential is listed in both the internals security guard and the certifications intent. Because guards run first, any visitor typing what are his credentials receives the security-refusal message instead of the certifications answer.

lib/assistant/faq.ts — the credential keyword appears in both the internals guard and the certs intent, causing incorrect responses for legitimate certification queries.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/assistant/faq.ts | New deterministic FAQ matcher with guardrails and knowledge intents. One logic defect: credential appears in both the internals guard and the certs intent, so legitimate queries like what are his credentials incorrectly trigger the security refusal. |
| components/signal/ThreatGlobe.tsx | Adds day/night terminator shader, onIocClick prop, and resizes dot/ring radii. Shader construction and uniform-drive loop are sound. Loaded textures and ShaderMaterial are never disposed on unmount. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User input] --> B[normalize input]
    B --> C{Guard check}
    C -- jailbreak match --> D[Jailbreak refusal]
    C -- secrets match --> E[Secrets hint]
    C -- internals match also catches credential --> F[Internals refusal]
    C -- no match --> G[Score all intents]
    G --> H{bestScore > 0?}
    H -- yes --> I[Return best intent reply]
    H -- no --> J[FALLBACK reply]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User input] --> B[normalize input]
    B --> C{Guard check}
    C -- jailbreak match --> D[Jailbreak refusal]
    C -- secrets match --> E[Secrets hint]
    C -- internals match also catches credential --> F[Internals refusal]
    C -- no match --> G[Score all intents]
    G --> H{bestScore > 0?}
    H -- yes --> I[Return best intent reply]
    H -- no --> J[FALLBACK reply]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fassistant%2Ffaq.ts%3A93-94%0A**Guard%2Fintent%20keyword%20collision%20on%20%22credential%22**%0A%0AThe%20string%20%60%22credential%22%60%20appears%20in%20both%20%60GUARDS%5B%22internals%22%5D.patterns%60%20%28line%2093%29%20and%20%60INTENTS%5B%22certs%22%5D.keywords%60%20%28line%20175%29.%20Because%20guardrails%20are%20checked%20first%2C%20any%20user%20query%20containing%20%22credentials%22%20triggers%20the%20internals%20guard%20and%20returns%20the%20security-refusal%20message%20instead%20of%20the%20certifications%20answer.%20The%20%60hits%28%29%60%20function's%20plural%20tolerance%20means%20the%20singular%20key%20%60%22credential%22%60%20also%20catches%20the%20plural%20form.%20Users%20asking%20a%20natural%20certification%20question%20will%20be%20told%20the%20assistant%20%22can't%20help%20with%20poking%20at%20this%20site's%20internals.%22%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Fsignal%2FThreatGlobe.tsx%3A389-390%0A**ShaderMaterial%2Ftextures%20never%20disposed%20on%20unmount**%0A%0AThe%20%60THREE.ShaderMaterial%60%20and%20both%20%60THREE.Texture%60%20objects%20%28%60day%60%2C%20%60night%60%29%20are%20allocated%20on%20the%20heap%20and%20registered%20with%20the%20GPU%20driver%2C%20but%20no%20%60dispose%28%29%60%20call%20is%20ever%20made.%20In%20WebGL%20each%20undisposed%20texture%20and%20material%20is%20a%20leak%20in%20the%20GPU%20memory%20pool.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20alive%20%3D%20false%0A%20%20%20%20%20%20setShaderMat%28%28prev%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20if%20%28prev%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%3B%28prev.uniforms.dayTexture%3F.value%20as%20THREE.Texture%20%7C%20null%29%3F.dispose%28%29%0A%20%20%20%20%20%20%20%20%20%20%3B%28prev.uniforms.nightTexture%3F.value%20as%20THREE.Texture%20%7C%20null%29%3F.dispose%28%29%0A%20%20%20%20%20%20%20%20%20%20prev.dispose%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20null%0A%20%20%20%20%20%20%7D%29%0A%20%20%20%20%7D%0A%20%20%7D%2C%20%5Bterminator%2C%20shaderMat%5D%29%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=39&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fbuild-missing-faq-threatglobe%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fbuild-missing-faq-threatglobe%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fassistant%2Ffaq.ts%3A93-94%0A**Guard%2Fintent%20keyword%20collision%20on%20%22credential%22**%0A%0AThe%20string%20%60%22credential%22%60%20appears%20in%20both%20%60GUARDS%5B%22internals%22%5D.patterns%60%20%28line%2093%29%20and%20%60INTENTS%5B%22certs%22%5D.keywords%60%20%28line%20175%29.%20Because%20guardrails%20are%20checked%20first%2C%20any%20user%20query%20containing%20%22credentials%22%20triggers%20the%20internals%20guard%20and%20returns%20the%20security-refusal%20message%20instead%20of%20the%20certifications%20answer.%20The%20%60hits%28%29%60%20function's%20plural%20tolerance%20means%20the%20singular%20key%20%60%22credential%22%60%20also%20catches%20the%20plural%20form.%20Users%20asking%20a%20natural%20certification%20question%20will%20be%20told%20the%20assistant%20%22can't%20help%20with%20poking%20at%20this%20site's%20internals.%22%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Fsignal%2FThreatGlobe.tsx%3A389-390%0A**ShaderMaterial%2Ftextures%20never%20disposed%20on%20unmount**%0A%0AThe%20%60THREE.ShaderMaterial%60%20and%20both%20%60THREE.Texture%60%20objects%20%28%60day%60%2C%20%60night%60%29%20are%20allocated%20on%20the%20heap%20and%20registered%20with%20the%20GPU%20driver%2C%20but%20no%20%60dispose%28%29%60%20call%20is%20ever%20made.%20In%20WebGL%20each%20undisposed%20texture%20and%20material%20is%20a%20leak%20in%20the%20GPU%20memory%20pool.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20alive%20%3D%20false%0A%20%20%20%20%20%20setShaderMat%28%28prev%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20if%20%28prev%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%3B%28prev.uniforms.dayTexture%3F.value%20as%20THREE.Texture%20%7C%20null%29%3F.dispose%28%29%0A%20%20%20%20%20%20%20%20%20%20%3B%28prev.uniforms.nightTexture%3F.value%20as%20THREE.Texture%20%7C%20null%29%3F.dispose%28%29%0A%20%20%20%20%20%20%20%20%20%20prev.dispose%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20null%0A%20%20%20%20%20%20%7D%29%0A%20%20%20%20%7D%0A%20%20%7D%2C%20%5Bterminator%2C%20shaderMat%5D%29%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=39&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(build): add missing lib/assistant/fa..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/1734657a16e46eebd67620bfd3cad1a60059e56b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39401260)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->