### PR TITLE
fix: add /signal route + wire up dead easter-egg/login counters & real Konami code

### DIFF
--- a/app/signal/page.tsx
+++ b/app/signal/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next"
+import { OSPageShell } from "@/components/os/OSPageShell"
+import { SignalPageLayout } from "@/components/signal/SignalPageLayout"
+import { aggregateSignalFeed } from "@/lib/signal-feed/aggregate"
+
+export const metadata: Metadata = {
+  title: "Signal | Hamzah Al-Ramli",
+  description:
+    "Live cyber-threat signal feed: KEV exploits, vendor advisories, IOCs and security news, aggregated and deduplicated in real time.",
+  alternates: {
+    canonical: "https://www.goodnbad.info/signal",
+  },
+}
+
+// The feed aggregates live external sources on every request — never statically
+// cache the page itself (the API route handles its own SWR caching).
+export const dynamic = "force-dynamic"
+
+export default async function SignalPage() {
+  const { items, fetchedAt, sourceErrors } = await aggregateSignalFeed()
+
+  return (
+    <OSPageShell osName="signal.exe" label="Threat Signal Feed">
+      <div className="container mx-auto max-w-6xl px-4 py-8 md:py-12">
+        <SignalPageLayout
+          initialItems={items}
+          fetchedAt={fetchedAt}
+          sourceErrors={sourceErrors}
+        />
+      </div>
+    </OSPageShell>
+  )
+}

--- a/components/hacker-terminal.tsx
+++ b/components/hacker-terminal.tsx
@@ -115,7 +115,10 @@ export function HackerTerminal() {
   const [isInitialized, setIsInitialized] = useState(false)
   const terminalRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  
+  // Always points at the latest handleCommand so the global Konami listener
+  // (registered once on mount) never calls a stale closure.
+  const handleCommandRef = useRef<((command: string) => void) | null>(null)
+
   // Command history for arrow key navigation
   const [commandHistory, setCommandHistory] = useState<string[]>([])
   const [historyIndex, setHistoryIndex] = useState(-1)
@@ -704,6 +707,9 @@ export function HackerTerminal() {
     setCurrentInput("");
   }
 
+  // Expose the freshest handleCommand to the mount-time Konami listener.
+  handleCommandRef.current = handleCommand
+
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && currentInput.trim()) {
       await handleCommand(currentInput.trim());
@@ -741,6 +747,35 @@ export function HackerTerminal() {
     if (inputRef.current) {
       inputRef.current.focus()
     }
+  }, [])
+
+  // Global Konami code (↑↑↓↓←→←→BA) listener. Previously the only way to fire
+  // the konami easter egg was to literally type the word "konami"; this wires
+  // up the real sequence anywhere on the page via a rolling keystroke buffer.
+  useEffect(() => {
+    const KONAMI_SEQUENCE = [
+      'arrowup', 'arrowup', 'arrowdown', 'arrowdown',
+      'arrowleft', 'arrowright', 'arrowleft', 'arrowright',
+      'b', 'a',
+    ]
+    let buffer: string[] = []
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      buffer.push(e.key.toLowerCase())
+      if (buffer.length > KONAMI_SEQUENCE.length) {
+        buffer = buffer.slice(-KONAMI_SEQUENCE.length)
+      }
+      if (
+        buffer.length === KONAMI_SEQUENCE.length &&
+        KONAMI_SEQUENCE.every((key, i) => key === buffer[i])
+      ) {
+        buffer = []
+        handleCommandRef.current?.('konami')
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
   // Initialize terminal systems and show welcome message

--- a/components/terminal/CommandProcessor.ts
+++ b/components/terminal/CommandProcessor.ts
@@ -118,6 +118,11 @@ export class CommandProcessor {
           context.behaviorTracker.discoveredSecrets.push(egg.trigger);
         }
 
+        // Count toward the persisted easterEggsFound stat (deduped per trigger
+        // inside the manager). behaviorTracker.discoveredSecrets is rebuilt on
+        // every command, so it cannot be the source of truth for the count.
+        context.gameManager?.recordEasterEgg?.(egg.trigger);
+
         return {
           output: egg.response,
           type: 'success',

--- a/components/terminal/config/commands.ts
+++ b/components/terminal/config/commands.ts
@@ -182,7 +182,12 @@ const loginCommand: Command = {
     }
     
     const [username, password] = args;
-    
+
+    // Count every genuine credential attempt (success or failure) toward the
+    // persisted loginAttempts stat — this is what unlocks the "persistent"
+    // achievement at 10 attempts. Usage errors (handled above) don't count.
+    context.gameManager?.incrementStat?.('loginAttempts');
+
     // Use AuthManager for proper authentication
      if (context.gameManager && context.gameManager.authManager) {
        const authResult = context.gameManager.authManager.login(username, password);

--- a/components/terminal/game/GameStateManager.ts
+++ b/components/terminal/game/GameStateManager.ts
@@ -30,6 +30,8 @@ export class GameStateManager {
           const parsed = JSON.parse(saved);
           return {
             ...parsed,
+            // Backward-compat: older saved states predate this field.
+            discoveredEasterEggs: parsed.discoveredEasterEggs ?? [],
             startTime: new Date(parsed.startTime),
             lastActivity: new Date(parsed.lastActivity),
             achievements: parsed.achievements.map((a: any) => ({
@@ -54,6 +56,7 @@ export class GameStateManager {
       solvedChallenges: [],
       unlockedCommands: ['help', 'clear', 'whoami', 'date', 'echo'],
       achievements: [],
+      discoveredEasterEggs: [],
       stats: {
         commandsExecuted: 0,
         challengesSolved: 0,
@@ -161,6 +164,22 @@ export class GameStateManager {
     this.gameState.lastActivity = new Date();
     this.checkAchievements();
     this.saveGameState();
+  }
+
+  /**
+   * Record an easter egg discovery, counting it toward the easterEggsFound
+   * stat exactly once per unique trigger. Repeatable eggs (e.g. "coffee") can
+   * fire many times in a session but must not inflate the count — otherwise the
+   * `easter_hunter` achievement (find 5 distinct eggs) would be trivially
+   * unlocked by spamming one egg.
+   */
+  public recordEasterEgg(trigger: string): void {
+    if (this.gameState.discoveredEasterEggs.includes(trigger)) {
+      return;
+    }
+    this.gameState.discoveredEasterEggs.push(trigger);
+    // incrementStat persists state and re-checks achievements for us.
+    this.incrementStat('easterEggsFound');
   }
 
   public unlockAchievement(achievementId: string): Achievement | null {

--- a/components/terminal/types.ts
+++ b/components/terminal/types.ts
@@ -110,6 +110,9 @@ export interface GameState {
   unlockedCommands: string[];
   currentChallenge?: string;
   flags?: string[];
+  // Triggers of easter eggs the player has discovered (persisted). Used to
+  // dedupe the easterEggsFound stat so repeatable eggs only count once.
+  discoveredEasterEggs: string[];
   achievements: Achievement[];
   stats: {
     commandsExecuted: number;


### PR DESCRIPTION
## Summary

Three "wired but never fired" bugs found during the site-logic audit, fixed in one PR:

### 1. `/signal` route was a 404
The route was fully *designed* — `OSPageShell`'s docstring lists `/signal`, `/news` permanently redirects to it, and the home page + mobile nav link to it — but `app/signal/page.tsx` never existed, so every `/signal` link 404'd (and `/news` redirected into a 404).

**Fix:** new server component `app/signal/page.tsx` that fetches via the existing `aggregateSignalFeed()` and renders the existing orphaned `SignalPageLayout` (50/50 feed + IOC inspector) inside `OSPageShell`. Pure assembly of components that already shipped on `main`.

### 2. `easter_hunter` achievement was unreachable
`stats.easterEggsFound` was only ever incremented in tests — production code never called it, so "find 5 easter eggs" could never unlock. `behaviorTracker.discoveredSecrets` resets on every command, so it couldn't be the counter.

**Fix:** persist discoveries on `GameState.discoveredEasterEggs` and count each unique trigger once via a new `GameStateManager.recordEasterEgg()`, called from `CommandProcessor.checkEasterEggs`. Deduping means repeatable eggs (e.g. `coffee`) can't be spammed to inflate the count. Backward-compatible load for existing saved states.

### 3. `persistent` achievement was unreachable
`stats.loginAttempts` was never incremented, so "attempt login 10 times" could never unlock.

**Fix:** `loginCommand` now increments `loginAttempts` on each genuine credential attempt (usage errors excluded).

### 4. Konami code only worked if you typed the word "konami"
There was no real sequence detection — the `konami` egg fired only when the literal string `konami` was entered.

**Fix:** a document-level `keydown` listener with a rolling buffer detects the real sequence (↑↑↓↓←→←→BA) anywhere on the page. Uses a `handleCommandRef` so the mount-time listener always calls the freshest `handleCommand` closure (no stale state).

## Test plan
- [x] `npm run build` passes (exit 0); `/signal` builds as a dynamic route.
- [ ] Visit `/signal` → loads feed + IOC inspector (no 404).
- [ ] Visit `/news` → redirects to `/signal`.
- [ ] Enter ↑↑↓↓←→←→BA on the homepage → Konami egg fires.
- [ ] Trigger 5 distinct easter eggs → `easter_hunter` unlocks; spamming one egg does not.
- [ ] Attempt `login` 10 times → `persistent` unlocks.

Branched off `main` (standalone — independent of the open `fix/home-*` PRs).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes four previously broken features: adds the missing `/signal` page (assembling already-shipped components), wires up the `easter_hunter` achievement via a new `recordEasterEgg` deduplication flow in `GameStateManager`, connects the `persistent` achievement by incrementing `loginAttempts` on genuine credential attempts, and replaces the "type the word konami" stub with a real document-level rolling-buffer sequence detector.

- **`/signal` page** — pure assembly of `aggregateSignalFeed` + `SignalPageLayout` inside `OSPageShell`; `force-dynamic` is correctly set to prevent static caching of a live-feed route.
- **Easter egg deduplication** — `discoveredEasterEggs: string[]` added to `GameState` with backward-compatible load; `recordEasterEgg()` dedupes by trigger so repeatable eggs can't inflate the `easter_hunter` counter.
- **Konami listener** — uses a `handleCommandRef` ref pattern so the mount-time `window` listener always calls the latest `handleCommand` closure without stale captures; one propagation issue exists where terminal arrow-key history navigation can inadvertently pre-fill the sequence buffer.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the arrow-key propagation issue in the Konami listener; all other changes are isolated and correctly implemented.

The window Konami listener does not guard against events originating from the terminal input, so the standard up-up-down-down history-navigation pattern silently pre-loads the first four Konami keys into the rolling buffer. A user who then presses left-right-left-right-BA anywhere on the page triggers the easter egg unintentionally. The remaining changes — the signal page, the easter egg deduplication, and the loginAttempts wiring — are all correctly placed and do not introduce regressions.

components/hacker-terminal.tsx — the Konami keydown handler needs a guard to ignore events from the terminal input element.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/signal/page.tsx | New server component assembling existing SignalPageLayout + aggregateSignalFeed; force-dynamic is correct. Minor: no top-level error boundary if aggregateSignalFeed throws. |
| components/hacker-terminal.tsx | Adds Konami keydown listener + handleCommandRef pattern; ref approach is correct but the listener does not guard against terminal input events, causing arrow-key history navigation to contaminate the Konami buffer. |
| components/terminal/CommandProcessor.ts | Adds recordEasterEgg call after each matched egg; correctly placed after the one-time dedup check; no issues. |
| components/terminal/config/commands.ts | loginAttempts increment is correctly placed after both the already-logged-in and usage error early returns; only genuine credential attempts count. |
| components/terminal/game/GameStateManager.ts | New recordEasterEgg method dedupes by trigger using includes(), delegates persistence + achievement checks to existing incrementStat; backward-compat loading is correct. |
| components/terminal/types.ts | Adds discoveredEasterEggs: string[] to GameState; clean, minimal, backward-compatible. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant W as window keydown
    participant KH as Konami Handler
    participant HR as handleCommandRef
    participant CP as CommandProcessor
    participant GSM as GameStateManager

    U->>W: up up down down left right left right B A
    W->>KH: onKeyDown (rolling buffer)
    KH-->>KH: buffer matches KONAMI_SEQUENCE?
    KH->>HR: handleCommandRef.current(konami)
    HR->>CP: executeCommand(konami, context)
    CP->>CP: checkEasterEggs(konami, context)
    CP->>GSM: recordEasterEgg(konami)
    GSM-->>GSM: discoveredEasterEggs.includes(konami)?
    alt First discovery
        GSM->>GSM: push trigger, incrementStat(easterEggsFound)
        GSM->>GSM: checkAchievements - unlock easter_hunter if 5 or more
        GSM->>GSM: saveGameState()
    else Already discovered
        GSM-->>GSM: return no-op
    end

    Note over U, W: login flow
    U->>CP: login username password
    CP->>GSM: incrementStat(loginAttempts)
    GSM->>GSM: checkAchievements - unlock persistent if 10 or more
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant W as window keydown
    participant KH as Konami Handler
    participant HR as handleCommandRef
    participant CP as CommandProcessor
    participant GSM as GameStateManager

    U->>W: up up down down left right left right B A
    W->>KH: onKeyDown (rolling buffer)
    KH-->>KH: buffer matches KONAMI_SEQUENCE?
    KH->>HR: handleCommandRef.current(konami)
    HR->>CP: executeCommand(konami, context)
    CP->>CP: checkEasterEggs(konami, context)
    CP->>GSM: recordEasterEgg(konami)
    GSM-->>GSM: discoveredEasterEggs.includes(konami)?
    alt First discovery
        GSM->>GSM: push trigger, incrementStat(easterEggsFound)
        GSM->>GSM: checkAchievements - unlock easter_hunter if 5 or more
        GSM->>GSM: saveGameState()
    else Already discovered
        GSM-->>GSM: return no-op
    end

    Note over U, W: login flow
    U->>CP: login username password
    CP->>GSM: incrementStat(loginAttempts)
    GSM->>GSM: checkAchievements - unlock persistent if 10 or more
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2Fhacker-terminal.tsx%3A763-775%0A**Arrow%20key%20history%20navigation%20pre-fills%20the%20Konami%20buffer**%0A%0AThe%20%60window%60%20listener%20captures%20every%20%60keydown%60%20event%20including%20those%20fired%20while%20the%20terminal%20input%20has%20focus.%20The%20terminal's%20%60handleKeyDown%60%20calls%20%60e.preventDefault%28%29%60%20on%20%60ArrowUp%60%2F%60ArrowDown%60%20for%20history%20navigation%2C%20but%20this%20does%20not%20stop%20propagation%20%E2%80%94%20the%20native%20event%20still%20reaches%20the%20window-level%20listener.%20A%20user%20navigating%20history%20with%20%60%E2%86%91%E2%86%91%E2%86%93%E2%86%93%60%20%28very%20common%3A%20go%20up%20two%20commands%2C%20come%20back%20down%29%20silently%20deposits%20the%20first%20four%20characters%20of%20the%20Konami%20sequence%20into%20the%20buffer.%20If%20they%20then%20type%20%60%E2%86%90%E2%86%92%E2%86%90%E2%86%92BA%60%20anywhere%20on%20the%20page%2C%20the%20egg%20fires%20unexpectedly.%0A%0AAdd%20a%20guard%20at%20the%20top%20of%20%60onKeyDown%60%20to%20bail%20out%20when%20the%20event%20originates%20from%20the%20terminal%20input%20itself%2C%20for%20example%3A%20%60if%20%28e.target%20%3D%3D%3D%20inputRef.current%29%20return%3B%60%20%E2%80%94%20this%20keeps%20the%20Konami%20sequence%20working%20globally%20while%20preventing%20command-history%20navigation%20from%20contaminating%20the%20buffer.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fsignal%2Fpage.tsx%3A20%0A**Uncaught%20%60aggregateSignalFeed%60%20exception%20crashes%20the%20page**%0A%0AThe%20PR%20marks%20%60sourceErrors%60%20as%20one%20of%20the%20function's%20return%20values%2C%20implying%20per-source%20failures%20are%20handled%20internally.%20However%2C%20if%20%60aggregateSignalFeed%60%20itself%20throws%20%28e.g.%20network%20timeout%20before%20any%20fetch%20resolves%2C%20or%20an%20import-level%20error%20in%20the%20aggregator%20module%29%2C%20the%20unhandled%20rejection%20propagates%20up%20and%20Next.js%20renders%20the%20nearest%20%60error.tsx%60%20boundary%20%E2%80%94%20or%20a%20blank%20500%20if%20none%20exists.%20Since%20%60force-dynamic%60%20runs%20this%20on%20every%20request%2C%20a%20transient%20upstream%20outage%20would%20make%20%60%2Fsignal%60%20temporarily%20unreachable.%20Wrapping%20the%20call%20in%20%60try%2Fcatch%60%20and%20falling%20back%20to%20empty%20%60items%60%20with%20a%20%60sourceErrors%60%20entry%20would%20make%20the%20page%20resilient.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=44&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fsignal-route-and-easter-eggs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsignal-route-and-easter-eggs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2Fhacker-terminal.tsx%3A763-775%0A**Arrow%20key%20history%20navigation%20pre-fills%20the%20Konami%20buffer**%0A%0AThe%20%60window%60%20listener%20captures%20every%20%60keydown%60%20event%20including%20those%20fired%20while%20the%20terminal%20input%20has%20focus.%20The%20terminal's%20%60handleKeyDown%60%20calls%20%60e.preventDefault%28%29%60%20on%20%60ArrowUp%60%2F%60ArrowDown%60%20for%20history%20navigation%2C%20but%20this%20does%20not%20stop%20propagation%20%E2%80%94%20the%20native%20event%20still%20reaches%20the%20window-level%20listener.%20A%20user%20navigating%20history%20with%20%60%E2%86%91%E2%86%91%E2%86%93%E2%86%93%60%20%28very%20common%3A%20go%20up%20two%20commands%2C%20come%20back%20down%29%20silently%20deposits%20the%20first%20four%20characters%20of%20the%20Konami%20sequence%20into%20the%20buffer.%20If%20they%20then%20type%20%60%E2%86%90%E2%86%92%E2%86%90%E2%86%92BA%60%20anywhere%20on%20the%20page%2C%20the%20egg%20fires%20unexpectedly.%0A%0AAdd%20a%20guard%20at%20the%20top%20of%20%60onKeyDown%60%20to%20bail%20out%20when%20the%20event%20originates%20from%20the%20terminal%20input%20itself%2C%20for%20example%3A%20%60if%20%28e.target%20%3D%3D%3D%20inputRef.current%29%20return%3B%60%20%E2%80%94%20this%20keeps%20the%20Konami%20sequence%20working%20globally%20while%20preventing%20command-history%20navigation%20from%20contaminating%20the%20buffer.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fsignal%2Fpage.tsx%3A20%0A**Uncaught%20%60aggregateSignalFeed%60%20exception%20crashes%20the%20page**%0A%0AThe%20PR%20marks%20%60sourceErrors%60%20as%20one%20of%20the%20function's%20return%20values%2C%20implying%20per-source%20failures%20are%20handled%20internally.%20However%2C%20if%20%60aggregateSignalFeed%60%20itself%20throws%20%28e.g.%20network%20timeout%20before%20any%20fetch%20resolves%2C%20or%20an%20import-level%20error%20in%20the%20aggregator%20module%29%2C%20the%20unhandled%20rejection%20propagates%20up%20and%20Next.js%20renders%20the%20nearest%20%60error.tsx%60%20boundary%20%E2%80%94%20or%20a%20blank%20500%20if%20none%20exists.%20Since%20%60force-dynamic%60%20runs%20this%20on%20every%20request%2C%20a%20transient%20upstream%20outage%20would%20make%20%60%2Fsignal%60%20temporarily%20unreachable.%20Wrapping%20the%20call%20in%20%60try%2Fcatch%60%20and%20falling%20back%20to%20empty%20%60items%60%20with%20a%20%60sourceErrors%60%20entry%20would%20make%20the%20page%20resilient.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=44&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: add /signal route and wire up dead ..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/e7f630cc249f4f7455ddf6af371a1239590f27a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39639575)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->