### PR TITLE
fix: /signal redirect loop (route was unreachable) + one-time easter-egg replay

### DIFF
--- a/app/signal/page.tsx
+++ b/app/signal/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next"
+import { OSPageShell } from "@/components/os/OSPageShell"
+import { SignalPageLayout } from "@/components/signal/SignalPageLayout"
+import { aggregateSignalFeed } from "@/lib/signal-feed/aggregate"
+
+export const metadata: Metadata = {
+  title: "Signal | Hamzah Al-Ramli",
+  description:
+    "Live cyber-threat signal feed: KEV exploits, vendor advisories, IOCs and security news, aggregated and deduplicated in real time.",
+  alternates: {
+    canonical: "https://www.goodnbad.info/signal",
+  },
+}
+
+// The feed aggregates live external sources on every request — never statically
+// cache the page itself (the API route handles its own SWR caching).
+export const dynamic = "force-dynamic"
+
+export default async function SignalPage() {
+  const { items, fetchedAt, sourceErrors } = await aggregateSignalFeed()
+
+  return (
+    <OSPageShell osName="signal.exe" label="Threat Signal Feed">
+      <div className="container mx-auto max-w-6xl px-4 py-8 md:py-12">
+        <SignalPageLayout
+          initialItems={items}
+          fetchedAt={fetchedAt}
+          sourceErrors={sourceErrors}
+        />
+      </div>
+    </OSPageShell>
+  )
+}

--- a/components/hacker-terminal.tsx
+++ b/components/hacker-terminal.tsx
@@ -115,7 +115,10 @@ export function HackerTerminal() {
   const [isInitialized, setIsInitialized] = useState(false)
   const terminalRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  
+  // Always points at the latest handleCommand so the global Konami listener
+  // (registered once on mount) never calls a stale closure.
+  const handleCommandRef = useRef<((command: string) => void) | null>(null)
+
   // Command history for arrow key navigation
   const [commandHistory, setCommandHistory] = useState<string[]>([])
   const [historyIndex, setHistoryIndex] = useState(-1)
@@ -704,6 +707,9 @@ export function HackerTerminal() {
     setCurrentInput("");
   }
 
+  // Expose the freshest handleCommand to the mount-time Konami listener.
+  handleCommandRef.current = handleCommand
+
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && currentInput.trim()) {
       await handleCommand(currentInput.trim());
@@ -741,6 +747,35 @@ export function HackerTerminal() {
     if (inputRef.current) {
       inputRef.current.focus()
     }
+  }, [])
+
+  // Global Konami code (↑↑↓↓←→←→BA) listener. Previously the only way to fire
+  // the konami easter egg was to literally type the word "konami"; this wires
+  // up the real sequence anywhere on the page via a rolling keystroke buffer.
+  useEffect(() => {
+    const KONAMI_SEQUENCE = [
+      'arrowup', 'arrowup', 'arrowdown', 'arrowdown',
+      'arrowleft', 'arrowright', 'arrowleft', 'arrowright',
+      'b', 'a',
+    ]
+    let buffer: string[] = []
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      buffer.push(e.key.toLowerCase())
+      if (buffer.length > KONAMI_SEQUENCE.length) {
+        buffer = buffer.slice(-KONAMI_SEQUENCE.length)
+      }
+      if (
+        buffer.length === KONAMI_SEQUENCE.length &&
+        KONAMI_SEQUENCE.every((key, i) => key === buffer[i])
+      ) {
+        buffer = []
+        handleCommandRef.current?.('konami')
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
   // Initialize terminal systems and show welcome message

--- a/components/terminal/CommandProcessor.ts
+++ b/components/terminal/CommandProcessor.ts
@@ -108,8 +108,13 @@ export class CommandProcessor {
           continue;
         }
 
-        // Check if it's a one-time Easter egg
-        if (egg.oneTime && context.behaviorTracker.discoveredSecrets.includes(egg.trigger)) {
+        // Check if it's a one-time Easter egg. Gate on the PERSISTED discovery
+        // list, not behaviorTracker.discoveredSecrets — the latter is rebuilt
+        // empty on every command (see hacker-terminal.tsx), so it could never
+        // suppress a replay and "oneTime" eggs (e.g. konami) fired every time.
+        const persistedEggs: string[] =
+          context.gameManager?.getGameState?.()?.discoveredEasterEggs ?? [];
+        if (egg.oneTime && persistedEggs.includes(egg.trigger)) {
           continue;
         }
 

--- a/components/terminal/CommandProcessor.ts
+++ b/components/terminal/CommandProcessor.ts
@@ -118,6 +118,11 @@ export class CommandProcessor {
           context.behaviorTracker.discoveredSecrets.push(egg.trigger);
         }
 
+        // Count toward the persisted easterEggsFound stat (deduped per trigger
+        // inside the manager). behaviorTracker.discoveredSecrets is rebuilt on
+        // every command, so it cannot be the source of truth for the count.
+        context.gameManager?.recordEasterEgg?.(egg.trigger);
+
         return {
           output: egg.response,
           type: 'success',

--- a/components/terminal/config/commands.ts
+++ b/components/terminal/config/commands.ts
@@ -182,7 +182,12 @@ const loginCommand: Command = {
     }
     
     const [username, password] = args;
-    
+
+    // Count every genuine credential attempt (success or failure) toward the
+    // persisted loginAttempts stat — this is what unlocks the "persistent"
+    // achievement at 10 attempts. Usage errors (handled above) don't count.
+    context.gameManager?.incrementStat?.('loginAttempts');
+
     // Use AuthManager for proper authentication
      if (context.gameManager && context.gameManager.authManager) {
        const authResult = context.gameManager.authManager.login(username, password);

--- a/components/terminal/game/GameStateManager.ts
+++ b/components/terminal/game/GameStateManager.ts
@@ -30,6 +30,8 @@ export class GameStateManager {
           const parsed = JSON.parse(saved);
           return {
             ...parsed,
+            // Backward-compat: older saved states predate this field.
+            discoveredEasterEggs: parsed.discoveredEasterEggs ?? [],
             startTime: new Date(parsed.startTime),
             lastActivity: new Date(parsed.lastActivity),
             achievements: parsed.achievements.map((a: any) => ({
@@ -54,6 +56,7 @@ export class GameStateManager {
       solvedChallenges: [],
       unlockedCommands: ['help', 'clear', 'whoami', 'date', 'echo'],
       achievements: [],
+      discoveredEasterEggs: [],
       stats: {
         commandsExecuted: 0,
         challengesSolved: 0,
@@ -161,6 +164,22 @@ export class GameStateManager {
     this.gameState.lastActivity = new Date();
     this.checkAchievements();
     this.saveGameState();
+  }
+
+  /**
+   * Record an easter egg discovery, counting it toward the easterEggsFound
+   * stat exactly once per unique trigger. Repeatable eggs (e.g. "coffee") can
+   * fire many times in a session but must not inflate the count — otherwise the
+   * `easter_hunter` achievement (find 5 distinct eggs) would be trivially
+   * unlocked by spamming one egg.
+   */
+  public recordEasterEgg(trigger: string): void {
+    if (this.gameState.discoveredEasterEggs.includes(trigger)) {
+      return;
+    }
+    this.gameState.discoveredEasterEggs.push(trigger);
+    // incrementStat persists state and re-checks achievements for us.
+    this.incrementStat('easterEggsFound');
   }
 
   public unlockAchievement(achievementId: string): Achievement | null {

--- a/components/terminal/types.ts
+++ b/components/terminal/types.ts
@@ -110,6 +110,9 @@ export interface GameState {
   unlockedCommands: string[];
   currentChallenge?: string;
   flags?: string[];
+  // Triggers of easter eggs the player has discovered (persisted). Used to
+  // dedupe the easterEggsFound stat so repeatable eggs only count once.
+  discoveredEasterEggs: string[];
   achievements: Achievement[];
   stats: {
     commandsExecuted: number;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,12 +23,10 @@ const nextConfig = {
         destination: '/deployments',
         permanent: true,
       },
-      // Signal + News merged into a single canonical threat page at /news.
-      {
-        source: '/signal',
-        destination: '/news',
-        permanent: true,
-      },
+      // NOTE: /signal is the canonical threat-intel page (app/signal/page.tsx).
+      // /news is retired and redirects to /signal (see app/news/page.tsx). Do NOT
+      // add a /signal -> /news redirect here: it pairs with that one to form an
+      // infinite redirect loop (ERR_TOO_MANY_REDIRECTS) that takes BOTH routes down.
     ]
   },
 }


### PR DESCRIPTION
## Why

Post-merge verification of #44 (fanned out per-route audit agents) found the `/signal` route it shipped is **unreachable in production**, plus a one-time easter-egg replay bug affecting the Konami listener that PR added. Both are fixed here.

### 1. `/signal` redirect loop (ship-blocker)
`next.config.mjs` had a stale `/signal → /news` permanent redirect (from when the pages were merged "into a single canonical page at /news"). But `app/news/page.tsx` was later changed to redirect `/news → /signal`. Result:

```
/signal → 308 → /news → redirect('/signal') → /signal → 308 → … (ERR_TOO_MANY_REDIRECTS)
```

Both routes were down. The build compiles fine (config redirects run in the edge layer, before the App Router resolves `page.tsx`), so CI never caught it. Fix: remove the stale config rule. `/news → /signal` stays — that's the correct canonical direction.

### 2. One-time easter eggs fired every time
`CommandProcessor.checkEasterEggs` gated `oneTime` eggs on `behaviorTracker.discoveredSecrets`, which `hacker-terminal.tsx` rebuilds **empty on every command** — so the check was always against `[]` and one-time eggs (incl. the Konami "30 Lives Granted" the new keyboard listener triggers) replayed forever. Now gated on the persisted `discoveredEasterEggs` list (#44's addition), which survives across commands.

## Test plan
- [x] `npm run build` → exit 0; `ƒ /signal` present in route manifest
- [ ] Visit `/signal` on the Vercel preview → loads the feed (no redirect loop)
- [ ] Visit `/news` → single redirect to `/signal`
- [ ] Terminal: enter Konami sequence twice → "30 Lives" shows once, then no replay

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR resolves two production bugs introduced in #44: an infinite redirect loop that made both `/signal` and `/news` unreachable, and a one-time easter egg that replayed on every invocation due to the wrong deduplication source.

- **Redirect loop fix**: Removes the stale `next.config.mjs` rule that sent `/signal → /news` (permanent 308), which collided with `app/news/page.tsx`'s `redirect('/signal')` to form an infinite loop. The new `app/signal/page.tsx` page now serves the canonical feed, and `/news` correctly redirects to it.
- **Easter egg one-time gate**: `CommandProcessor.checkEasterEggs` now reads from the persisted `GameState.discoveredEasterEggs` list (backed by `localStorage`) instead of `behaviorTracker.discoveredSecrets`, which was rebuilt as an empty array on every command invocation — meaning the one-time guard was never effective.
- **Supporting changes**: Adds `GameStateManager.recordEasterEgg()` with per-trigger deduplication for the `easterEggsFound` stat, a global Konami key-sequence listener using a `handleCommandRef` ref pattern, and correct `loginAttempts` stat tracking in the login command.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — both targeted bugs are fixed correctly with no regressions introduced in the changed code paths.

The redirect fix is correct and well-guarded with a comment preventing re-introduction. The easter egg deduplication logic is sound: gating on localStorage-backed discoveredEasterEggs properly survives across commands. The handleCommandRef pattern is the idiomatic React way to give a mount-time effect access to a fresh closure. The only issues are minor: getGameState() is called once per egg in the loop rather than once before it, and the returned shallow copy leaks the live discoveredEasterEggs array reference — neither affects current correctness but both are worth a cleanup pass.

components/terminal/game/GameStateManager.ts — the getGameState() shallow copy exposes the internal discoveredEasterEggs array by reference; components/terminal/CommandProcessor.ts — getGameState() is called N times (once per egg) inside the loop.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| next.config.mjs | Removes the stale /signal → /news permanent redirect that was causing an infinite loop with the App Router redirect in app/news/page.tsx; adds a comment to prevent re-introduction. |
| app/signal/page.tsx | New page component that serves the canonical /signal threat-intel feed; correctly marked force-dynamic to skip static caching and includes appropriate metadata with canonical URL. |
| components/terminal/CommandProcessor.ts | Fixes one-time easter egg replay by gating on the persisted discoveredEasterEggs list instead of the in-memory behaviorTracker.discoveredSecrets; adds recordEasterEgg() call for deduped stat tracking. Minor: getGameState() is called once per loop iteration instead of once before the loop. |
| components/hacker-terminal.tsx | Adds handleCommandRef pattern to give the mount-time Konami useEffect access to the latest handleCommand closure without dependency churn; Konami key buffer and sequence detection logic are correct. |
| components/terminal/game/GameStateManager.ts | Adds discoveredEasterEggs field with backward-compat defaulting, initializes it in createNewGameState, and implements recordEasterEgg() with per-trigger deduplication. getGameState() returns a shallow copy that leaks the live discoveredEasterEggs array reference to callers. |
| components/terminal/config/commands.ts | Adds incrementStat('loginAttempts') after the usage-error guard so only genuine credential submissions count toward the persistent achievement; correctly placed before the AuthManager.login() call and does not conflict with AuthManager's own per-username in-memory lockout counter. |
| components/terminal/types.ts | Adds discoveredEasterEggs: string[] to the GameState interface to match the new runtime field; no other changes. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /signal] -->|Before PR| B[next.config.mjs: 308 → /news]
    B --> C[app/news/page.tsx: redirect → /signal]
    C --> B
    B -.->|ERR_TOO_MANY_REDIRECTS| X[💥 Both routes down]

    A2[User visits /signal] -->|After PR| D[app/signal/page.tsx SignalPage renders feed]

    E[User visits /news] --> F[app/news/page.tsx: redirect → /signal]
    F --> D

    G[Konami key sequence] --> H[window keydown listener rolling buffer check]
    H -->|match| I[handleCommandRef.current 'konami']
    I --> J[executeCommand 'konami']
    J --> K{command registered?}
    K -->|no| L[checkEasterEggs]
    L --> M{discoveredEasterEggs includes 'konami'?}
    M -->|no, first time| N[Fire easter egg + recordEasterEgg]
    M -->|yes, already fired| O[skip — oneTime gate]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User visits /signal] -->|Before PR| B[next.config.mjs: 308 → /news]
    B --> C[app/news/page.tsx: redirect → /signal]
    C --> B
    B -.->|ERR_TOO_MANY_REDIRECTS| X[💥 Both routes down]

    A2[User visits /signal] -->|After PR| D[app/signal/page.tsx SignalPage renders feed]

    E[User visits /news] --> F[app/news/page.tsx: redirect → /signal]
    F --> D

    G[Konami key sequence] --> H[window keydown listener rolling buffer check]
    H -->|match| I[handleCommandRef.current 'konami']
    I --> J[executeCommand 'konami']
    J --> K{command registered?}
    K -->|no| L[checkEasterEggs]
    L --> M{discoveredEasterEggs includes 'konami'?}
    M -->|no, first time| N[Fire easter egg + recordEasterEgg]
    M -->|yes, already fired| O[skip — oneTime gate]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/terminal/game/GameStateManager.ts`, line 89-91 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/ca1bf99bbda25ca6f0e208476a581f2d14e279cc/components/terminal/game/GameStateManager.ts#L89-L91)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `getGameState()` returns a shallow copy where `discoveredEasterEggs` (an array) is the same reference as the internal `this.gameState.discoveredEasterEggs`. Any caller that receives the "copy" and mutates the array will silently corrupt the manager's internal state. Given that `checkEasterEggs` now relies on this array for correctness, it's worth returning a defensively copied array to prevent accidental drift.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fterminal%2Fgame%2FGameStateManager.ts%0ALine%3A%2089-91%0A%0AComment%3A%0A%60getGameState%28%29%60%20returns%20a%20shallow%20copy%20where%20%60discoveredEasterEggs%60%20%28an%20array%29%20is%20the%20same%20reference%20as%20the%20internal%20%60this.gameState.discoveredEasterEggs%60.%20Any%20caller%20that%20receives%20the%20%22copy%22%20and%20mutates%20the%20array%20will%20silently%20corrupt%20the%20manager's%20internal%20state.%20Given%20that%20%60checkEasterEggs%60%20now%20relies%20on%20this%20array%20for%20correctness%2C%20it's%20worth%20returning%20a%20defensively%20copied%20array%20to%20prevent%20accidental%20drift.%0A%0A%60%60%60suggestion%0A%20%20public%20getGameState%28%29%3A%20GameState%20%7B%0A%20%20%20%20return%20%7B%20...this.gameState%2C%20discoveredEasterEggs%3A%20%5B...this.gameState.discoveredEasterEggs%5D%20%7D%3B%0A%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=45&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fsignal-redirect-loop-and-onetime-eggs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsignal-redirect-loop-and-onetime-eggs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fterminal%2Fgame%2FGameStateManager.ts%0ALine%3A%2089-91%0A%0AComment%3A%0A%60getGameState%28%29%60%20returns%20a%20shallow%20copy%20where%20%60discoveredEasterEggs%60%20%28an%20array%29%20is%20the%20same%20reference%20as%20the%20internal%20%60this.gameState.discoveredEasterEggs%60.%20Any%20caller%20that%20receives%20the%20%22copy%22%20and%20mutates%20the%20array%20will%20silently%20corrupt%20the%20manager's%20internal%20state.%20Given%20that%20%60checkEasterEggs%60%20now%20relies%20on%20this%20array%20for%20correctness%2C%20it's%20worth%20returning%20a%20defensively%20copied%20array%20to%20prevent%20accidental%20drift.%0A%0A%60%60%60suggestion%0A%20%20public%20getGameState%28%29%3A%20GameState%20%7B%0A%20%20%20%20return%20%7B%20...this.gameState%2C%20discoveredEasterEggs%3A%20%5B...this.gameState.discoveredEasterEggs%5D%20%7D%3B%0A%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=45&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2Fterminal%2FCommandProcessor.ts%3A115-117%0A**%60getGameState%28%29%60%20called%20on%20every%20loop%20iteration**%0A%0A%60getGameState%28%29%60%20is%20called%20inside%20the%20%60for%20%28const%20egg%20of%20easterEggs%29%60%20loop%2C%20once%20per%20egg%2C%20even%20though%20the%20result%20only%20changes%20after%20a%20%60recordEasterEgg%28%29%60%20call%20which%20only%20happens%20after%20the%20loop%20exits%20via%20%60return%60.%20Each%20call%20allocates%20a%20new%20shallow-copy%20object%20unnecessarily.%20Hoisting%20this%20single%20call%20before%20the%20loop%20would%20eliminate%20the%20redundant%20allocations%20and%20make%20the%20lookup's%20single-source-of-truth%20intent%20clearer.%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Fterminal%2Fgame%2FGameStateManager.ts%3A89-91%0A%60getGameState%28%29%60%20returns%20a%20shallow%20copy%20where%20%60discoveredEasterEggs%60%20%28an%20array%29%20is%20the%20same%20reference%20as%20the%20internal%20%60this.gameState.discoveredEasterEggs%60.%20Any%20caller%20that%20receives%20the%20%22copy%22%20and%20mutates%20the%20array%20will%20silently%20corrupt%20the%20manager's%20internal%20state.%20Given%20that%20%60checkEasterEggs%60%20now%20relies%20on%20this%20array%20for%20correctness%2C%20it's%20worth%20returning%20a%20defensively%20copied%20array%20to%20prevent%20accidental%20drift.%0A%0A%60%60%60suggestion%0A%20%20public%20getGameState%28%29%3A%20GameState%20%7B%0A%20%20%20%20return%20%7B%20...this.gameState%2C%20discoveredEasterEggs%3A%20%5B...this.gameState.discoveredEasterEggs%5D%20%7D%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=45&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fsignal-redirect-loop-and-onetime-eggs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsignal-redirect-loop-and-onetime-eggs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2Fterminal%2FCommandProcessor.ts%3A115-117%0A**%60getGameState%28%29%60%20called%20on%20every%20loop%20iteration**%0A%0A%60getGameState%28%29%60%20is%20called%20inside%20the%20%60for%20%28const%20egg%20of%20easterEggs%29%60%20loop%2C%20once%20per%20egg%2C%20even%20though%20the%20result%20only%20changes%20after%20a%20%60recordEasterEgg%28%29%60%20call%20which%20only%20happens%20after%20the%20loop%20exits%20via%20%60return%60.%20Each%20call%20allocates%20a%20new%20shallow-copy%20object%20unnecessarily.%20Hoisting%20this%20single%20call%20before%20the%20loop%20would%20eliminate%20the%20redundant%20allocations%20and%20make%20the%20lookup's%20single-source-of-truth%20intent%20clearer.%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Fterminal%2Fgame%2FGameStateManager.ts%3A89-91%0A%60getGameState%28%29%60%20returns%20a%20shallow%20copy%20where%20%60discoveredEasterEggs%60%20%28an%20array%29%20is%20the%20same%20reference%20as%20the%20internal%20%60this.gameState.discoveredEasterEggs%60.%20Any%20caller%20that%20receives%20the%20%22copy%22%20and%20mutates%20the%20array%20will%20silently%20corrupt%20the%20manager's%20internal%20state.%20Given%20that%20%60checkEasterEggs%60%20now%20relies%20on%20this%20array%20for%20correctness%2C%20it's%20worth%20returning%20a%20defensively%20copied%20array%20to%20prevent%20accidental%20drift.%0A%0A%60%60%60suggestion%0A%20%20public%20getGameState%28%29%3A%20GameState%20%7B%0A%20%20%20%20return%20%7B%20...this.gameState%2C%20discoveredEasterEggs%3A%20%5B...this.gameState.discoveredEasterEggs%5D%20%7D%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=45&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: remove /signal redirect loop and ma..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/ca1bf99bbda25ca6f0e208476a581f2d14e279cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39642523)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->