### PR TITLE
feat: multi-PDF upsell + all-access cross-sell on /subscribe

### DIFF
--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -11,7 +11,7 @@ import {
   BUILD_STEPS, PRODUCT, PROMO_WINDOW_MS, buildPromoCode, gumroadUrl, gumroadPrice,
 } from "@/lib/subscribe/config"
 import { personalize } from "@/lib/subscribe/personalize"
-import { trackById } from "@/lib/subscribe/tracks"
+import { TRACKS, TRACK_IDS, trackById } from "@/lib/subscribe/tracks"
 
 const ICONS: Record<string, LucideIcon> = {
   user: User, zap: Zap, wrench: Wrench, alert: AlertTriangle, layers: Layers, clock: Clock,
@@ -204,6 +204,11 @@ export default function SubscribePage() {
   const buyUrl = gumroadUrl(selectedTracks, person.osVariant)
   const price = gumroadPrice(selectedTracks)
   const vaultName = person.recommendedBundle === "single" ? `${tracksLabel} Vault` : "All-Access Vault"
+
+  // Upsell: all-access upgrade + other individual tracks not in the recommendation
+  const allAccessUrl = gumroadUrl(TRACK_IDS, person.osVariant)
+  const otherTracks = TRACKS.filter((t) => !selectedTracks.includes(t.id))
+  const showUpsell = selectedTracks.length > 0 && selectedTracks.length < TRACK_IDS.length
 
   return (
     <main className="relative min-h-screen bg-zinc-950 text-zinc-100 pb-24">
@@ -492,8 +497,6 @@ export default function SubscribePage() {
               </div>
             )}
 
-            <p className="text-center font-mono text-[11px] text-emerald-600/80" dir="rtl">{PRODUCT.socialProofAr}</p>
-
             {/* What you get */}
             <div className="space-y-2 rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-4 py-4">
               <p className="mb-1 font-mono text-[10px] uppercase tracking-widest text-zinc-600">what you get · ما تحصل عليه</p>
@@ -511,6 +514,91 @@ export default function SubscribePage() {
             <p className="text-center font-mono text-[10px] text-zinc-700" dir="rtl">
               وصول فوري · دفع آمن عبر Gumroad · instant access
             </p>
+
+            {/* ── UPSELL: other vaults ───────────────────────────────────── */}
+            {showUpsell && (
+              <div className="space-y-3 border-t border-zinc-800/60 pt-5">
+                <p className="text-center font-mono text-[10px] uppercase tracking-widest text-zinc-600">
+                  expand your vault · وسّع خزينتك
+                </p>
+
+                {/* All-access upgrade — always show unless user already matched all tracks */}
+                {allAccessUrl && (
+                  <div className="rounded-xl border border-emerald-900/50 bg-emerald-950/10 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-mono text-[10px] uppercase tracking-widest text-emerald-600/70">
+                          best deal · أفضل صفقة
+                        </p>
+                        <p className="mt-0.5 text-sm font-semibold text-zinc-100">All-Access Vault</p>
+                        <p className="text-xs text-zinc-500" dir="rtl">
+                          كل الـ {TRACK_IDS.length} خزائن — سعر واحد
+                        </p>
+                        <p className="font-mono text-[10px] text-zinc-600">
+                          All {TRACK_IDS.length} vaults · one price
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <p className="font-mono text-[11px] text-zinc-600 line-through">
+                          ${TRACK_IDS.length * 8}
+                        </p>
+                        <p className="font-mono text-xl font-bold text-emerald-300">
+                          $25<span className="text-xs font-normal text-zinc-500">/mo</span>
+                        </p>
+                      </div>
+                    </div>
+                    <a
+                      href={allAccessUrl}
+                      onClick={() => sendLead("gumroad-all", promo)}
+                      data-gumroad-overlay-checkout="true"
+                      className="mt-3 flex w-full items-center justify-center gap-2 rounded-md border border-emerald-700 bg-emerald-950/30 px-4 py-2.5 font-mono text-xs font-semibold uppercase tracking-wide text-emerald-300 transition-all hover:bg-emerald-900/40 hover:text-emerald-200"
+                    >
+                      Upgrade to All-Access <ArrowRight className="h-3.5 w-3.5" />
+                    </a>
+                  </div>
+                )}
+
+                {/* Individual tracks not in the recommendation — show up to 3 */}
+                {otherTracks.slice(0, 3).map((track) => {
+                  const trackUrl = gumroadUrl([track.id], person.osVariant)
+                  return (
+                    <div
+                      key={track.id}
+                      className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900/20 px-4 py-3"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs font-medium text-zinc-300" dir="rtl">
+                          {track.ar}
+                        </p>
+                        <p className="font-mono text-[10px] text-zinc-600 truncate">
+                          {track.tagEn}
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <p className="font-mono text-xs font-bold text-zinc-400">$8<span className="text-[10px] font-normal text-zinc-600">/mo</span></p>
+                      </div>
+                      {trackUrl ? (
+                        <a
+                          href={trackUrl}
+                          onClick={() => sendLead(`gumroad-${track.id}`, promo)}
+                          data-gumroad-overlay-checkout="true"
+                          className="shrink-0 rounded border border-zinc-700 bg-zinc-800/60 px-3 py-1.5 font-mono text-[10px] uppercase tracking-wide text-zinc-400 transition-all hover:border-zinc-500 hover:text-zinc-200"
+                        >
+                          Add
+                        </a>
+                      ) : (
+                        <span className="shrink-0 rounded border border-zinc-800 px-3 py-1.5 font-mono text-[10px] uppercase tracking-wide text-zinc-700">
+                          Soon
+                        </span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            <p className="text-center font-mono text-[11px] text-emerald-600/80" dir="rtl">{PRODUCT.socialProofAr}</p>
+
           </section>
         )}
 


### PR DESCRIPTION
## Summary
Completes the multi-PDF upsell on the `/subscribe` paywall. When a visitor has selected at least one vault track but fewer than all, the page now shows:

- **All-Access upgrade card** — strikes the per-track total (`tracks x $8`) through to **$25/mo**, opens Gumroad overlay checkout, fires the `gumroad-all` lead.
- **Cross-sell rows** for up to 3 remaining tracks (Arabic name + tagline + `$8/mo`), each an "Add" deep-link, or a "Soon" badge when that track has no Gumroad URL yet.

## Why a fresh branch (not the feature branch)
`4ddd5c0` on `feat/vault-personalization` bundled 13 files and is now **stale** vs `main` (missing `4c24112`, the eDEX-UI / IOC-surface refactor). Merging it as-is would revert main's newer work. This PR ports **only** `app/subscribe/page.tsx` onto a fresh branch off `origin/main`, so the diff is exactly the upsell (+91 / -3).

## Deploy effect
Merging triggers a production rebuild that also inlines the 9 `NEXT_PUBLIC_GUMROAD_*` vars already set in Vercel production (AGENTS, CREATIVE x3, ALL x3, SECURITY x2).

## Test plan
- [x] `tsc --noEmit` clean across the whole project
- [ ] `/subscribe`: pick 1 track -> upsell card + cross-sell rows appear; pick all -> upsell hidden
- [ ] All-Access card opens Gumroad overlay at $25/mo
- [ ] "Add" rows deep-link to the correct per-track Gumroad product; track without a URL shows "Soon"

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ports the multi-PDF upsell feature onto a fresh branch off `main`, adding an all-access upgrade card and up to three individual-track cross-sell rows beneath the `/subscribe` paywall when a visitor has selected between 1 and 5 vault tracks.

- **Upsell section** (`showUpsell`) renders when `selectedTracks.length > 0 && < TRACK_IDS.length`, showing a strikethrough `TRACK_IDS.length × $8` → $25/mo all-access card plus up to 3 remaining individual tracks at $8/mo each with Gumroad overlay links (or a \"Soon\" badge when no URL is configured).
- **Logic gap**: `gumroadUrl` maps any selection of 2+ tracks to `GUMROAD.all` and `vaultName` becomes \"All-Access Vault\", so for 2–5 track selections both the primary \"GET MY VAULT\" CTA and the upsell \"Upgrade to All-Access\" card point to the identical Gumroad product — the upgrade prompt is unreachable by definition.
- **Social proof paragraph** was repositioned from above the \"What you get\" block to below the upsell section; no functional change.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The page is functional for single-track selections, but the upsell section misfires for any visitor who picks 2 or more tracks — showing an "Upgrade to All-Access" prompt that links to the exact same product already offered as the primary CTA.

The upsell logic targets 1–5 track selections, but gumroadUrl resolves duo and all-access tiers to GUMROAD.all — the same URL the main GET MY VAULT button already opens. Any user who selected 2+ tracks lands on a page where both the primary CTA and the upsell card point to identical Gumroad products, making the upgrade prompt nonsensical. The individual cross-sell rows for those same users price 3 additional tracks at $8/mo each ($24 combined), visually undercutting the $25 all-access bundle just above. The single-track path works as intended.

app/subscribe/page.tsx — specifically the showUpsell condition and the All-Access upgrade card block inside the upsell section.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/subscribe/page.tsx | Adds all-access upgrade card and individual-track cross-sell rows below the paywall; the showUpsell condition fires for 1–5 tracks but the upgrade card duplicates the main CTA for any selection of 2+ tracks because gumroadUrl already maps duo/all tiers to GUMROAD.all. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User completes quiz] --> B{selectedTracks.length}
    B -->|0| C[No plan shown]
    B -->|1| D[Single-track Vault\nmain CTA → GUMROAD track URL]
    B -->|2| E[All-Access Vault ⚠️\nmain CTA → GUMROAD.all]
    B -->|3-5| F[All-Access Vault ⚠️\nmain CTA → GUMROAD.all]
    B -->|6 all| G[All-Access Vault\nno upsell shown]
    D --> H{showUpsell = true}
    E --> I{showUpsell = true ⚠️}
    F --> J{showUpsell = true ⚠️}
    H --> K[Upgrade to All-Access card\n→ GUMROAD.all ✓ meaningful]
    H --> L[Cross-sell up to 3 tracks @ $8/mo]
    I --> M[Upgrade to All-Access card\n→ GUMROAD.all = same URL as main CTA ✗]
    I --> N[Cross-sell rows @ $8/mo\nundercuts $25 all-access offer ✗]
    J --> O[Upgrade to All-Access card\n→ GUMROAD.all = same URL as main CTA ✗]
    J --> P[Cross-sell rows @ $8/mo\nundercuts $25 all-access offer ✗]
    style M fill:#7f1d1d,color:#fca5a5
    style O fill:#7f1d1d,color:#fca5a5
    style N fill:#78350f,color:#fcd34d
    style P fill:#78350f,color:#fcd34d
    style K fill:#14532d,color:#86efac
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User completes quiz] --> B{selectedTracks.length}
    B -->|0| C[No plan shown]
    B -->|1| D[Single-track Vault\nmain CTA → GUMROAD track URL]
    B -->|2| E[All-Access Vault ⚠️\nmain CTA → GUMROAD.all]
    B -->|3-5| F[All-Access Vault ⚠️\nmain CTA → GUMROAD.all]
    B -->|6 all| G[All-Access Vault\nno upsell shown]
    D --> H{showUpsell = true}
    E --> I{showUpsell = true ⚠️}
    F --> J{showUpsell = true ⚠️}
    H --> K[Upgrade to All-Access card\n→ GUMROAD.all ✓ meaningful]
    H --> L[Cross-sell up to 3 tracks @ $8/mo]
    I --> M[Upgrade to All-Access card\n→ GUMROAD.all = same URL as main CTA ✗]
    I --> N[Cross-sell rows @ $8/mo\nundercuts $25 all-access offer ✗]
    J --> O[Upgrade to All-Access card\n→ GUMROAD.all = same URL as main CTA ✗]
    J --> P[Cross-sell rows @ $8/mo\nundercuts $25 all-access offer ✗]
    style M fill:#7f1d1d,color:#fca5a5
    style O fill:#7f1d1d,color:#fca5a5
    style N fill:#78350f,color:#fcd34d
    style P fill:#78350f,color:#fcd34d
    style K fill:#14532d,color:#86efac
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fsubscribe%2Fpage.tsx%3A209-211%0A**Upgrade%20card%20duplicates%20the%20main%20CTA%20for%202%E2%80%935%20track%20selections**%0A%0AWhen%20a%20user%20selects%202%20or%20more%20tracks%2C%20%60gumroadUrl%28selectedTracks%2C%20os%29%60%20already%20resolves%20to%20%60GUMROAD.all%60%20%28because%20%60tierForTracks%60%20maps%20duo%2Fall%20tiers%20to%20key%20%60%22all%22%60%29%2C%20and%20%60vaultName%60%20becomes%20%60%22All-Access%20Vault%22%60.%20The%20page%20then%20renders%20the%20primary%20%22GET%20MY%20VAULT%22%20button%20pointing%20to%20the%20all-access%20URL%2C%20and%20immediately%20below%20renders%20the%20upsell%20card%20that%20says%20%22Upgrade%20to%20All-Access%22%20linking%20to%20the%20identical%20URL.%20A%20visitor%20who%20picked%202%20tracks%20sees%20two%20CTAs%20for%20the%20exact%20same%20Gumroad%20product%20%E2%80%94%20the%20upgrade%20prompt%20is%20logically%20impossible%20since%20they're%20already%20buying%20all-access.%20%60showUpsell%60%20should%20exclude%20selections%20where%20the%20main%20offer%20is%20already%20all-access%2C%20i.e.%20%60selectedTracks.length%20%3D%3D%3D%201%60%3B%20or%20at%20minimum%20the%20%60allAccessUrl%60%20card%20block%20should%20be%20gated%20on%20%60person.recommendedBundle%20%3D%3D%3D%20%22single%22%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fsubscribe%2Fpage.tsx%3A211%0AThe%20%60showUpsell%60%20guard%20currently%20fires%20for%20any%20selection%20of%201%E2%80%935%20tracks%2C%20but%20the%20All-Access%20upgrade%20card%20is%20only%20meaningful%20when%20the%20user's%20primary%20recommendation%20is%20a%20single-track%20vault%20%281%20track%20selected%29.%20For%202%2B%20tracks%20the%20main%20CTA%20is%20already%20all-access%2C%20so%20the%20%22Upgrade%20to%20All-Access%22%20sub-section%20inside%20the%20upsell%20block%20becomes%20redundant.%20Scoping%20the%20entire%20upsell%20to%20%60selectedTracks.length%20%3D%3D%3D%201%60%20is%20the%20cleanest%20fix%3B%20alternatively%20gate%20just%20the%20upgrade%20card%20on%20%60person.recommendedBundle%20%3D%3D%3D%20%22single%22%60%20if%20you%20still%20want%20cross-sell%20rows%20for%20multi-track%20selections.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Only%20show%20the%20All-Access%20upgrade%20upsell%20when%20the%20primary%20recommendation%20is%20a%0A%20%20%2F%2F%20single-track%20vault%20%E2%80%94%20for%202%2B%20tracks%20gumroadUrl%20already%20resolves%20to%20all-access%2C%0A%20%20%2F%2F%20so%20the%20%22Upgrade%20to%20All-Access%22%20card%20would%20duplicate%20the%20main%20CTA.%0A%20%20const%20showUpsell%20%3D%20selectedTracks.length%20%3D%3D%3D%201%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fsubscribe%2Fpage.tsx%3A562-596%0A**Cross-sell%20row%20pricing%20undercuts%20the%20all-access%20recommendation%20for%20multi-track%20users**%0A%0AEach%20individual%20cross-sell%20row%20offers%20a%20track%20at%20%60%248%2Fmo%60.%20When%20a%20user%20has%20selected%202%20tracks%2C%20they%20are%20already%20being%20recommended%20the%20All-Access%20Vault%20at%20%60%2425%2Fmo%60%20%28all%206%20vaults%29.%20The%20upsell%20section%20then%20surfaces%20up%20to%203%20additional%20tracks%20at%20%60%248%2Fmo%60%20each%20%E2%80%94%20meaning%20a%20visitor%20could%20mentally%20price%20%223%20remaining%20tracks%20I%20care%20about%22%20at%20%60%2424%2Fmo%60%20vs%20the%20%60%2425%60%20all-access%20bundle.%20This%20undercuts%20the%20all-access%20pitch%20and%20may%20reduce%20conversion%20to%20the%20higher-value%20SKU.%20If%20%60showUpsell%60%20is%20scoped%20to%20%60selectedTracks.length%20%3D%3D%3D%201%60%20as%20suggested%20above%2C%20this%20becomes%20moot%3B%20otherwise%20the%20cross-sell%20rows%20should%20be%20hidden%20%28or%20re-priced%29%20when%20the%20primary%20offer%20is%20already%20all-access.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=40&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fsubscribe-upsell%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsubscribe-upsell%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fsubscribe%2Fpage.tsx%3A209-211%0A**Upgrade%20card%20duplicates%20the%20main%20CTA%20for%202%E2%80%935%20track%20selections**%0A%0AWhen%20a%20user%20selects%202%20or%20more%20tracks%2C%20%60gumroadUrl%28selectedTracks%2C%20os%29%60%20already%20resolves%20to%20%60GUMROAD.all%60%20%28because%20%60tierForTracks%60%20maps%20duo%2Fall%20tiers%20to%20key%20%60%22all%22%60%29%2C%20and%20%60vaultName%60%20becomes%20%60%22All-Access%20Vault%22%60.%20The%20page%20then%20renders%20the%20primary%20%22GET%20MY%20VAULT%22%20button%20pointing%20to%20the%20all-access%20URL%2C%20and%20immediately%20below%20renders%20the%20upsell%20card%20that%20says%20%22Upgrade%20to%20All-Access%22%20linking%20to%20the%20identical%20URL.%20A%20visitor%20who%20picked%202%20tracks%20sees%20two%20CTAs%20for%20the%20exact%20same%20Gumroad%20product%20%E2%80%94%20the%20upgrade%20prompt%20is%20logically%20impossible%20since%20they're%20already%20buying%20all-access.%20%60showUpsell%60%20should%20exclude%20selections%20where%20the%20main%20offer%20is%20already%20all-access%2C%20i.e.%20%60selectedTracks.length%20%3D%3D%3D%201%60%3B%20or%20at%20minimum%20the%20%60allAccessUrl%60%20card%20block%20should%20be%20gated%20on%20%60person.recommendedBundle%20%3D%3D%3D%20%22single%22%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fsubscribe%2Fpage.tsx%3A211%0AThe%20%60showUpsell%60%20guard%20currently%20fires%20for%20any%20selection%20of%201%E2%80%935%20tracks%2C%20but%20the%20All-Access%20upgrade%20card%20is%20only%20meaningful%20when%20the%20user's%20primary%20recommendation%20is%20a%20single-track%20vault%20%281%20track%20selected%29.%20For%202%2B%20tracks%20the%20main%20CTA%20is%20already%20all-access%2C%20so%20the%20%22Upgrade%20to%20All-Access%22%20sub-section%20inside%20the%20upsell%20block%20becomes%20redundant.%20Scoping%20the%20entire%20upsell%20to%20%60selectedTracks.length%20%3D%3D%3D%201%60%20is%20the%20cleanest%20fix%3B%20alternatively%20gate%20just%20the%20upgrade%20card%20on%20%60person.recommendedBundle%20%3D%3D%3D%20%22single%22%60%20if%20you%20still%20want%20cross-sell%20rows%20for%20multi-track%20selections.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Only%20show%20the%20All-Access%20upgrade%20upsell%20when%20the%20primary%20recommendation%20is%20a%0A%20%20%2F%2F%20single-track%20vault%20%E2%80%94%20for%202%2B%20tracks%20gumroadUrl%20already%20resolves%20to%20all-access%2C%0A%20%20%2F%2F%20so%20the%20%22Upgrade%20to%20All-Access%22%20card%20would%20duplicate%20the%20main%20CTA.%0A%20%20const%20showUpsell%20%3D%20selectedTracks.length%20%3D%3D%3D%201%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fsubscribe%2Fpage.tsx%3A562-596%0A**Cross-sell%20row%20pricing%20undercuts%20the%20all-access%20recommendation%20for%20multi-track%20users**%0A%0AEach%20individual%20cross-sell%20row%20offers%20a%20track%20at%20%60%248%2Fmo%60.%20When%20a%20user%20has%20selected%202%20tracks%2C%20they%20are%20already%20being%20recommended%20the%20All-Access%20Vault%20at%20%60%2425%2Fmo%60%20%28all%206%20vaults%29.%20The%20upsell%20section%20then%20surfaces%20up%20to%203%20additional%20tracks%20at%20%60%248%2Fmo%60%20each%20%E2%80%94%20meaning%20a%20visitor%20could%20mentally%20price%20%223%20remaining%20tracks%20I%20care%20about%22%20at%20%60%2424%2Fmo%60%20vs%20the%20%60%2425%60%20all-access%20bundle.%20This%20undercuts%20the%20all-access%20pitch%20and%20may%20reduce%20conversion%20to%20the%20higher-value%20SKU.%20If%20%60showUpsell%60%20is%20scoped%20to%20%60selectedTracks.length%20%3D%3D%3D%201%60%20as%20suggested%20above%2C%20this%20becomes%20moot%3B%20otherwise%20the%20cross-sell%20rows%20should%20be%20hidden%20%28or%20re-priced%29%20when%20the%20primary%20offer%20is%20already%20all-access.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=40&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: multi-PDF upsell + all-access cros..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/6bdc524921a83616f725efd223d4b9babcdcbf06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39403415)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->