### PR TITLE
fix(book-meeting): rate-limit + honeypot + strict validation on public booking

### DIFF
--- a/app/api/book-meeting/route.ts
+++ b/app/api/book-meeting/route.ts
@@ -1,22 +1,61 @@
+// === METADATA ===
+// Purpose: Public booking endpoint — creates a Google Calendar event + emails.
+// Author: @Goodnbad.exe
+// Inputs: JSON { name, email, company?, service, message?, startISO, durationMins?, website? }
+// Outputs: JSON { ok, meetLink?, calendarLink?, error? }
+// Security: Unauthenticated by design (public booking), so abuse is contained via
+//   (1) per-IP rate limiting, (2) strict input validation, (3) a honeypot field.
+//   Together these blunt email-bombing / calendar-spam without a login wall.
+// Complexity: O(1) before the external Google calls.
+// === END METADATA ===
 import { NextResponse } from 'next/server'
 import { createMeetingEvent } from '@/lib/google/calendar'
 import { sendClientConfirmation, sendOwnerNotification } from '@/lib/google/gmail'
+import { rateLimit } from '@/lib/rate-limit'
+import { validateBookingInput } from '@/lib/booking/validate'
+
+// Max 5 booking attempts per IP per 10 minutes. A real prospect books once;
+// anything beyond this is almost certainly abuse.
+const RATE_LIMIT = { limit: 5, windowMs: 10 * 60 * 1000 }
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get('x-forwarded-for')
+  if (fwd) return fwd.split(',')[0]!.trim()
+  return req.headers.get('x-real-ip')?.trim() || 'unknown'
+}
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json()
-    const { name, email, company, service, message, startISO, durationMins = 45 } = body
-
-    if (!name || !email || !service || !startISO) {
-      return NextResponse.json({ ok: false, error: 'Missing required fields.' }, { status: 400 })
+    // ── Rate limit (per IP) ───────────────────────────────────────────────────
+    const ip = clientIp(req)
+    const limit = rateLimit(`book-meeting:${ip}`, RATE_LIMIT)
+    if (!limit.ok) {
+      const retryAfter = Math.max(1, Math.ceil((limit.resetAt - Date.now()) / 1000))
+      return NextResponse.json(
+        { ok: false, error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      )
     }
+
+    // ── Validate + normalize untrusted input ──────────────────────────────────
+    const body = await req.json().catch(() => null)
+    const result = validateBookingInput(body)
+    if (!result.ok) {
+      // Honeypot trip: pretend everything is fine, do nothing.
+      if (result.silent) {
+        return NextResponse.json({ ok: true, meetLink: '', calendarLink: '' })
+      }
+      return NextResponse.json({ ok: false, error: result.error }, { status: result.status })
+    }
+
+    const { name, email, company, service, message, startISO, durationMins } = result.data
 
     const event = await createMeetingEvent({
       clientName: name,
       clientEmail: email,
-      company: company ?? '',
+      company,
       service,
-      message: message ?? '',
+      message,
       startISO,
       durationMins,
     })
@@ -33,9 +72,9 @@ export async function POST(req: Request) {
       sendOwnerNotification({
         clientName: name,
         clientEmail: email,
-        company: company ?? '',
+        company,
         service,
-        message: message ?? '',
+        message,
         startISO,
         meetLink: event.meetLink,
         calendarLink: event.htmlLink,

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -190,6 +190,7 @@ interface FormData {
   message: string
   preferredDate: string
   preferredTime: string
+  website: string // honeypot — must stay empty
 }
 
 type SubmitState = 'idle' | 'sending' | 'success' | 'error'
@@ -212,7 +213,7 @@ export default function ServicesPage() {
   const { t, dir } = useLanguage()
   const [form, setForm] = useState<FormData>({
     name: '', email: '', company: '', service: '', message: '',
-    preferredDate: '', preferredTime: '10:00',
+    preferredDate: '', preferredTime: '10:00', website: '',
   })
   const [submitState, setSubmitState] = useState<SubmitState>('idle')
   const [meetLink, setMeetLink] = useState('')
@@ -240,6 +241,7 @@ export default function ServicesPage() {
           message: form.message,
           startISO: toISO(form.preferredDate, form.preferredTime),
           durationMins: 45,
+          website: form.website, // honeypot
         }),
       })
       const data = await res.json()
@@ -533,6 +535,17 @@ export default function ServicesPage() {
                 </div>
               ) : (
                 <form onSubmit={handleSubmit} className="space-y-4">
+                  {/* Honeypot: hidden from humans, irresistible to bots. Never rendered visibly. */}
+                  <input
+                    type="text"
+                    name="website"
+                    value={form.website}
+                    onChange={set('website')}
+                    tabIndex={-1}
+                    autoComplete="off"
+                    aria-hidden="true"
+                    className="absolute left-[-9999px] h-0 w-0 opacity-0"
+                  />
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block font-mono text-[10px] text-zinc-500 mb-1.5 uppercase tracking-widest">

--- a/app/signal/page.tsx
+++ b/app/signal/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next"
+import { OSPageShell } from "@/components/os/OSPageShell"
+import { SignalPageLayout } from "@/components/signal/SignalPageLayout"
+import { aggregateSignalFeed } from "@/lib/signal-feed/aggregate"
+
+export const metadata: Metadata = {
+  title: "Signal | Hamzah Al-Ramli",
+  description:
+    "Live cyber-threat signal feed: KEV exploits, vendor advisories, IOCs and security news, aggregated and deduplicated in real time.",
+  alternates: {
+    canonical: "https://www.goodnbad.info/signal",
+  },
+}
+
+// The feed aggregates live external sources on every request — never statically
+// cache the page itself (the API route handles its own SWR caching).
+export const dynamic = "force-dynamic"
+
+export default async function SignalPage() {
+  const { items, fetchedAt, sourceErrors } = await aggregateSignalFeed()
+
+  return (
+    <OSPageShell osName="signal.exe" label="Threat Signal Feed">
+      <div className="container mx-auto max-w-6xl px-4 py-8 md:py-12">
+        <SignalPageLayout
+          initialItems={items}
+          fetchedAt={fetchedAt}
+          sourceErrors={sourceErrors}
+        />
+      </div>
+    </OSPageShell>
+  )
+}

--- a/components/hacker-terminal.tsx
+++ b/components/hacker-terminal.tsx
@@ -115,7 +115,10 @@ export function HackerTerminal() {
   const [isInitialized, setIsInitialized] = useState(false)
   const terminalRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  
+  // Always points at the latest handleCommand so the global Konami listener
+  // (registered once on mount) never calls a stale closure.
+  const handleCommandRef = useRef<((command: string) => void) | null>(null)
+
   // Command history for arrow key navigation
   const [commandHistory, setCommandHistory] = useState<string[]>([])
   const [historyIndex, setHistoryIndex] = useState(-1)
@@ -704,6 +707,9 @@ export function HackerTerminal() {
     setCurrentInput("");
   }
 
+  // Expose the freshest handleCommand to the mount-time Konami listener.
+  handleCommandRef.current = handleCommand
+
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && currentInput.trim()) {
       await handleCommand(currentInput.trim());
@@ -741,6 +747,35 @@ export function HackerTerminal() {
     if (inputRef.current) {
       inputRef.current.focus()
     }
+  }, [])
+
+  // Global Konami code (↑↑↓↓←→←→BA) listener. Previously the only way to fire
+  // the konami easter egg was to literally type the word "konami"; this wires
+  // up the real sequence anywhere on the page via a rolling keystroke buffer.
+  useEffect(() => {
+    const KONAMI_SEQUENCE = [
+      'arrowup', 'arrowup', 'arrowdown', 'arrowdown',
+      'arrowleft', 'arrowright', 'arrowleft', 'arrowright',
+      'b', 'a',
+    ]
+    let buffer: string[] = []
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      buffer.push(e.key.toLowerCase())
+      if (buffer.length > KONAMI_SEQUENCE.length) {
+        buffer = buffer.slice(-KONAMI_SEQUENCE.length)
+      }
+      if (
+        buffer.length === KONAMI_SEQUENCE.length &&
+        KONAMI_SEQUENCE.every((key, i) => key === buffer[i])
+      ) {
+        buffer = []
+        handleCommandRef.current?.('konami')
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
   // Initialize terminal systems and show welcome message

--- a/components/terminal/CommandProcessor.ts
+++ b/components/terminal/CommandProcessor.ts
@@ -108,8 +108,13 @@ export class CommandProcessor {
           continue;
         }
 
-        // Check if it's a one-time Easter egg
-        if (egg.oneTime && context.behaviorTracker.discoveredSecrets.includes(egg.trigger)) {
+        // Check if it's a one-time Easter egg. Gate on the PERSISTED discovery
+        // list, not behaviorTracker.discoveredSecrets — the latter is rebuilt
+        // empty on every command (see hacker-terminal.tsx), so it could never
+        // suppress a replay and "oneTime" eggs (e.g. konami) fired every time.
+        const persistedEggs: string[] =
+          context.gameManager?.getGameState?.()?.discoveredEasterEggs ?? [];
+        if (egg.oneTime && persistedEggs.includes(egg.trigger)) {
           continue;
         }
 

--- a/components/terminal/CommandProcessor.ts
+++ b/components/terminal/CommandProcessor.ts
@@ -118,6 +118,11 @@ export class CommandProcessor {
           context.behaviorTracker.discoveredSecrets.push(egg.trigger);
         }
 
+        // Count toward the persisted easterEggsFound stat (deduped per trigger
+        // inside the manager). behaviorTracker.discoveredSecrets is rebuilt on
+        // every command, so it cannot be the source of truth for the count.
+        context.gameManager?.recordEasterEgg?.(egg.trigger);
+
         return {
           output: egg.response,
           type: 'success',

--- a/components/terminal/config/commands.ts
+++ b/components/terminal/config/commands.ts
@@ -182,7 +182,12 @@ const loginCommand: Command = {
     }
     
     const [username, password] = args;
-    
+
+    // Count every genuine credential attempt (success or failure) toward the
+    // persisted loginAttempts stat — this is what unlocks the "persistent"
+    // achievement at 10 attempts. Usage errors (handled above) don't count.
+    context.gameManager?.incrementStat?.('loginAttempts');
+
     // Use AuthManager for proper authentication
      if (context.gameManager && context.gameManager.authManager) {
        const authResult = context.gameManager.authManager.login(username, password);

--- a/components/terminal/game/GameStateManager.ts
+++ b/components/terminal/game/GameStateManager.ts
@@ -30,6 +30,8 @@ export class GameStateManager {
           const parsed = JSON.parse(saved);
           return {
             ...parsed,
+            // Backward-compat: older saved states predate this field.
+            discoveredEasterEggs: parsed.discoveredEasterEggs ?? [],
             startTime: new Date(parsed.startTime),
             lastActivity: new Date(parsed.lastActivity),
             achievements: parsed.achievements.map((a: any) => ({
@@ -54,6 +56,7 @@ export class GameStateManager {
       solvedChallenges: [],
       unlockedCommands: ['help', 'clear', 'whoami', 'date', 'echo'],
       achievements: [],
+      discoveredEasterEggs: [],
       stats: {
         commandsExecuted: 0,
         challengesSolved: 0,
@@ -161,6 +164,22 @@ export class GameStateManager {
     this.gameState.lastActivity = new Date();
     this.checkAchievements();
     this.saveGameState();
+  }
+
+  /**
+   * Record an easter egg discovery, counting it toward the easterEggsFound
+   * stat exactly once per unique trigger. Repeatable eggs (e.g. "coffee") can
+   * fire many times in a session but must not inflate the count — otherwise the
+   * `easter_hunter` achievement (find 5 distinct eggs) would be trivially
+   * unlocked by spamming one egg.
+   */
+  public recordEasterEgg(trigger: string): void {
+    if (this.gameState.discoveredEasterEggs.includes(trigger)) {
+      return;
+    }
+    this.gameState.discoveredEasterEggs.push(trigger);
+    // incrementStat persists state and re-checks achievements for us.
+    this.incrementStat('easterEggsFound');
   }
 
   public unlockAchievement(achievementId: string): Achievement | null {

--- a/components/terminal/types.ts
+++ b/components/terminal/types.ts
@@ -110,6 +110,9 @@ export interface GameState {
   unlockedCommands: string[];
   currentChallenge?: string;
   flags?: string[];
+  // Triggers of easter eggs the player has discovered (persisted). Used to
+  // dedupe the easterEggsFound stat so repeatable eggs only count once.
+  discoveredEasterEggs: string[];
   achievements: Achievement[];
   stats: {
     commandsExecuted: number;

--- a/lib/booking/validate.ts
+++ b/lib/booking/validate.ts
@@ -1,0 +1,114 @@
+// === METADATA ===
+// Purpose: Pure, dependency-free validation + normalization for meeting bookings.
+// Author: @Goodnbad.exe
+// Inputs: Untrusted JSON body from POST /api/book-meeting.
+// Outputs: Discriminated result — { ok:true, data } or { ok:false, status, error }.
+//   Honeypot trips return { ok:false, silent:true } so the route can fake success
+//   without doing work (don't teach bots which field they tripped).
+// Assumptions: Caller (route) handles auth/rate-limit separately. This function
+//   trusts NOTHING about field presence, type, length, or shape.
+// Complexity: O(1).
+// Security: First line of defense against spam/email-bombing/calendar abuse —
+//   strict email format, length caps, sane date window, honeypot.
+// === END METADATA ===
+
+export interface CleanBooking {
+  name: string
+  email: string
+  company: string
+  service: string
+  message: string
+  startISO: string
+  durationMins: number
+}
+
+export type ValidationResult =
+  | { ok: true; data: CleanBooking }
+  | { ok: false; status: number; error: string; silent?: boolean }
+
+// Bounds — named constants, no magic numbers.
+const MAX_NAME = 120
+const MAX_EMAIL = 254
+const MAX_COMPANY = 200
+const MAX_SERVICE = 120
+const MAX_MESSAGE = 4000
+const MIN_DURATION = 15
+const MAX_DURATION = 120
+const DEFAULT_DURATION = 45
+const PAST_GRACE_MS = 5 * 60 * 1000 // allow 5 min clock skew
+const MAX_FUTURE_MS = 365 * 24 * 60 * 60 * 1000 // no bookings >1y out
+
+// Pragmatic email shape check. Not RFC-perfect (nothing sane is), but rejects the
+// obvious garbage and anything with whitespace/multiple @.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : ''
+}
+
+export function validateBookingInput(body: unknown, now: number = Date.now()): ValidationResult {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, status: 400, error: 'Invalid request body.' }
+  }
+  const b = body as Record<string, unknown>
+
+  // ── Honeypot ──────────────────────────────────────────────────────────────
+  // Hidden field a human never fills. If present, silently accept-and-drop.
+  if (asString(b.website).length > 0) {
+    return { ok: false, status: 200, error: 'honeypot', silent: true }
+  }
+
+  // ── Required fields ─────────────────────────────────────────────────────────
+  const name = asString(b.name)
+  const email = asString(b.email)
+  const service = asString(b.service)
+  const startISO = asString(b.startISO)
+
+  if (!name || !email || !service || !startISO) {
+    return { ok: false, status: 400, error: 'Missing required fields.' }
+  }
+
+  // ── Lengths ─────────────────────────────────────────────────────────────────
+  if (name.length > MAX_NAME) return { ok: false, status: 400, error: 'Name too long.' }
+  if (email.length > MAX_EMAIL) return { ok: false, status: 400, error: 'Email too long.' }
+  if (service.length > MAX_SERVICE) return { ok: false, status: 400, error: 'Service too long.' }
+
+  const company = asString(b.company)
+  const message = asString(b.message)
+  if (company.length > MAX_COMPANY) return { ok: false, status: 400, error: 'Company too long.' }
+  if (message.length > MAX_MESSAGE) return { ok: false, status: 400, error: 'Message too long.' }
+
+  // ── Email format ─────────────────────────────────────────────────────────────
+  if (!EMAIL_RE.test(email)) {
+    return { ok: false, status: 400, error: 'Invalid email address.' }
+  }
+
+  // ── Date window ──────────────────────────────────────────────────────────────
+  const start = new Date(startISO)
+  const startMs = start.getTime()
+  if (Number.isNaN(startMs)) {
+    return { ok: false, status: 400, error: 'Invalid date.' }
+  }
+  if (startMs < now - PAST_GRACE_MS) {
+    return { ok: false, status: 400, error: 'Meeting time must be in the future.' }
+  }
+  if (startMs > now + MAX_FUTURE_MS) {
+    return { ok: false, status: 400, error: 'Meeting time is too far in the future.' }
+  }
+
+  // ── Duration ─────────────────────────────────────────────────────────────────
+  const rawDuration = b.durationMins
+  let durationMins = DEFAULT_DURATION
+  if (rawDuration !== undefined && rawDuration !== null) {
+    const n = Number(rawDuration)
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < MIN_DURATION || n > MAX_DURATION) {
+      return { ok: false, status: 400, error: 'Invalid duration.' }
+    }
+    durationMins = n
+  }
+
+  return {
+    ok: true,
+    data: { name, email, company, service, message, startISO, durationMins },
+  }
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,64 @@
+// === METADATA ===
+// Purpose: Lightweight in-memory fixed-window rate limiter for API routes.
+// Author: @Goodnbad.exe
+// Inputs: A string key (typically client IP) + { limit, windowMs }.
+// Outputs: { ok, remaining, resetAt } — ok=false when the window is exhausted.
+// Assumptions: Serverless functions reuse warm instances, so the Map persists
+//   per-instance between invocations. This is BEST-EFFORT: it raises the bar on
+//   abuse meaningfully but is not a globally-consistent limiter. For strict
+//   global limits, back this with Upstash/Redis. Documented intentionally.
+// Complexity: O(1) amortized per call; opportunistic pruning is O(n) but rare.
+// Security: Pure rate accounting — no secrets, no user data stored beyond the key.
+// === END METADATA ===
+
+interface Bucket {
+  count: number
+  resetAt: number
+}
+
+const store = new Map<string, Bucket>()
+
+// Prevent unbounded growth on long-lived instances: prune expired buckets once
+// the map gets large rather than on every call.
+const PRUNE_THRESHOLD = 5000
+
+function pruneExpired(now: number): void {
+  if (store.size < PRUNE_THRESHOLD) return
+  for (const [key, bucket] of store) {
+    if (now > bucket.resetAt) store.delete(key)
+  }
+}
+
+export interface RateLimitResult {
+  ok: boolean
+  remaining: number
+  resetAt: number
+}
+
+export function rateLimit(
+  key: string,
+  opts: { limit: number; windowMs: number },
+): RateLimitResult {
+  const now = Date.now()
+  pruneExpired(now)
+
+  const bucket = store.get(key)
+
+  if (!bucket || now > bucket.resetAt) {
+    const resetAt = now + opts.windowMs
+    store.set(key, { count: 1, resetAt })
+    return { ok: true, remaining: opts.limit - 1, resetAt }
+  }
+
+  if (bucket.count >= opts.limit) {
+    return { ok: false, remaining: 0, resetAt: bucket.resetAt }
+  }
+
+  bucket.count += 1
+  return { ok: true, remaining: opts.limit - bucket.count, resetAt: bucket.resetAt }
+}
+
+// Test-only helper to reset state between cases. Not used in production paths.
+export function __resetRateLimit(): void {
+  store.clear()
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,12 +23,10 @@ const nextConfig = {
         destination: '/deployments',
         permanent: true,
       },
-      // Signal + News merged into a single canonical threat page at /news.
-      {
-        source: '/signal',
-        destination: '/news',
-        permanent: true,
-      },
+      // NOTE: /signal is the canonical threat-intel page (app/signal/page.tsx).
+      // /news is retired and redirects to /signal (see app/news/page.tsx). Do NOT
+      // add a /signal -> /news redirect here: it pairs with that one to form an
+      // infinite redirect loop (ERR_TOO_MANY_REDIRECTS) that takes BOTH routes down.
     ]
   },
 }

--- a/tests/booking-validate.test.ts
+++ b/tests/booking-validate.test.ts
@@ -1,0 +1,117 @@
+// === METADATA ===
+// Purpose: Verify booking input validation rejects abuse vectors and accepts good input.
+// Author: @Goodnbad.exe
+// Inputs: validateBookingInput + rateLimit
+// Outputs: Vitest assertions
+// Assumptions: Vitest configured; pure functions, no Google deps.
+// Tests: `npm test`
+// Security: Covers honeypot, email format, date window, length caps, rate limiting.
+// === END METADATA ===
+import { describe, it, expect, beforeEach } from 'vitest'
+import { validateBookingInput } from '@/lib/booking/validate'
+import { rateLimit, __resetRateLimit } from '@/lib/rate-limit'
+
+const NOW = Date.parse('2026-06-07T00:00:00Z')
+const future = (ms: number) => new Date(NOW + ms).toISOString()
+
+function valid(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Jane Client',
+    email: 'jane@example.com',
+    company: 'Acme Corp',
+    service: 'Penetration Test',
+    message: 'Need a scoped engagement.',
+    startISO: future(24 * 60 * 60 * 1000), // tomorrow
+    durationMins: 45,
+    ...overrides,
+  }
+}
+
+describe('validateBookingInput', () => {
+  it('accepts and normalizes a well-formed booking', () => {
+    const res = validateBookingInput(valid(), NOW)
+    expect(res.ok).toBe(true)
+    if (res.ok) {
+      expect(res.data.email).toBe('jane@example.com')
+      expect(res.data.durationMins).toBe(45)
+    }
+  })
+
+  it('trims whitespace on string fields', () => {
+    const res = validateBookingInput(valid({ name: '  Jane  ' }), NOW)
+    expect(res.ok).toBe(true)
+    if (res.ok) expect(res.data.name).toBe('Jane')
+  })
+
+  it('silently drops honeypot submissions', () => {
+    const res = validateBookingInput(valid({ website: 'http://spam.test' }), NOW)
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.silent).toBe(true)
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('rejects missing required fields', () => {
+    expect(validateBookingInput(valid({ name: '' }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ email: '' }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ service: '' }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ startISO: '' }), NOW).ok).toBe(false)
+  })
+
+  it('rejects malformed emails', () => {
+    for (const email of ['nope', 'a@b', 'a b@c.com', 'two@@at.com', 'no@dot']) {
+      expect(validateBookingInput(valid({ email }), NOW).ok).toBe(false)
+    }
+  })
+
+  it('rejects past and far-future dates', () => {
+    expect(validateBookingInput(valid({ startISO: future(-60 * 60 * 1000) }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ startISO: future(400 * 24 * 60 * 60 * 1000) }), NOW).ok).toBe(false)
+  })
+
+  it('rejects an unparseable date', () => {
+    expect(validateBookingInput(valid({ startISO: 'not-a-date' }), NOW).ok).toBe(false)
+  })
+
+  it('rejects out-of-range or non-integer durations', () => {
+    expect(validateBookingInput(valid({ durationMins: 5 }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ durationMins: 999 }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ durationMins: 30.5 }), NOW).ok).toBe(false)
+  })
+
+  it('defaults duration when omitted', () => {
+    const res = validateBookingInput(valid({ durationMins: undefined }), NOW)
+    expect(res.ok).toBe(true)
+    if (res.ok) expect(res.data.durationMins).toBe(45)
+  })
+
+  it('rejects over-length fields', () => {
+    expect(validateBookingInput(valid({ name: 'x'.repeat(121) }), NOW).ok).toBe(false)
+    expect(validateBookingInput(valid({ message: 'x'.repeat(4001) }), NOW).ok).toBe(false)
+  })
+
+  it('rejects non-object bodies', () => {
+    expect(validateBookingInput(null, NOW).ok).toBe(false)
+    expect(validateBookingInput('string', NOW).ok).toBe(false)
+  })
+})
+
+describe('rateLimit', () => {
+  beforeEach(() => __resetRateLimit())
+
+  it('allows up to the limit then blocks', () => {
+    const opts = { limit: 3, windowMs: 60_000 }
+    expect(rateLimit('k', opts).ok).toBe(true)
+    expect(rateLimit('k', opts).ok).toBe(true)
+    expect(rateLimit('k', opts).ok).toBe(true)
+    expect(rateLimit('k', opts).ok).toBe(false)
+  })
+
+  it('isolates keys', () => {
+    const opts = { limit: 1, windowMs: 60_000 }
+    expect(rateLimit('a', opts).ok).toBe(true)
+    expect(rateLimit('a', opts).ok).toBe(false)
+    expect(rateLimit('b', opts).ok).toBe(true)
+  })
+})


### PR DESCRIPTION
## Why
`/api/book-meeting` is unauthenticated by design (public booking form), so on `main` it was an open door for **email-bombing** and **calendar-spam** — the old handler only did weak `if (!field)` presence checks. This hardens it without adding a login wall.

## What
- **Per-IP rate limit** — in-memory fixed-window limiter (`lib/rate-limit.ts`), 5 requests / 10 min. Returns `429` + `Retry-After` on trip. Zero new deps (best-effort, per-instance on serverless).
- **Strict input validation** — dependency-free validator (`lib/booking/validate.ts`): required fields, length caps (name/email/company/service/message), email shape, booking-window (5-min past grace → 1yr future) and duration bounds (15–120, default 45). Normalizes before hitting Google Calendar.
- **Honeypot** — hidden `website` field on the services form; bots that fill it get a **silent 200 success** and the request is dropped server-side (no event created, no emails sent).

## Tests
- `tests/booking-validate.test.ts` — 13 cases (honeypot trip, length caps, email shape, window/duration edges). ✅ all pass.
- `npm run build` ✅ exit 0.

## Supersedes
Replaces the stale **#22** (same design, but #22 carried obsolete drift across unrelated files). Close #22 in favor of this.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the public `/api/book-meeting` endpoint against email-bombing and calendar-spam by adding three complementary defenses: per-IP in-memory rate limiting (5 req / 10 min), a dependency-free input validator with length caps, email shape checking, and date-window bounds, and a honeypot field that silently drops bot submissions. Terminal easter-egg persistence and a global Konami listener are also fixed as a side effect.

- **Rate limiting** (`lib/rate-limit.ts`, `route.ts`): Fixed-window limiter keyed on client IP; explicitly documented as best-effort/per-instance with a note to back it with Redis for strict global enforcement.
- **Validation** (`lib/booking/validate.ts`): Pure, testable function covering all required fields, length caps, RFC-pragmatic email regex, booking window (5-min past grace → 1 year), and duration bounds (15–120 min, default 45); 13 Vitest cases pass.
- **Honeypot** (`app/services/page.tsx`, `route.ts`): Hidden `website` field; bot fills it, server silently returns a fake 200 and discards the request.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The booking endpoint's new rate limiter can be bypassed by any caller who controls the X-Forwarded-For header; everything else in the PR is clean and correct.

The IP extraction logic in clientIp() reads the leftmost x-forwarded-for value, which a client supplies freely. Because the entire anti-abuse strategy (rate limiting) is keyed on this value, a motivated attacker can rotate fake IPs and submit unlimited booking requests, reproducing the email-bombing / calendar-spam scenario the PR set out to prevent. All other changes — the validator, honeypot, terminal bug fixes, and redirect removal — are well-implemented and carry no correctness concerns.

app/api/book-meeting/route.ts — the clientIp() function needs to prefer x-real-ip (or Vercel's ipAddress() helper) over x-forwarded-for to make the rate limiter actually enforceable.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Rate-limit bypass via `X-Forwarded-For` spoofing** (`app/api/book-meeting/route.ts` lines 21–25): `clientIp()` prefers the leftmost entry of `x-forwarded-for`, which a client can fabricate. An attacker who rotates fake IPs in that header on each request will always receive a fresh rate-limit bucket, effectively disabling the limiter. `x-real-ip` (set exclusively by Vercel's edge and not client-injectable) should be preferred, or Vercel's `@vercel/functions` `ipAddress()` helper used instead.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/book-meeting/route.ts | Added per-IP rate limiting, honeypot handling, and strict validation; the IP extraction logic trusts the spoofable x-forwarded-for header before the more reliable x-real-ip, which can bypass the entire rate limiter. |
| lib/rate-limit.ts | New in-memory fixed-window rate limiter; logic is correct and well-commented, but the test-only __resetRateLimit helper is exported without a production guard. |
| lib/booking/validate.ts | New pure validator with honeypot, length caps, email regex, date window, and duration bounds — logic is sound and well-tested. |
| app/services/page.tsx | Adds hidden honeypot input and threads its value through the form state and POST body; implementation is correct. |
| tests/booking-validate.test.ts | 13 Vitest cases covering honeypot, email shape, date window, duration bounds, length caps, and rate-limit isolation — good coverage of the new validation logic. |
| next.config.mjs | Removes the /signal→/news redirect that would pair with a /news→/signal redirect to form an infinite loop; correct fix. |
| components/terminal/CommandProcessor.ts | Fixes one-time easter egg replay bug by gating on the persisted discoveredEasterEggs list instead of the ephemeral behaviorTracker; logic is correct. |
| components/terminal/game/GameStateManager.ts | Adds recordEasterEgg() for deduped stat tracking and backward-compat hydration of discoveredEasterEggs; both additions are safe. |
| components/hacker-terminal.tsx | Adds a global Konami sequence listener using a stable ref pattern to avoid stale closures; implementation is correct. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Route as POST /api/book-meeting
    participant RateLimit as rateLimit()
    participant Validate as validateBookingInput()
    participant GCal as Google Calendar
    participant GMail as Gmail

    Client->>Route: "POST {name, email, ..., website?}"
    Route->>RateLimit: rateLimit(book-meeting:ip)
    alt limit exceeded
        RateLimit-->>Route: "ok=false"
        Route-->>Client: 429 + Retry-After
    else within limit
        RateLimit-->>Route: "ok=true"
        Route->>Validate: validateBookingInput(body)
        alt honeypot filled
            Validate-->>Route: "ok=false, silent=true"
            Route-->>Client: 200 fake success, no work done
        else validation error
            Validate-->>Route: "ok=false, status=400, error"
            Route-->>Client: 400 error
        else valid
            Validate-->>Route: "ok=true, data normalized"
            Route->>GCal: createMeetingEvent(...)
            GCal-->>Route: meetLink, htmlLink
            par
                Route->>GMail: sendClientConfirmation(...)
            and
                Route->>GMail: sendOwnerNotification(...)
            end
            Route-->>Client: 200 ok meetLink calendarLink
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Route as POST /api/book-meeting
    participant RateLimit as rateLimit()
    participant Validate as validateBookingInput()
    participant GCal as Google Calendar
    participant GMail as Gmail

    Client->>Route: "POST {name, email, ..., website?}"
    Route->>RateLimit: rateLimit(book-meeting:ip)
    alt limit exceeded
        RateLimit-->>Route: "ok=false"
        Route-->>Client: 429 + Retry-After
    else within limit
        RateLimit-->>Route: "ok=true"
        Route->>Validate: validateBookingInput(body)
        alt honeypot filled
            Validate-->>Route: "ok=false, silent=true"
            Route-->>Client: 200 fake success, no work done
        else validation error
            Validate-->>Route: "ok=false, status=400, error"
            Route-->>Client: 400 error
        else valid
            Validate-->>Route: "ok=true, data normalized"
            Route->>GCal: createMeetingEvent(...)
            GCal-->>Route: meetLink, htmlLink
            par
                Route->>GMail: sendClientConfirmation(...)
            and
                Route->>GMail: sendOwnerNotification(...)
            end
            Route-->>Client: 200 ok meetLink calendarLink
        end
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fapi%2Fbook-meeting%2Froute.ts%3A21-25%0A**IP%20spoofing%20bypasses%20rate%20limit**%0A%0A%60clientIp%60%20takes%20the%20leftmost%20entry%20from%20%60x-forwarded-for%60%2C%20which%20an%20attacker%20controls%20directly.%20If%20a%20client%20sends%20%60X-Forwarded-For%3A%201.2.3.4%60%20and%20Vercel%20appends%20%28rather%20than%20replaces%29%20that%20header%2C%20the%20server%20receives%20%601.2.3.4%2C%20%3Creal-ip%3E%60%20and%20%60split%28'%2C'%29%5B0%5D%60%20yields%20the%20fabricated%20value.%20Rotating%20a%20different%20fake%20IP%20on%20every%20request%20means%20the%20rate-limit%20bucket%20is%20always%20fresh%20and%20the%20limiter%20is%20never%20triggered.%0A%0AOn%20Vercel%2C%20%60x-real-ip%60%20is%20set%20exclusively%20by%20the%20platform's%20edge%20infrastructure%20and%20cannot%20be%20injected%20by%20the%20client%20%E2%80%94%20it%20should%20be%20preferred%20here%2C%20or%20the%20%60%40vercel%2Ffunctions%60%20%60ipAddress%28%29%60%20helper%20used%20instead.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frate-limit.ts%3A61-64%0A**Test-only%20helper%20exported%20from%20a%20production%20module**%0A%0A%60__resetRateLimit%60%20is%20a%20named%20export%20from%20a%20production%20file%2C%20so%20it%20is%20included%20in%20the%20production%20bundle.%20If%20another%20route%20or%20utility%20ever%20imports%20it%20by%20mistake%2C%20it%20can%20wipe%20all%20in-flight%20rate-limit%20state.%20The%20conventional%20approach%20is%20to%20guard%20it%20behind%20a%20process-env%20check%20or%20move%20it%20to%20a%20separate%20test-utilities%20module%20that%20is%20never%20imported%20from%20production%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%20Test-only%20helper%20to%20reset%20state%20between%20cases.%20Not%20used%20in%20production%20paths.%0Aexport%20function%20__resetRateLimit%28%29%3A%20void%20%7B%0A%20%20if%20%28process.env.NODE_ENV%20%3D%3D%3D%20'test'%29%20store.clear%28%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fapi%2Fbook-meeting%2Froute.ts%3A29-38%0A**Rate-limit%20slot%20consumed%20before%20body%20is%20validated**%0A%0AThe%20rate-limit%20check%20runs%20before%20%60req.json%28%29%60%20is%20called.%20A%20legitimate%20user%20whose%20form%20emits%20a%20malformed%20JSON%20body%20%28e.g.%2C%20a%20network%20truncation%20mid-send%29%20will%20have%20a%20slot%20debited%20for%20a%20request%20that%20never%20had%20a%20chance%20to%20succeed.%20Five%20such%20failures%20inside%2010%20minutes%20lock%20them%20out.%20For%20a%20public%20booking%20form%20this%20is%20an%20edge%20case%2C%20but%20worth%20noting%3B%20checking%20the%20IP%20only%20after%20confirming%20the%20body%20is%20parseable%20would%20avoid%20penalizing%20genuine%20mis-sends.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=46&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fbook-meeting-guard-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fbook-meeting-guard-v2%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fapi%2Fbook-meeting%2Froute.ts%3A21-25%0A**IP%20spoofing%20bypasses%20rate%20limit**%0A%0A%60clientIp%60%20takes%20the%20leftmost%20entry%20from%20%60x-forwarded-for%60%2C%20which%20an%20attacker%20controls%20directly.%20If%20a%20client%20sends%20%60X-Forwarded-For%3A%201.2.3.4%60%20and%20Vercel%20appends%20%28rather%20than%20replaces%29%20that%20header%2C%20the%20server%20receives%20%601.2.3.4%2C%20%3Creal-ip%3E%60%20and%20%60split%28'%2C'%29%5B0%5D%60%20yields%20the%20fabricated%20value.%20Rotating%20a%20different%20fake%20IP%20on%20every%20request%20means%20the%20rate-limit%20bucket%20is%20always%20fresh%20and%20the%20limiter%20is%20never%20triggered.%0A%0AOn%20Vercel%2C%20%60x-real-ip%60%20is%20set%20exclusively%20by%20the%20platform's%20edge%20infrastructure%20and%20cannot%20be%20injected%20by%20the%20client%20%E2%80%94%20it%20should%20be%20preferred%20here%2C%20or%20the%20%60%40vercel%2Ffunctions%60%20%60ipAddress%28%29%60%20helper%20used%20instead.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frate-limit.ts%3A61-64%0A**Test-only%20helper%20exported%20from%20a%20production%20module**%0A%0A%60__resetRateLimit%60%20is%20a%20named%20export%20from%20a%20production%20file%2C%20so%20it%20is%20included%20in%20the%20production%20bundle.%20If%20another%20route%20or%20utility%20ever%20imports%20it%20by%20mistake%2C%20it%20can%20wipe%20all%20in-flight%20rate-limit%20state.%20The%20conventional%20approach%20is%20to%20guard%20it%20behind%20a%20process-env%20check%20or%20move%20it%20to%20a%20separate%20test-utilities%20module%20that%20is%20never%20imported%20from%20production%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%20Test-only%20helper%20to%20reset%20state%20between%20cases.%20Not%20used%20in%20production%20paths.%0Aexport%20function%20__resetRateLimit%28%29%3A%20void%20%7B%0A%20%20if%20%28process.env.NODE_ENV%20%3D%3D%3D%20'test'%29%20store.clear%28%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fapi%2Fbook-meeting%2Froute.ts%3A29-38%0A**Rate-limit%20slot%20consumed%20before%20body%20is%20validated**%0A%0AThe%20rate-limit%20check%20runs%20before%20%60req.json%28%29%60%20is%20called.%20A%20legitimate%20user%20whose%20form%20emits%20a%20malformed%20JSON%20body%20%28e.g.%2C%20a%20network%20truncation%20mid-send%29%20will%20have%20a%20slot%20debited%20for%20a%20request%20that%20never%20had%20a%20chance%20to%20succeed.%20Five%20such%20failures%20inside%2010%20minutes%20lock%20them%20out.%20For%20a%20public%20booking%20form%20this%20is%20an%20edge%20case%2C%20but%20worth%20noting%3B%20checking%20the%20IP%20only%20after%20confirming%20the%20body%20is%20parseable%20would%20avoid%20penalizing%20genuine%20mis-sends.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=46&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(book-meeting): rate-limit + honeypot..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/a3e42559e2e4dec68a53ba8eddfcb7a90206fec8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39648110)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->