### PR TITLE
fix(home): side-by-side signal/IOC + Arabic i18n on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { OSDesktop, OSTaskbar, AmbientFeed } from "@/components/os"
 import { cn } from "@/lib/utils"
 import type { FeedEntry } from "@/components/os"
 import type { ThreatIoc } from "@/app/api/threats/route"
+import { useLanguage } from "@/components/language-provider"
 import { IocInspector } from "@/components/signal/IocInspector"
 import { MobileSignalOverlay } from "@/components/signal/MobileSignalOverlay"
 import { GlobeLegend } from "@/components/signal/GlobeLegend"
@@ -47,14 +48,6 @@ const MODULE_ITEMS: { href: string; code: string; label: string; sub: string; Ic
   { href: "/signal",      code: "03", label: "SIGNAL",      sub: "Live activity · Feed",         Icon: Radio    },
   { href: "/contact",     code: "04", label: "CONTACT",     sub: "Encrypted channel",            Icon: Mail     },
   { href: "/terminal",    code: "05", label: "TERMINAL",    sub: "Command interface",            Icon: Terminal },
-]
-
-// Hero credential chips
-const HERO_META = [
-  "CEH (pursuing)",
-  "Security+ (pursuing)",
-  "Google Cybersecurity",
-  "BSc CS · Taylor's University",
 ]
 
 // All layer labels (used to seed the default active set)
@@ -151,6 +144,7 @@ interface LayerPanelProps {
 }
 
 function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
+  const { t } = useLanguage()
   const [expanded, setExpanded] = useState(false)
 
   return (
@@ -163,7 +157,7 @@ function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
           className="flex items-center gap-2 rounded border border-zinc-800 bg-zinc-950/70 px-3 py-1.5 font-mono text-[9px] uppercase tracking-widest text-zinc-500 backdrop-blur-sm transition-all hover:border-zinc-700 hover:text-zinc-300"
         >
           <Layers className="h-3 w-3" />
-          LAYERS
+          {t("الطبقات", "LAYERS")}
           <span className="ml-1 text-[8px] text-zinc-600">
             {activeLayers.size}/{ALL_LAYER_LABELS.length}
           </span>
@@ -181,7 +175,7 @@ function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
           <div className="flex items-center justify-between border-b border-zinc-800/80 px-3 py-2">
             <div className="flex items-center gap-2">
               <Layers className="h-3 w-3 text-zinc-500" />
-              <span className="font-mono text-[9px] uppercase tracking-widest text-zinc-500">World Layers</span>
+              <span className="font-mono text-[9px] uppercase tracking-widest text-zinc-500">{t("طبقات العالم", "World Layers")}</span>
             </div>
             <button
               type="button"
@@ -326,6 +320,27 @@ function LiveAttacksStrip({ iocs }: { iocs: ThreatIoc[] }) {
 // Page
 // ---------------------------------------------------------------------------
 export default function HomePage() {
+  const { t, dir } = useLanguage()
+
+  // Localized hero credential chips — cert names stay as proper nouns; only the
+  // human-readable qualifiers translate.
+  const heroMeta = [
+    t("CEH (قيد الدراسة)", "CEH (pursuing)"),
+    t("Security+ (قيد الدراسة)", "Security+ (pursuing)"),
+    "Google Cybersecurity",
+    t("بكالوريوس علوم حاسب · جامعة تايلورز", "BSc CS · Taylor's University"),
+  ]
+
+  // Localized module descriptions, keyed by route. The uppercase module labels
+  // (PERSONNEL, SIGNAL…) stay as terminal-style codes; only the sub-line is prose.
+  const moduleSub: Record<string, string> = {
+    "/personnel":   t("ملف · سيرة ذاتية · تصريح",   "Dossier · CV · Clearance"),
+    "/deployments": t("ملفات المهام · المعمارية",    "Mission files · Architecture"),
+    "/signal":      t("نشاط حيّ · موجز",             "Live activity · Feed"),
+    "/contact":     t("قناة مشفّرة",                 "Encrypted channel"),
+    "/terminal":    t("واجهة الأوامر",               "Command interface"),
+  }
+
   const [liveEntries,  setLiveEntries]  = useState<FeedEntry[]>([])
   const [recentIocs,   setRecentIocs]   = useState<ThreatIoc[]>([])
   const [hoveredIoc,   setHoveredIoc]   = useState<ThreatIoc | null>(null)
@@ -508,7 +523,7 @@ export default function HomePage() {
             className="flex items-center gap-2 rounded border border-emerald-900 bg-zinc-950/70 px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-emerald-400 backdrop-blur-md transition-all hover:border-emerald-700 hover:bg-emerald-950/40"
           >
             <Maximize2 className="h-3.5 w-3.5" />
-            Inspect Globe
+            {t("فحص الكرة الأرضية", "Inspect Globe")}
           </button>
           {/* On-globe legend + live indicator counter (color key · count · feeds) */}
           <div className="hidden lg:block">
@@ -524,7 +539,7 @@ export default function HomePage() {
           className="fixed right-4 top-16 z-40 flex items-center gap-2 rounded border border-zinc-800 bg-zinc-950/75 px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-zinc-400 backdrop-blur-md transition-colors hover:border-zinc-600 hover:text-zinc-200"
         >
           <X className="h-3.5 w-3.5" />
-          exit globe preview
+          {t("خروج من معاينة الكرة", "exit globe preview")}
         </button>
       )}
 
@@ -542,11 +557,11 @@ export default function HomePage() {
 
         {/* ── HERO IDENTITY ─────────────────────────────────── */}
         <section className={wrap(globeInspect, globeInspect ? "pt-4 pb-3" : "pt-[9vh] pb-[7vh]")}>
-          <div className="w-full pointer-events-auto">
+          <div className="w-full pointer-events-auto" dir={dir}>
             {/* Kicker */}
             <span className="inline-flex items-center gap-2.5 mb-[30px] rounded-[5px] border border-zinc-800 bg-zinc-900/50 px-3.5 py-[7px] font-mono text-[11px] uppercase tracking-[0.26em] text-zinc-400 backdrop-blur-sm">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_theme(colors.emerald.500)]" />
-              SUBJECT VERIFIED · RIYADH, SA
+              {t("تم التحقق من الهوية · الرياض، السعودية", "SUBJECT VERIFIED · RIYADH, SA")}
             </span>
 
             {/* Identity — display scale (sized to fit the left column), restrained
@@ -564,13 +579,13 @@ export default function HomePage() {
               className="mt-[26px] max-w-[48ch] leading-[1.5] text-zinc-300"
               style={{ fontSize: globeInspect ? "1rem" : "clamp(17px, 2vw, 21px)" }}
             >
-              Hamzah Al-Ramli — <span className="font-semibold text-zinc-100">Cybersecurity &amp; Automation Architect.</span>{" "}
-              I build defensive systems, threat tooling, and the automation that runs them.
+              {t("حمزة الرملي — ", "Hamzah Al-Ramli — ")}<span className="font-semibold text-zinc-100">{t("مهندس أمن سيبراني وأتمتة.", "Cybersecurity & Automation Architect.")}</span>{" "}
+              {t("أبني الأنظمة الدفاعية وأدوات رصد التهديدات والأتمتة التي تُشغّلها.", "I build defensive systems, threat tooling, and the automation that runs them.")}
             </p>
 
             {/* Credential chips */}
             <div className="mt-[22px] flex flex-wrap gap-2.5 font-mono text-[11px] text-zinc-400">
-              {HERO_META.map((m) => (
+              {heroMeta.map((m) => (
                 <span key={m} className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
                   {m}
                 </span>
@@ -584,13 +599,13 @@ export default function HomePage() {
                 className="inline-flex items-center gap-2.5 rounded-md bg-emerald-500 px-6 py-3.5 font-mono text-[13px] font-semibold uppercase tracking-[0.1em] text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
               >
                 <Mail className="h-4 w-4" />
-                Open encrypted channel
+                {t("افتح قناة مشفّرة", "Open encrypted channel")}
               </Link>
               <Link
                 href="/personnel"
                 className="inline-flex items-center gap-2.5 rounded-md border border-zinc-800 bg-zinc-950/40 px-6 py-3.5 font-mono text-[13px] font-medium uppercase tracking-[0.1em] text-zinc-300 backdrop-blur-sm transition-all hover:border-zinc-600 hover:text-zinc-100"
               >
-                View full dossier
+                {t("عرض الملف الكامل", "View full dossier")}
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </div>
@@ -622,7 +637,7 @@ export default function HomePage() {
                     <Icon className="h-[19px] w-[19px]" />
                   </div>
                   <div className="font-mono text-sm font-semibold tracking-wide text-zinc-100">{label}</div>
-                  <div className="mt-1.5 font-mono text-[11px] leading-[1.5] text-zinc-500">{sub}</div>
+                  <div className="mt-1.5 font-mono text-[11px] leading-[1.5] text-zinc-500" dir={dir}>{moduleSub[href] ?? sub}</div>
                 </Link>
               ))}
             </div>
@@ -642,17 +657,23 @@ export default function HomePage() {
                 <span className="ml-auto text-zinc-500">live · ambient</span>
               </div>
               <div className="px-4 py-4">
-                <AmbientFeed
-                  entries={STATIC_ENTRIES}
-                  liveEntries={liveEntries}
-                  interval={8000}
-                  maxLines={6}
-                />
+                {/* Feed + IOC surface sit SIDE BY SIDE (50/50) on md+; they stack
+                    on mobile. Left = live signal feed, right = live IOC surface. */}
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5">
+                  <div className="min-w-0">
+                    <AmbientFeed
+                      entries={STATIC_ENTRIES}
+                      liveEntries={liveEntries}
+                      interval={8000}
+                      maxLines={6}
+                    />
+                  </div>
 
-                {/* Live IOC surface — docked here beside the signal feed
-                    (was a floating right-edge rail). Click a row to inspect. */}
-                <div className="mt-4 border-t border-zinc-900 pt-3.5">
-                  <IocInspector placement="inline" recent={recentIocs} hovered={hoveredIoc} pinned={pinnedIoc} onPin={setPinnedIoc} onClose={() => setGlobeInspect(false)} />
+                  {/* Live IOC surface — docked beside the signal feed (was a
+                      floating right-edge rail). Click a row to inspect. */}
+                  <div className="min-w-0 border-t border-zinc-900 pt-3.5 md:border-l md:border-t-0 md:pl-5 md:pt-0">
+                    <IocInspector placement="inline" recent={recentIocs} hovered={hoveredIoc} pinned={pinnedIoc} onPin={setPinnedIoc} onClose={() => setGlobeInspect(false)} />
+                  </div>
                 </div>
 
                 <div className="mt-4 border-t border-zinc-900 pt-3.5">
@@ -661,7 +682,7 @@ export default function HomePage() {
                     className="flex items-center gap-1.5 font-mono text-[12px] text-zinc-500 transition-colors hover:text-emerald-500"
                   >
                     <ArrowRight className="h-3 w-3" />
-                    open full signal feed
+                    {t("افتح موجز الإشارة الكامل", "open full signal feed")}
                   </Link>
                 </div>
               </div>
@@ -683,7 +704,7 @@ export default function HomePage() {
         <div className="px-4">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-3">
             <span className="font-mono text-[10px] text-zinc-700 uppercase tracking-widest">
-              GOODNBAD.EXE © {new Date().getFullYear()} — live cyberattack monitor
+              GOODNBAD.EXE © {new Date().getFullYear()} — {t("مراقب الهجمات السيبرانية الحيّة", "live cyberattack monitor")}
             </span>
             <div className="flex items-center gap-4">
               {[


### PR DESCRIPTION
## What

Two landing-page (`app/page.tsx`) fixes you flagged:

### 1. Signal feed renders 50/50 horizontal (was vertical)
The signal strip stacked `AmbientFeed` on top of the `IocInspector` in a single column. Now they sit **side-by-side (50/50) on `md+`** with a vertical divider, and still stack on mobile with a horizontal divider.

### 2. Arabic now works on the home page
The home page was never wired into the `LanguageProvider` i18n the sibling pages (about/news/contact/deployments/personnel) already use — so the toggle had nothing to translate. Added `useLanguage()` and localized the **human-readable copy** via `t("عربي","en")` + `dir`:
- hero kicker, role line, credential qualifiers, CTAs
- module descriptions (keyed by route)
- globe controls (Inspect Globe, exit preview, World Layers, LAYERS)
- "open full signal feed" + footer tagline

**Intentionally kept in English** (brand / terminal codes / identifiers): `os.modules`, `signal.feed`, `C2 SERVER`, the uppercase module labels, and the globe layer labels (those are `Set` identifiers persisted to localStorage — translating them would break persistence and the day/night terminator toggle).

## Test plan
- [x] `npm run build` green (exit 0)
- [ ] Toggle to Arabic on `/` → hero/modules/footer read RTL Arabic; globe stays anchored right
- [ ] Resize: feed + IOC sit side-by-side ≥768px, stack <768px

## Note (out of scope, found while here)
The "open full signal feed" link and the `SIGNAL` module both point to `/signal`, which **doesn't exist** (only `app/api/signal-feed/route.ts`) — it 404s. There's an orphaned `components/signal/SignalPageLayout.tsx` that looks built for exactly that route. Happy to wire it up in a follow-up.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes two focused fixes to `app/page.tsx`: it refactors the signal strip so `AmbientFeed` and `IocInspector` render side-by-side at `md+` using a two-column CSS grid, and it wires `useLanguage()` into both `HomePage` and `LayerPanel` to deliver full Arabic i18n on the landing page (hero copy, module descriptions, globe controls, and footer tagline).

- The side-by-side layout uses `grid-cols-1 / md:grid-cols-2` with `min-w-0` overflow guards and switches the divider from horizontal to vertical on wider viewports.
- Arabic localisation correctly scopes `dir={dir}` to the hero wrapper and module sub-lines, keeps terminal identifiers in English to preserve localStorage persistence, and delegates global `<html dir>` to the existing `LanguageProvider` in the root layout.
- Two minor polish gaps: the `<ArrowRight>` icon in the "View full dossier" CTA doesn't mirror for RTL, and credential-chip keys use translated strings causing full remounts on each language toggle.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are UI-only, touch a single file, and the i18n integration correctly reuses the existing LanguageProvider already in the root layout.

Both changes are self-contained and low-risk. The layout refactor is structurally sound and the Arabic wiring follows the same pattern used on sibling pages. The two findings are cosmetic: the ArrowRight icon points the wrong way in RTL, and credential chips remount instead of updating on language toggle.

Only app/page.tsx changed; the RTL arrow and chip key issues are both in the hero section of that file.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/page.tsx | Adds side-by-side Signal/IOC grid layout and wires up `useLanguage()` for Arabic i18n on the home page. The layout change is clean; a directional icon in an RTL CTA is worth addressing. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    LP[LanguageProvider\nroot layout] -->|lang / dir / t| HP[HomePage\nuseLanguage]
    LP -->|lang / dir / t| LayerPanel[LayerPanel\nuseLanguage]
    HP -->|dir prop| HeroDiv["Hero wrapper div dir={dir}"]
    HP -->|dir prop| ModuleSub["Module sub-desc div dir={dir}"]
    HP -->|t calls| heroMeta["heroMeta credential chips"]
    HP -->|t calls| moduleSub["moduleSub per-route descriptions"]
    HP -->|t calls| GlobalCopy["Globe controls and footer copy"]
    LayerPanel -->|t calls| LayerButtons["LAYERS pill and World Layers header"]
    subgraph SignalStrip["Signal Strip side-by-side md+"]
        AmbientFeed["AmbientFeed left column"]
        IocInspector["IocInspector right column"]
    end
    HP --> SignalStrip
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    LP[LanguageProvider\nroot layout] -->|lang / dir / t| HP[HomePage\nuseLanguage]
    LP -->|lang / dir / t| LayerPanel[LayerPanel\nuseLanguage]
    HP -->|dir prop| HeroDiv["Hero wrapper div dir={dir}"]
    HP -->|dir prop| ModuleSub["Module sub-desc div dir={dir}"]
    HP -->|t calls| heroMeta["heroMeta credential chips"]
    HP -->|t calls| moduleSub["moduleSub per-route descriptions"]
    HP -->|t calls| GlobalCopy["Globe controls and footer copy"]
    LayerPanel -->|t calls| LayerButtons["LAYERS pill and World Layers header"]
    subgraph SignalStrip["Signal Strip side-by-side md+"]
        AmbientFeed["AmbientFeed left column"]
        IocInspector["IocInspector right column"]
    end
    HP --> SignalStrip
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/page.tsx`, line 588-592 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/3413c6c2745a98bd5b6c26794eb59e50f672f073/app/page.tsx#L588-L592)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Translated strings as React keys cause full remounts on language switch**

   `heroMeta.map((m) => <span key={m}>)` uses the translated string itself as the key. Toggling to Arabic replaces every key (e.g., `"CEH (pursuing)"` → `"CEH (قيد الدراسة)"`), so React unmounts and remounts all four chips on each toggle instead of updating in place. Using stable index-based keys avoids this.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20588-592%0A%0AComment%3A%0A**Translated%20strings%20as%20React%20keys%20cause%20full%20remounts%20on%20language%20switch**%0A%0A%60heroMeta.map%28%28m%29%20%3D%3E%20%3Cspan%20key%3D%7Bm%7D%3E%29%60%20uses%20the%20translated%20string%20itself%20as%20the%20key.%20Toggling%20to%20Arabic%20replaces%20every%20key%20%28e.g.%2C%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20so%20React%20unmounts%20and%20remounts%20all%20four%20chips%20on%20each%20toggle%20instead%20of%20updating%20in%20place.%20Using%20stable%20index-based%20keys%20avoids%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhome-signal-5050-and-arabic-i18n%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhome-signal-5050-and-arabic-i18n%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20588-592%0A%0AComment%3A%0A**Translated%20strings%20as%20React%20keys%20cause%20full%20remounts%20on%20language%20switch**%0A%0A%60heroMeta.map%28%28m%29%20%3D%3E%20%3Cspan%20key%3D%7Bm%7D%3E%29%60%20uses%20the%20translated%20string%20itself%20as%20the%20key.%20Toggling%20to%20Arabic%20replaces%20every%20key%20%28e.g.%2C%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20so%20React%20unmounts%20and%20remounts%20all%20four%20chips%20on%20each%20toggle%20instead%20of%20updating%20in%20place.%20Using%20stable%20index-based%20keys%20avoids%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fpage.tsx%3A588-592%0A**Translated%20strings%20as%20React%20keys%20cause%20full%20remounts%20on%20language%20switch**%0A%0A%60heroMeta.map%28%28m%29%20%3D%3E%20%3Cspan%20key%3D%7Bm%7D%3E%29%60%20uses%20the%20translated%20string%20itself%20as%20the%20key.%20Toggling%20to%20Arabic%20replaces%20every%20key%20%28e.g.%2C%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20so%20React%20unmounts%20and%20remounts%20all%20four%20chips%20on%20each%20toggle%20instead%20of%20updating%20in%20place.%20Using%20stable%20index-based%20keys%20avoids%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fpage.tsx%3A604-610%0A**Directional%20icon%20doesn't%20mirror%20in%20RTL**%0A%0A%60%3CArrowRight%3E%60%20is%20a%20directional%20icon.%20With%20%60dir%3D%22rtl%22%60%20on%20the%20parent%2C%20flexbox%20reverses%20the%20visual%20order%20so%20the%20icon%20appears%20on%20the%20*left*%20of%20the%20text%20%E2%80%94%20but%20the%20SVG%20itself%20still%20points%20right%20%28%E2%86%92%29.%20In%20RTL%20conventions%20a%20forward-navigation%20cue%20should%20point%20left%20%28%E2%86%90%29.%20The%20mismatch%20gives%20Arabic%20readers%20an%20inconsistent%20signal%20at%20this%20secondary%20CTA.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CLink%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20href%3D%22%2Fpersonnel%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22inline-flex%20items-center%20gap-2.5%20rounded-md%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-6%20py-3.5%20font-mono%20text-%5B13px%5D%20font-medium%20uppercase%20tracking-%5B0.1em%5D%20text-zinc-300%20backdrop-blur-sm%20transition-all%20hover%3Aborder-zinc-600%20hover%3Atext-zinc-100%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%B9%D8%B1%D8%B6%20%D8%A7%D9%84%D9%85%D9%84%D9%81%20%D8%A7%D9%84%D9%83%D8%A7%D9%85%D9%84%22%2C%20%22View%20full%20dossier%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CArrowRight%20className%3D%7Bcn%28%22h-4%20w-4%22%2C%20dir%20%3D%3D%3D%20%22rtl%22%20%26%26%20%22rotate-180%22%29%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FLink%3E%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhome-signal-5050-and-arabic-i18n%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhome-signal-5050-and-arabic-i18n%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fpage.tsx%3A588-592%0A**Translated%20strings%20as%20React%20keys%20cause%20full%20remounts%20on%20language%20switch**%0A%0A%60heroMeta.map%28%28m%29%20%3D%3E%20%3Cspan%20key%3D%7Bm%7D%3E%29%60%20uses%20the%20translated%20string%20itself%20as%20the%20key.%20Toggling%20to%20Arabic%20replaces%20every%20key%20%28e.g.%2C%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20so%20React%20unmounts%20and%20remounts%20all%20four%20chips%20on%20each%20toggle%20instead%20of%20updating%20in%20place.%20Using%20stable%20index-based%20keys%20avoids%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fpage.tsx%3A604-610%0A**Directional%20icon%20doesn't%20mirror%20in%20RTL**%0A%0A%60%3CArrowRight%3E%60%20is%20a%20directional%20icon.%20With%20%60dir%3D%22rtl%22%60%20on%20the%20parent%2C%20flexbox%20reverses%20the%20visual%20order%20so%20the%20icon%20appears%20on%20the%20*left*%20of%20the%20text%20%E2%80%94%20but%20the%20SVG%20itself%20still%20points%20right%20%28%E2%86%92%29.%20In%20RTL%20conventions%20a%20forward-navigation%20cue%20should%20point%20left%20%28%E2%86%90%29.%20The%20mismatch%20gives%20Arabic%20readers%20an%20inconsistent%20signal%20at%20this%20secondary%20CTA.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CLink%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20href%3D%22%2Fpersonnel%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22inline-flex%20items-center%20gap-2.5%20rounded-md%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-6%20py-3.5%20font-mono%20text-%5B13px%5D%20font-medium%20uppercase%20tracking-%5B0.1em%5D%20text-zinc-300%20backdrop-blur-sm%20transition-all%20hover%3Aborder-zinc-600%20hover%3Atext-zinc-100%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%B9%D8%B1%D8%B6%20%D8%A7%D9%84%D9%85%D9%84%D9%81%20%D8%A7%D9%84%D9%83%D8%A7%D9%85%D9%84%22%2C%20%22View%20full%20dossier%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CArrowRight%20className%3D%7Bcn%28%22h-4%20w-4%22%2C%20dir%20%3D%3D%3D%20%22rtl%22%20%26%26%20%22rotate-180%22%29%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FLink%3E%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(home): side-by-side signal/IOC + Ara..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/3413c6c2745a98bd5b6c26794eb59e50f672f073) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39470850)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->