### PR TITLE
fix(home): align OS module strip, globe anchor & veil for legibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -483,7 +483,7 @@ export default function HomePage() {
             ? "radial-gradient(120% 80% at 50% 34%, rgba(9,9,11,0.18) 0%, rgba(9,9,11,0.88) 80%)"
             : globeInspect
               ? "radial-gradient(ellipse 80% 75% at 38% 50%, rgba(9,9,11,0.08) 0%, rgba(9,9,11,0.5) 100%)"
-              : "radial-gradient(120% 90% at 76% 42%, rgba(9,9,11,0) 0%, rgba(9,9,11,0.35) 55%, rgba(9,9,11,0.86) 100%), linear-gradient(90deg, rgba(9,9,11,0.92) 0%, rgba(9,9,11,0.55) 38%, rgba(9,9,11,0) 70%)",
+              : "radial-gradient(120% 90% at 76% 42%, rgba(9,9,11,0) 0%, rgba(9,9,11,0.35) 55%, rgba(9,9,11,0.86) 100%), linear-gradient(90deg, rgba(9,9,11,0.92) 0%, rgba(9,9,11,0.55) 38%, rgba(9,9,11,0.12) 72%, rgba(9,9,11,0) 82%)",
         }}
       />
 
@@ -602,7 +602,7 @@ export default function HomePage() {
             a full-width left-anchored STRIP — one horizontal row of all five
             modules on desktop. It deliberately overlays the globe on the right
             (cards keep backdrop-blur so they stay legible). */}
-        <section className={globeInspect ? wrap(true, "pb-12") : "w-full mr-auto px-5 sm:px-8 lg:pl-20 lg:pr-8 pb-12"}>
+        <section className={globeInspect ? wrap(true, "pb-12") : "w-full px-5 sm:px-8 lg:pl-20 lg:pr-0 lg:max-w-[68vw] xl:max-w-[66vw] pb-12"}>
           <div className={cn(globeInspect && "w-full pointer-events-auto")}>
             <div className="mb-4 flex items-center gap-3.5 font-mono text-[12px] uppercase tracking-[0.22em] text-zinc-500">
               <span>os.modules</span>

--- a/components/signal/ThreatGlobe.tsx
+++ b/components/signal/ThreatGlobe.tsx
@@ -439,7 +439,7 @@ export function ThreatGlobe({
   return (
     <div
       aria-hidden={!interactive}
-      className={rightAligned ? "absolute top-1/2 left-1/2 lg:left-[72%]" : "absolute top-1/2 left-1/2"}
+      className={rightAligned ? "absolute top-1/2 left-1/2 md:left-[58%] lg:left-[68%]" : "absolute top-1/2 left-1/2"}
       style={{ width: w, height: h, transform: globeOffset }}
     >
       <Globe


### PR DESCRIPTION
## What
Fixes the Goodnbad OS homepage concept: horizontal module layout + globe positioning (second-brain commitment).

The left-dark veil faded to transparent at **70%** while the globe centered at **lg:left-[72%]**, so module cards in the right half washed out against the globe glow, and on screens >1440px the strip ran past the globe seam.

## Changes (CSS/layout only)
- **Veil**: extend the 90deg gradient — soft 12% haze at 72%, fade to 0 at 82% (backs the cards without hiding the globe).
- **Module strip**: cap at `lg:max-w-[68vw]` / `xl:max-w-[66vw]`, drop the right padding so the last card ends on the globe seam.
- **Globe anchor**: `md:left-[58%] lg:left-[68%]` so the strip edge and globe co-align (and tablet no longer centers the globe behind the cards).

No logic or data changes.

## Test plan
- [ ] Visual check at 768 / 1024 / 1440 / 1920 — cards legible, no gap/overrun, globe seam aligns
- [ ] `globeInspect` mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CSS-only layout fix aligning the homepage OS module strip, globe anchor, and dark veil so cards remain legible against the globe glow across all breakpoints.

- **Veil**: the `linear-gradient` now adds a soft 12% haze at 72% before fading to transparent at 82%, giving the right-half cards a readable backdrop without obscuring the globe.
- **Module strip**: `lg:pr-8` and `mr-auto` are dropped in favour of `lg:max-w-[68vw] xl:max-w-[66vw]`, capping the strip so its right edge co-aligns with the globe centre at every large-screen breakpoint.
- **Globe anchor**: gains an intermediate `md:left-[58%]` stop so the globe no longer sits directly behind the cards on tablet; `lg:left-[68%]` (down from 72%) pulls the globe seam inward to match the new strip width.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Pure CSS/layout change with no logic or data modifications — safe to merge once visual QA passes at the listed breakpoints.

All three changes are internally consistent and match the stated goals. The only gap is the tablet range (768–1023 px) where the globe shifts to 58% but the module strip has no corresponding width cap, leaving the rightmost cards relying solely on backdrop-blur against the globe glow — a minor visual inconsistency rather than a functional breakage.

The module strip section in `app/page.tsx` (line 605) deserves a second look at the `md` breakpoint.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/page.tsx | Veil gradient extended to 82% opacity stop, module strip gains lg:max-w-[68vw]/xl:max-w-[66vw] cap and drops lg:pr-8 and mr-auto; changes are consistent and intentional |
| components/signal/ThreatGlobe.tsx | Globe anchor updated from lg:left-[72%] to md:left-[58%] lg:left-[68%]; adds an intermediate tablet position for better separation from left-side content |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Breakpoints["Responsive layout (non-inspect mode)"]
        A["< md (mobile)"] --> A1["Veil: radial only\nGlobe: left-1/2 (centered)\nStrip: full width, px-5"]
        B["md – lg (tablet)"] --> B1["Veil: full gradient\nGlobe: md:left-58% NEW\nStrip: full width, sm:px-8"]
        C["lg – xl (desktop)"] --> C1["Veil: full gradient\nGlobe: lg:left-68% was 72%\nStrip: max-w-68vw, pr-0 was pr-8"]
        D[">= xl (wide)"] --> D1["Veil: full gradient\nGlobe: lg:left-68%\nStrip: max-w-66vw"]
    end
    C1 -- "right edge aligns with globe centre" --> E["Globe centre @ 68%\nStrip right edge @ 68vw"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Breakpoints["Responsive layout (non-inspect mode)"]
        A["< md (mobile)"] --> A1["Veil: radial only\nGlobe: left-1/2 (centered)\nStrip: full width, px-5"]
        B["md – lg (tablet)"] --> B1["Veil: full gradient\nGlobe: md:left-58% NEW\nStrip: full width, sm:px-8"]
        C["lg – xl (desktop)"] --> C1["Veil: full gradient\nGlobe: lg:left-68% was 72%\nStrip: max-w-68vw, pr-0 was pr-8"]
        D[">= xl (wide)"] --> D1["Veil: full gradient\nGlobe: lg:left-68%\nStrip: max-w-66vw"]
    end
    C1 -- "right edge aligns with globe centre" --> E["Globe centre @ 68%\nStrip right edge @ 68vw"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fpage.tsx%3A605%0A**No%20%60md%60%20max-width%20counterpart%20for%20the%20tablet%20globe%20shift**%0A%0AAt%20%60md%60%20%28768%E2%80%931023%20px%29%20the%20globe%20moves%20to%20%60md%3Aleft-%5B58%25%5D%60%2C%20but%20the%20module%20strip%20still%20stretches%20full%20viewport%20width.%20The%20PR's%20%22strip%20edge%20and%20globe%20co-align%22%20guarantee%20only%20holds%20at%20%60lg%60%20and%20above.%20In%20practice%20the%20three-column%20card%20grid%20at%20%60md%60%20spans%20the%20full%20content%20area%2C%20so%20the%20two%20rightmost%20cards%20overlap%20the%20globe%20without%20the%20veil%20backing%20them%20%28the%20veil's%20soft%20stop%20ends%20at%2082%25%2C%20which%20is%20well%20past%20the%2058%25%20globe%20centre%20on%20tablet%29.%20An%20%60md%3Amax-w-%5B58vw%5D%60%20%28or%20similar%29%20on%20the%20section%20would%20extend%20the%20alignment%20intent%20to%20the%20tablet%20range%20too.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhomepage-os-globe-align%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhomepage-os-globe-align%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fpage.tsx%3A605%0A**No%20%60md%60%20max-width%20counterpart%20for%20the%20tablet%20globe%20shift**%0A%0AAt%20%60md%60%20%28768%E2%80%931023%20px%29%20the%20globe%20moves%20to%20%60md%3Aleft-%5B58%25%5D%60%2C%20but%20the%20module%20strip%20still%20stretches%20full%20viewport%20width.%20The%20PR's%20%22strip%20edge%20and%20globe%20co-align%22%20guarantee%20only%20holds%20at%20%60lg%60%20and%20above.%20In%20practice%20the%20three-column%20card%20grid%20at%20%60md%60%20spans%20the%20full%20content%20area%2C%20so%20the%20two%20rightmost%20cards%20overlap%20the%20globe%20without%20the%20veil%20backing%20them%20%28the%20veil's%20soft%20stop%20ends%20at%2082%25%2C%20which%20is%20well%20past%20the%2058%25%20globe%20centre%20on%20tablet%29.%20An%20%60md%3Amax-w-%5B58vw%5D%60%20%28or%20similar%29%20on%20the%20section%20would%20extend%20the%20alignment%20intent%20to%20the%20tablet%20range%20too.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=42&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(home): align OS module strip, globe ..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/681984376476622e27825a0ac3aff14847c08c52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39511449)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->