### PR TITLE
fix(e2e): de-flake mobile-safari suite + restore test collection

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,10 +9,23 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never' }]],
 
   use: {
-    baseURL: 'https://www.goodnbad.info',
+    // Default to the local build (deterministic, no Vercel bot wall). Override
+    // with E2E_BASE to smoke-test a preview/prod deployment.
+    baseURL: process.env.E2E_BASE ?? 'http://localhost:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
+
+  // Auto-start a local server so the suite is self-contained. Skipped when
+  // E2E_BASE targets a real deployment.
+  webServer: process.env.E2E_BASE
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
 
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -31,7 +31,6 @@ test.describe('Core pages', () => {
     { path: '/personnel',  title: /Personnel|Hamzah/i },
     { path: '/services',   title: /Services/i },
     { path: '/signal',     title: /Signal|Intelligence/i },
-    { path: '/signal',     title: /Signal/i },
     { path: '/deployments',title: /Deployments/i },
     { path: '/contact',    title: /Contact/i },
     { path: '/horus',      title: /Horus/i },
@@ -172,7 +171,7 @@ test.describe('Mobile (iPhone 14)', () => {
   test.use({ viewport: { width: 390, height: 844 }, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1' })
 
   test('Homepage loads without globe canvas on mobile', async ({ page }) => {
-    await gotoSafe(page, '', { waitUntil: 'networkidle' })
+    await gotoSafe(page, '', { waitUntil: 'load' })
     // Globe canvas should NOT be present on mobile (we skip WebGL < 768px)
     const canvas = await page.locator('canvas').count()
     expect(canvas).toBe(0)
@@ -188,7 +187,7 @@ test.describe('Mobile (iPhone 14)', () => {
   test('/signal page loads on mobile without WebGL crash', async ({ page }) => {
     const errors: string[] = []
     page.on('pageerror', (e) => errors.push(e.message))
-    await gotoSafe(page, '/signal', { waitUntil: 'networkidle' })
+    await gotoSafe(page, '/signal', { waitUntil: 'load' })
     const fatalErrors = errors.filter((e) =>
       e.toLowerCase().includes('webgl') || e.toLowerCase().includes('three') || e.toLowerCase().includes('canvas')
     )
@@ -212,7 +211,7 @@ test.describe('Performance', () => {
   })
 
   test('Images have width/height to prevent CLS', async ({ page }) => {
-    await gotoSafe(page, '/personnel', { waitUntil: 'networkidle' })
+    await gotoSafe(page, '/personnel', { waitUntil: 'load' })
     const images = await page.locator('img').all()
     for (const img of images.slice(0, 10)) {
       const w = await img.getAttribute('width')


### PR DESCRIPTION
## What
De-flakes the mobile-safari (WebKit) E2E suite (second-brain commitment). Supersedes the stale, conflicting **#28**.

## Root causes found
1. **The whole suite was broken** — a duplicate `/signal` entry in the `routes` array threw `duplicate test title`, so Playwright loaded **0 tests**.
2. `baseURL` pointed at **production** (`https://www.goodnbad.info`) with **no local server**, so runs hit the Vercel bot wall / connection-refused.
3. `waitUntil:'networkidle'` on the homepage, `/signal` and `/personnel` **never settles** because the live IOC globe feed polls continuously.

## Changes (test/config only — no app code)
- Remove the duplicate `/signal` route → suite now collects **48 tests** (was 0).
- `baseURL` defaults to `http://localhost:3000` (override via `E2E_BASE`).
- Add a `webServer` block (`npm run dev`) so the suite is self-contained; skipped when `E2E_BASE` targets a deployment.
- Replace the 3 `networkidle` waits with `load`.

## Test plan
- [x] `npx playwright test --list` → 48 tests in 1 file (collection restored)
- [ ] `npx playwright test` locally (webServer auto-starts dev) — confirm green on chromium + mobile-safari
- [ ] Optional: real iPhone Safari smoke check via `E2E_BASE=<preview-url>`

Closes #28 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR de-flakes the mobile-safari (WebKit) E2E suite by fixing three root causes that left the suite collecting zero tests and timing out on every run.

- **Duplicate route removed**: The second `{ path: '/signal', ... }` entry caused Playwright to report a "duplicate test title" error and abort collection entirely; removing it restores all 48 tests.
- **Local-first baseURL**: `baseURL` now defaults to `http://localhost:3000` (overridable via `E2E_BASE`), with a `webServer` block that auto-starts `npm run dev`, making the suite self-contained without needing a live Vercel deployment.
- **`networkidle` → `load`**: Three navigation calls that could never settle (the IOC globe feed polls indefinitely) are switched to `waitUntil: 'load'`, preventing the suite from timing out on those pages.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are test/config only with no app code touched; the duplicate-route fix is the critical correction and the rest are straightforward stabilisation choices.

The duplicate /signal removal and networkidle → load swaps are clearly correct. The two remaining concerns are the dev-server introducing a gap between test and production behaviour, and the post-load race window in the WebGL-crash test that could allow a real crash to go undetected. Neither is a blocker, but together they leave a meaningful blind spot in the suite's ability to catch mobile regressions.

playwright.config.ts (webServer command choice) and the /signal WebGL-crash test in tests/e2e/site.spec.ts deserve a second look before treating the suite as a reliable mobile regression guard.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| playwright.config.ts | Switches baseURL to localhost with E2E_BASE override, adds webServer block that auto-starts npm run dev; dev-mode server may mask production-build behavior. |
| tests/e2e/site.spec.ts | Removes duplicate /signal route (the root cause of 0 tests collected), replaces three networkidle waits with load; WebGL-error test now has a potential race window after load. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npx playwright test] --> B{E2E_BASE set?}
    B -- No --> C[webServer: npm run dev\nlocalhost:3000]
    B -- Yes --> D[Skip webServer\nUse E2E_BASE URL]
    C --> E[baseURL = localhost:3000]
    D --> F[baseURL = E2E_BASE]
    E --> G[Run test suite\n48 tests collected]
    F --> G
    G --> H{Vercel bot wall\n429 / Security Checkpoint?}
    H -- Yes --> I[test.skip — not a failure]
    H -- No --> J[Assert page title / status / content]
    J --> K{waitUntil strategy}
    K -- domcontentloaded default --> L[Core page & SEO tests]
    K -- load replaced networkidle --> M[Mobile canvas check\nWebGL crash check\nCLS image check]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[npx playwright test] --> B{E2E_BASE set?}
    B -- No --> C[webServer: npm run dev\nlocalhost:3000]
    B -- Yes --> D[Skip webServer\nUse E2E_BASE URL]
    C --> E[baseURL = localhost:3000]
    D --> F[baseURL = E2E_BASE]
    E --> G[Run test suite\n48 tests collected]
    F --> G
    G --> H{Vercel bot wall\n429 / Security Checkpoint?}
    H -- Yes --> I[test.skip — not a failure]
    H -- No --> J[Assert page title / status / content]
    J --> K{waitUntil strategy}
    K -- domcontentloaded default --> L[Core page & SEO tests]
    K -- load replaced networkidle --> M[Mobile canvas check\nWebGL crash check\nCLS image check]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/e2e/site.spec.ts`, line 187-195 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/34356814816cafff8a1e150eb74a323b526d5f9a/tests/e2e/site.spec.ts#L187-L195)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Race window between `load` and React hydration in the WebGL-crash test**

   `waitUntil: 'load'` resolves when the browser fires the `load` event. On a Next.js page, Three.js / WebGL initialisation happens inside `useEffect` hooks that run *after* the first paint — i.e., after `load`. `gotoSafe` returns and `fatalErrors` is evaluated immediately, but any `pageerror` emitted during that post-`load` hydration window is silently ignored. The test can pass (no errors collected yet) while the actual user experiences a WebGL crash a moment later. A short `page.waitForFunction` polling for a known-stable DOM marker, or even `await page.waitForTimeout(1000)` as a stopgap, would close most of the gap.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fe2e%2Fsite.spec.ts%0ALine%3A%20187-195%0A%0AComment%3A%0A**Race%20window%20between%20%60load%60%20and%20React%20hydration%20in%20the%20WebGL-crash%20test**%0A%0A%60waitUntil%3A%20'load'%60%20resolves%20when%20the%20browser%20fires%20the%20%60load%60%20event.%20On%20a%20Next.js%20page%2C%20Three.js%20%2F%20WebGL%20initialisation%20happens%20inside%20%60useEffect%60%20hooks%20that%20run%20*after*%20the%20first%20paint%20%E2%80%94%20i.e.%2C%20after%20%60load%60.%20%60gotoSafe%60%20returns%20and%20%60fatalErrors%60%20is%20evaluated%20immediately%2C%20but%20any%20%60pageerror%60%20emitted%20during%20that%20post-%60load%60%20hydration%20window%20is%20silently%20ignored.%20The%20test%20can%20pass%20%28no%20errors%20collected%20yet%29%20while%20the%20actual%20user%20experiences%20a%20WebGL%20crash%20a%20moment%20later.%20A%20short%20%60page.waitForFunction%60%20polling%20for%20a%20known-stable%20DOM%20marker%2C%20or%20even%20%60await%20page.waitForTimeout%281000%29%60%20as%20a%20stopgap%2C%20would%20close%20most%20of%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fe2e-mobile-safari-deflake-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fe2e-mobile-safari-deflake-v2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fe2e%2Fsite.spec.ts%0ALine%3A%20187-195%0A%0AComment%3A%0A**Race%20window%20between%20%60load%60%20and%20React%20hydration%20in%20the%20WebGL-crash%20test**%0A%0A%60waitUntil%3A%20'load'%60%20resolves%20when%20the%20browser%20fires%20the%20%60load%60%20event.%20On%20a%20Next.js%20page%2C%20Three.js%20%2F%20WebGL%20initialisation%20happens%20inside%20%60useEffect%60%20hooks%20that%20run%20*after*%20the%20first%20paint%20%E2%80%94%20i.e.%2C%20after%20%60load%60.%20%60gotoSafe%60%20returns%20and%20%60fatalErrors%60%20is%20evaluated%20immediately%2C%20but%20any%20%60pageerror%60%20emitted%20during%20that%20post-%60load%60%20hydration%20window%20is%20silently%20ignored.%20The%20test%20can%20pass%20%28no%20errors%20collected%20yet%29%20while%20the%20actual%20user%20experiences%20a%20WebGL%20crash%20a%20moment%20later.%20A%20short%20%60page.waitForFunction%60%20polling%20for%20a%20known-stable%20DOM%20marker%2C%20or%20even%20%60await%20page.waitForTimeout%281000%29%60%20as%20a%20stopgap%2C%20would%20close%20most%20of%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplaywright.config.ts%3A24%0A**Dev-mode%20server%20for%20E2E%20runs**%0A%0A%60npm%20run%20dev%60%20starts%20Next.js%20in%20development%20mode%20%28React%20DevTools%20warnings%2C%20no%20route%20pre-rendering%2C%20no%20production%20optimizations%29.%20Tests%20passing%20against%20dev%20can%20miss%20regressions%20that%20only%20surface%20after%20%60next%20build%60%2C%20such%20as%20broken%20static%20generation%2C%20missing%20env-vars%20that%20are%20only%20read%20at%20build%20time%2C%20or%20production-only%20hydration%20mismatches.%20Consider%20%60npm%20run%20build%20%26%26%20npm%20start%60%20%28or%20%60next%20build%20%26%26%20next%20start%60%29%20for%20the%20%60command%60%20to%20keep%20the%20suite%20closer%20to%20what%20ships.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fe2e%2Fsite.spec.ts%3A187-195%0A**Race%20window%20between%20%60load%60%20and%20React%20hydration%20in%20the%20WebGL-crash%20test**%0A%0A%60waitUntil%3A%20'load'%60%20resolves%20when%20the%20browser%20fires%20the%20%60load%60%20event.%20On%20a%20Next.js%20page%2C%20Three.js%20%2F%20WebGL%20initialisation%20happens%20inside%20%60useEffect%60%20hooks%20that%20run%20*after*%20the%20first%20paint%20%E2%80%94%20i.e.%2C%20after%20%60load%60.%20%60gotoSafe%60%20returns%20and%20%60fatalErrors%60%20is%20evaluated%20immediately%2C%20but%20any%20%60pageerror%60%20emitted%20during%20that%20post-%60load%60%20hydration%20window%20is%20silently%20ignored.%20The%20test%20can%20pass%20%28no%20errors%20collected%20yet%29%20while%20the%20actual%20user%20experiences%20a%20WebGL%20crash%20a%20moment%20later.%20A%20short%20%60page.waitForFunction%60%20polling%20for%20a%20known-stable%20DOM%20marker%2C%20or%20even%20%60await%20page.waitForTimeout%281000%29%60%20as%20a%20stopgap%2C%20would%20close%20most%20of%20the%20gap.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fe2e-mobile-safari-deflake-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fe2e-mobile-safari-deflake-v2%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplaywright.config.ts%3A24%0A**Dev-mode%20server%20for%20E2E%20runs**%0A%0A%60npm%20run%20dev%60%20starts%20Next.js%20in%20development%20mode%20%28React%20DevTools%20warnings%2C%20no%20route%20pre-rendering%2C%20no%20production%20optimizations%29.%20Tests%20passing%20against%20dev%20can%20miss%20regressions%20that%20only%20surface%20after%20%60next%20build%60%2C%20such%20as%20broken%20static%20generation%2C%20missing%20env-vars%20that%20are%20only%20read%20at%20build%20time%2C%20or%20production-only%20hydration%20mismatches.%20Consider%20%60npm%20run%20build%20%26%26%20npm%20start%60%20%28or%20%60next%20build%20%26%26%20next%20start%60%29%20for%20the%20%60command%60%20to%20keep%20the%20suite%20closer%20to%20what%20ships.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fe2e%2Fsite.spec.ts%3A187-195%0A**Race%20window%20between%20%60load%60%20and%20React%20hydration%20in%20the%20WebGL-crash%20test**%0A%0A%60waitUntil%3A%20'load'%60%20resolves%20when%20the%20browser%20fires%20the%20%60load%60%20event.%20On%20a%20Next.js%20page%2C%20Three.js%20%2F%20WebGL%20initialisation%20happens%20inside%20%60useEffect%60%20hooks%20that%20run%20*after*%20the%20first%20paint%20%E2%80%94%20i.e.%2C%20after%20%60load%60.%20%60gotoSafe%60%20returns%20and%20%60fatalErrors%60%20is%20evaluated%20immediately%2C%20but%20any%20%60pageerror%60%20emitted%20during%20that%20post-%60load%60%20hydration%20window%20is%20silently%20ignored.%20The%20test%20can%20pass%20%28no%20errors%20collected%20yet%29%20while%20the%20actual%20user%20experiences%20a%20WebGL%20crash%20a%20moment%20later.%20A%20short%20%60page.waitForFunction%60%20polling%20for%20a%20known-stable%20DOM%20marker%2C%20or%20even%20%60await%20page.waitForTimeout%281000%29%60%20as%20a%20stopgap%2C%20would%20close%20most%20of%20the%20gap.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(e2e): de-flake mobile-safari suite +..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/34356814816cafff8a1e150eb74a323b526d5f9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39527063)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->