### PR TITLE
fix(terminal): wire AuthManager into command context

### DIFF
--- a/components/hacker-terminal.tsx
+++ b/components/hacker-terminal.tsx
@@ -158,9 +158,16 @@ export function HackerTerminal() {
   // Initialize managers on client side only
   useEffect(() => {
     if (typeof window !== 'undefined') {
+      const auth = new AuthManager();
+      const game = new GameStateManager();
+      // Wire auth into the game manager so command handlers can reach it via
+      // context.gameManager.authManager (login/logout/su all expect that path).
+      // Without this, every auth command silently fell through to the hardcoded
+      // fallback credentials instead of the real AuthManager.
+      ;(game as any).authManager = auth;
       setCommandProcessor(new CommandProcessor());
-      setAuthManager(new AuthManager());
-      setGameManager(new GameStateManager());
+      setAuthManager(auth);
+      setGameManager(game);
     }
   }, []);
 


### PR DESCRIPTION
## Why
The terminal's `login`, `logout`, and `su` command handlers all gate on `context.gameManager.authManager`, but the per-command `TerminalContext` only ever carried the `GameStateManager` — the `AuthManager` was instantiated but **never reachable from any command**. Because `TerminalContext.gameManager` is typed `any`, TypeScript never flagged the missing `.authManager`, so every auth command silently fell through to the **hardcoded fallback credentials** path instead of the real `AuthManager`.

## What
Attach the `AuthManager` onto the `GameStateManager` instance at construction (in the client init effect), so `context.gameManager.authManager` resolves to the *same* instance that backs `getCurrentUser()` / `getCurrentSession()`. One source of truth, no per-command re-wiring.

Verified `AuthManager` exposes `login` / `logout` / `switchUser` / `getCurrentUser` / `getCurrentSession` — the wiring reaches real methods, not a crash.

## Tests
- `npm run build` ✅ exit 0.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent auth bypass: the `login`, `logout`, and `su` command handlers all read `context.gameManager.authManager`, but `AuthManager` was never attached to the `GameStateManager`, so those commands always fell through to hardcoded fallback logic. The fix instantiates both managers together and attaches `auth` onto `game` before storing them in React state.

- The single-instance unification is correct — both React state and the command context now share the same `AuthManager`, eliminating the split-brain problem.
- However, the now-functional `logout` path calls `AuthManager.logout()`, which sets `currentSession = null` without restoring a guest session. The `handleCommand` guard immediately blocks all subsequent commands with \"Error: No active session\", locking the terminal until a full page refresh.
- The attachment uses `(game as any).authManager = auth`, bypassing TypeScript — a cleaner path would thread `authManager` directly through `TerminalContext`.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change fixes a real auth bypass but introduces a terminal lockout on every successful logout — users cannot type any command after logging out without refreshing the page.

The auth wiring itself is correct and the single-instance unification is sound, but the now-functional logout path destroys the session without restoring a guest session. Any user who runs `logout` lands in a broken terminal state for the rest of their session. The root cause is that `AuthManager.logout()` clears `currentSession` to `null` and `handleCommand` gates every subsequent command on a non-null session, with no recovery path short of a page reload.

components/hacker-terminal.tsx — specifically the post-logout session recovery path and the untyped authManager property attachment.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/hacker-terminal.tsx | Wires AuthManager onto GameStateManager via an untyped dynamic property so command handlers can reach it via context.gameManager.authManager; the fix correctly unifies the two previously-separate instances, but the now-functional logout path destroys the session without restoring a guest session, locking the terminal after every logout. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant handleCommand
    participant AuthManager
    participant logoutCommand

    Note over handleCommand,AuthManager: After this PR — auth is wired
    User->>handleCommand: types "logout"
    handleCommand->>AuthManager: getCurrentUser() → guest
    handleCommand->>AuthManager: getCurrentSession() → session
    handleCommand->>logoutCommand: executeCommand("logout", context)
    logoutCommand->>AuthManager: "logout() — sets currentSession = null"
    logoutCommand-->>handleCommand: "{output: "Logged out...", type: "info"}"

    User->>handleCommand: types next command
    handleCommand->>AuthManager: getCurrentUser() → null ⚠️
    handleCommand->>AuthManager: getCurrentSession() → null ⚠️
    handleCommand-->>User: "Error: No active session. Please restart the terminal."
    Note over User,handleCommand: Terminal locked until page refresh
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant handleCommand
    participant AuthManager
    participant logoutCommand

    Note over handleCommand,AuthManager: After this PR — auth is wired
    User->>handleCommand: types "logout"
    handleCommand->>AuthManager: getCurrentUser() → guest
    handleCommand->>AuthManager: getCurrentSession() → session
    handleCommand->>logoutCommand: executeCommand("logout", context)
    logoutCommand->>AuthManager: "logout() — sets currentSession = null"
    logoutCommand-->>handleCommand: "{output: "Logged out...", type: "info"}"

    User->>handleCommand: types next command
    handleCommand->>AuthManager: getCurrentUser() → null ⚠️
    handleCommand->>AuthManager: getCurrentSession() → null ⚠️
    handleCommand-->>User: "Error: No active session. Please restart the terminal."
    Note over User,handleCommand: Terminal locked until page refresh
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `components/hacker-terminal.tsx`, line 260-261 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/2a853cd02553e69857f88a79fb833074523b5cbc/components/hacker-terminal.tsx#L260-L261)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Post-logout terminal lockout**

   Now that `authManager` is properly wired, `logout` actually calls `AuthManager.logout()`, which sets `this.currentSession = null`. The very next command the user types calls `authManager.getCurrentUser()` → `null`, which triggers the guard at line ~293: `"Error: No active session. Please restart the terminal."` — the terminal is completely unusable until a hard refresh.

   Before this PR the `logout` command silently fell through to the no-op fallback (because `context.gameManager.authManager` was undefined), so the React-state `authManager` kept its active session intact. Now that the wiring works, `logout()` destroys the session without ever restoring a guest session, making the bug reproducible on every successful logout.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fhacker-terminal.tsx%0ALine%3A%20260-261%0A%0AComment%3A%0A**Post-logout%20terminal%20lockout**%0A%0ANow%20that%20%60authManager%60%20is%20properly%20wired%2C%20%60logout%60%20actually%20calls%20%60AuthManager.logout%28%29%60%2C%20which%20sets%20%60this.currentSession%20%3D%20null%60.%20The%20very%20next%20command%20the%20user%20types%20calls%20%60authManager.getCurrentUser%28%29%60%20%E2%86%92%20%60null%60%2C%20which%20triggers%20the%20guard%20at%20line%20~293%3A%20%60%22Error%3A%20No%20active%20session.%20Please%20restart%20the%20terminal.%22%60%20%E2%80%94%20the%20terminal%20is%20completely%20unusable%20until%20a%20hard%20refresh.%0A%0ABefore%20this%20PR%20the%20%60logout%60%20command%20silently%20fell%20through%20to%20the%20no-op%20fallback%20%28because%20%60context.gameManager.authManager%60%20was%20undefined%29%2C%20so%20the%20React-state%20%60authManager%60%20kept%20its%20active%20session%20intact.%20Now%20that%20the%20wiring%20works%2C%20%60logout%28%29%60%20destroys%20the%20session%20without%20ever%20restoring%20a%20guest%20session%2C%20making%20the%20bug%20reproducible%20on%20every%20successful%20logout.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=47&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fterminal-authmanager-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fterminal-authmanager-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20components%2Fhacker-terminal.tsx%0ALine%3A%20260-261%0A%0AComment%3A%0A**Post-logout%20terminal%20lockout**%0A%0ANow%20that%20%60authManager%60%20is%20properly%20wired%2C%20%60logout%60%20actually%20calls%20%60AuthManager.logout%28%29%60%2C%20which%20sets%20%60this.currentSession%20%3D%20null%60.%20The%20very%20next%20command%20the%20user%20types%20calls%20%60authManager.getCurrentUser%28%29%60%20%E2%86%92%20%60null%60%2C%20which%20triggers%20the%20guard%20at%20line%20~293%3A%20%60%22Error%3A%20No%20active%20session.%20Please%20restart%20the%20terminal.%22%60%20%E2%80%94%20the%20terminal%20is%20completely%20unusable%20until%20a%20hard%20refresh.%0A%0ABefore%20this%20PR%20the%20%60logout%60%20command%20silently%20fell%20through%20to%20the%20no-op%20fallback%20%28because%20%60context.gameManager.authManager%60%20was%20undefined%29%2C%20so%20the%20React-state%20%60authManager%60%20kept%20its%20active%20session%20intact.%20Now%20that%20the%20wiring%20works%2C%20%60logout%28%29%60%20destroys%20the%20session%20without%20ever%20restoring%20a%20guest%20session%2C%20making%20the%20bug%20reproducible%20on%20every%20successful%20logout.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=47&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2Fhacker-terminal.tsx%3A260-261%0A**Post-logout%20terminal%20lockout**%0A%0ANow%20that%20%60authManager%60%20is%20properly%20wired%2C%20%60logout%60%20actually%20calls%20%60AuthManager.logout%28%29%60%2C%20which%20sets%20%60this.currentSession%20%3D%20null%60.%20The%20very%20next%20command%20the%20user%20types%20calls%20%60authManager.getCurrentUser%28%29%60%20%E2%86%92%20%60null%60%2C%20which%20triggers%20the%20guard%20at%20line%20~293%3A%20%60%22Error%3A%20No%20active%20session.%20Please%20restart%20the%20terminal.%22%60%20%E2%80%94%20the%20terminal%20is%20completely%20unusable%20until%20a%20hard%20refresh.%0A%0ABefore%20this%20PR%20the%20%60logout%60%20command%20silently%20fell%20through%20to%20the%20no-op%20fallback%20%28because%20%60context.gameManager.authManager%60%20was%20undefined%29%2C%20so%20the%20React-state%20%60authManager%60%20kept%20its%20active%20session%20intact.%20Now%20that%20the%20wiring%20works%2C%20%60logout%28%29%60%20destroys%20the%20session%20without%20ever%20restoring%20a%20guest%20session%2C%20making%20the%20bug%20reproducible%20on%20every%20successful%20logout.%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Fhacker-terminal.tsx%3A167-170%0AUsing%20%60%28game%20as%20any%29.authManager%20%3D%20auth%60%20side-steps%20the%20type%20system%20entirely.%20%60GameStateManager%60%20has%20no%20%60authManager%60%20property%2C%20so%20this%20is%20an%20untyped%20duck-punch%20that%20TypeScript%20cannot%20verify.%20If%20%60GameStateManager%60%20is%20ever%20reconstructed%20or%20its%20reference%20is%20replaced%2C%20the%20property%20would%20need%20to%20be%20re-attached%20manually.%20A%20minimal%2C%20type-safe%20alternative%20is%20to%20thread%20%60authManager%60%20directly%20through%20%60TerminalContext%60%20%28the%20type%20already%20has%20%60gameManager%3F%3A%20any%60%29%2C%20since%20all%20command%20handlers%20ultimately%20receive%20a%20%60TerminalContext%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20setCommandProcessor%28new%20CommandProcessor%28%29%29%3B%0A%20%20%20%20%20%20setAuthManager%28auth%29%3B%0A%20%20%20%20%20%20setGameManager%28game%29%3B%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=47&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fterminal-authmanager-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fterminal-authmanager-wiring%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acomponents%2Fhacker-terminal.tsx%3A260-261%0A**Post-logout%20terminal%20lockout**%0A%0ANow%20that%20%60authManager%60%20is%20properly%20wired%2C%20%60logout%60%20actually%20calls%20%60AuthManager.logout%28%29%60%2C%20which%20sets%20%60this.currentSession%20%3D%20null%60.%20The%20very%20next%20command%20the%20user%20types%20calls%20%60authManager.getCurrentUser%28%29%60%20%E2%86%92%20%60null%60%2C%20which%20triggers%20the%20guard%20at%20line%20~293%3A%20%60%22Error%3A%20No%20active%20session.%20Please%20restart%20the%20terminal.%22%60%20%E2%80%94%20the%20terminal%20is%20completely%20unusable%20until%20a%20hard%20refresh.%0A%0ABefore%20this%20PR%20the%20%60logout%60%20command%20silently%20fell%20through%20to%20the%20no-op%20fallback%20%28because%20%60context.gameManager.authManager%60%20was%20undefined%29%2C%20so%20the%20React-state%20%60authManager%60%20kept%20its%20active%20session%20intact.%20Now%20that%20the%20wiring%20works%2C%20%60logout%28%29%60%20destroys%20the%20session%20without%20ever%20restoring%20a%20guest%20session%2C%20making%20the%20bug%20reproducible%20on%20every%20successful%20logout.%0A%0A%23%23%23%20Issue%202%20of%202%0Acomponents%2Fhacker-terminal.tsx%3A167-170%0AUsing%20%60%28game%20as%20any%29.authManager%20%3D%20auth%60%20side-steps%20the%20type%20system%20entirely.%20%60GameStateManager%60%20has%20no%20%60authManager%60%20property%2C%20so%20this%20is%20an%20untyped%20duck-punch%20that%20TypeScript%20cannot%20verify.%20If%20%60GameStateManager%60%20is%20ever%20reconstructed%20or%20its%20reference%20is%20replaced%2C%20the%20property%20would%20need%20to%20be%20re-attached%20manually.%20A%20minimal%2C%20type-safe%20alternative%20is%20to%20thread%20%60authManager%60%20directly%20through%20%60TerminalContext%60%20%28the%20type%20already%20has%20%60gameManager%3F%3A%20any%60%29%2C%20since%20all%20command%20handlers%20ultimately%20receive%20a%20%60TerminalContext%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20setCommandProcessor%28new%20CommandProcessor%28%29%29%3B%0A%20%20%20%20%20%20setAuthManager%28auth%29%3B%0A%20%20%20%20%20%20setGameManager%28game%29%3B%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=47&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(terminal): wire AuthManager into com..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/2a853cd02553e69857f88a79fb833074523b5cbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39754652)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->