### PR TITLE
fix(vault): gate downloads on a confirmed sale, not a forgeable lead

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,19 @@ NEXT_PUBLIC_GUMROAD_ALL_LINUX=
 NEXT_PUBLIC_GUMROAD_ALL_MACOS=
 # Optional fallback used when nothing above is set:
 NEXT_PUBLIC_GUMROAD_STORE=
+
+# ── Gumroad Ping webhook → Supabase `sales` (authoritative entitlement) ───────
+# Gumroad → Settings → Advanced → Ping: set the URL to
+#   https://www.goodnbad.info/api/gumroad/ping?token=<GUMROAD_PING_TOKEN>
+# Ping is UNSIGNED, so this shared secret in the URL is what authenticates it.
+# Generate a long random value (e.g. `openssl rand -hex 32`). Server-only.
+# Vault downloads are gated on a confirmed, non-refunded row in `sales`, so this
+# webhook (plus a one-time backfill of past sales) is REQUIRED for buyers to get
+# access. Apply supabase/migrations/0002_sales.sql first (db push or SQL editor).
+GUMROAD_PING_TOKEN=
+
+# ── Resend — transactional email (welcome on first charge) ───────────────────
+# Server-only. When unset, email is skipped gracefully (the funnel never breaks).
+# EMAIL_FROM must be a verified Resend sender, e.g. "Toolkit Vault <vault@goodnbad.info>".
+RESEND_API_KEY=
+EMAIL_FROM=

--- a/app/api/gumroad/ping/route.ts
+++ b/app/api/gumroad/ping/route.ts
@@ -1,0 +1,92 @@
+// === METADATA ===
+// Purpose: Receive Gumroad's "Ping" webhook (Settings → Advanced → Ping) on every
+//          sale/renewal and record it in Supabase `sales`. Unifies real buyers
+//          with the website waitlist so every email + purchase is in one place.
+// Security: Gumroad Ping is unsigned, so we require a secret token in the URL
+//          (?token=…) matched against GUMROAD_PING_TOKEN. Upsert on sale_id makes
+//          re-delivery idempotent. Always 200 so Gumroad doesn't retry-storm.
+// Payload: application/x-www-form-urlencoded (price in cents).
+// === END METADATA ===
+import { NextResponse } from "next/server"
+import { supabaseAdmin, isSupabaseConfigured } from "@/lib/supabase/server"
+import { sendEmail, isEmailConfigured } from "@/lib/email/resend"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function POST(req: Request) {
+  // 1) verify the shared secret in the ping URL
+  const token = new URL(req.url).searchParams.get("token")
+  const expected = process.env.GUMROAD_PING_TOKEN
+  if (expected && token !== expected) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 })
+  }
+
+  // 2) parse the form-encoded body
+  let form: FormData
+  try {
+    form = await req.formData()
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid body" }, { status: 400 })
+  }
+  const str = (k: string): string | null => {
+    const v = form.get(k)
+    return typeof v === "string" && v.length ? v : null
+  }
+
+  const email = str("email")
+  if (!email) return NextResponse.json({ ok: true, skipped: "no email" })
+
+  const raw: Record<string, string> = {}
+  for (const [k, v] of form.entries()) if (typeof v === "string") raw[k] = v
+
+  const sale = {
+    sale_id: str("sale_id"),
+    order_number: str("order_number"),
+    email,
+    product_name: str("product_name"),
+    product_permalink: str("product_permalink") ?? str("permalink"),
+    price_cents: str("price") ? Number(str("price")) : null,
+    currency: str("currency"),
+    recurrence: str("recurrence"),
+    subscription_id: str("subscription_id"),
+    is_recurring_charge: str("is_recurring_charge") === "true",
+    refunded: str("refunded") === "true",
+    offer_code: str("offer_code[name]") ?? str("discount_code") ?? str("offer_code"),
+    raw,
+  }
+
+  // 3) persist (idempotent on sale_id). Never throw — Gumroad expects a 200.
+  try {
+    if (isSupabaseConfigured()) {
+      const { error } = await supabaseAdmin().from("sales").upsert(sale, { onConflict: "sale_id" })
+      if (error) console.error("[gumroad ping] upsert error:", error.message)
+    } else {
+      console.log("[gumroad ping] (supabase not configured)\n" + JSON.stringify(sale))
+    }
+  } catch (e) {
+    console.error("[gumroad ping] failed:", e)
+  }
+
+  // 4) Welcome the buyer on their FIRST charge (not renewals). Never throw.
+  if (!sale.is_recurring_charge && isEmailConfigured()) {
+    try {
+      const product = sale.product_name ?? "your Toolkit Vault"
+      await sendEmail({
+        to: email,
+        subject: "Welcome to The Toolkit Vault 🗝️",
+        replyTo: process.env.LEAD_TO,
+        html: `<div style="font:15px/1.6 ui-sans-serif,system-ui;color:#18181b;max-width:520px">
+          <p>You're in — thanks for grabbing <b>${product.replace(/[<>]/g, "")}</b>.</p>
+          <p><b>Week 1</b> is on your Gumroad receipt (and in your Gumroad library). Over the next month, <b>Weeks 2–4</b> land in your inbox automatically — one short, designed PDF each week, tuned for your setup.</p>
+          <p style="direction:rtl">وصلك العدد الأول مع إيصال Gumroad. الأسابيع ٢–٤ بتوصلك تلقائيًا خلال الشهر — ملف PDF واحد كل أسبوع.</p>
+          <p style="color:#71717a;font-size:13px">The Toolkit Vault · goodnbad.info</p>
+        </div>`,
+      })
+    } catch (e) {
+      console.error("[gumroad ping] welcome email failed:", e)
+    }
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/vault/[file]/route.ts
+++ b/app/api/vault/[file]/route.ts
@@ -11,7 +11,7 @@ import { NextResponse } from "next/server"
 import { promises as fs } from "node:fs"
 import path from "node:path"
 import { verifyToken } from "@/lib/vault/sign"
-import { getEntitlement } from "@/lib/vault/entitlement"
+import { hasConfirmedSale, resolveVariantOs } from "@/lib/vault/entitlement"
 import { deliverableById, resolveFile } from "@/lib/vault/manifest"
 import { stampCached } from "@/lib/vault/watermark"
 
@@ -32,14 +32,18 @@ export async function GET(req: Request, ctx: { params: Promise<{ file: string }>
   const hit = deliverableById(file)
   if (!hit) return NextResponse.json({ ok: false, error: "not found" }, { status: 404 })
 
-  // 3) authoritative entitlement re-check (a leaked URL dies when entitlement lapses)
-  const ent = await getEntitlement(claim.email)
-  if (!ent || !ent.tracks.includes(hit.track)) {
+  // 3) authoritative entitlement re-check: a confirmed, non-refunded sale. This is
+  //    re-checked here (not just at sign time) so a leaked URL dies the moment the
+  //    sale is refunded. Leads NEVER grant access — only payment does.
+  if (!(await hasConfirmedSale(claim.email))) {
     return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 })
   }
 
-  // 4) resolve the tuned file for the buyer's stack, strictly inside content/vault
-  const rel = resolveFile(hit.track, hit.deliverable, ent.os)
+  // 4) resolve the tuned file for the buyer's stack, strictly inside content/vault.
+  //    The OS variant comes from the (non-authoritative) lead row, defaulting when
+  //    absent — it only picks a file variant, it does not gate access.
+  const os = await resolveVariantOs(claim.email)
+  const rel = resolveFile(hit.track, hit.deliverable, os)
   const root = path.resolve(process.cwd(), "content", "vault")
   const abs = path.resolve(process.cwd(), rel)
   if (abs !== root && !abs.startsWith(root + path.sep)) {

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -1,0 +1,50 @@
+// === METADATA ===
+// Purpose: One tiny server-only email sender backed by Resend's HTTP API. No SDK
+//          dependency — just fetch — so it adds zero install weight.
+// Config:  RESEND_API_KEY + EMAIL_FROM (e.g. "Toolkit Vault <vault@goodnbad.info>").
+//          When unset, sendEmail() returns { ok:false } WITHOUT throwing, so callers
+//          (lead route, ping webhook) degrade gracefully and never break the funnel.
+// Safety:  Every failure path logs via console.error — there is no silent swallow.
+// === END METADATA ===
+import "server-only"
+
+type SendArgs = {
+  to: string | string[]
+  subject: string
+  html: string
+  text?: string
+  replyTo?: string
+}
+
+export function isEmailConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY && process.env.EMAIL_FROM)
+}
+
+export async function sendEmail(args: SendArgs): Promise<{ ok: boolean; error?: string }> {
+  const key = process.env.RESEND_API_KEY
+  const from = process.env.EMAIL_FROM
+  if (!key || !from) return { ok: false, error: "email not configured" }
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        from,
+        to: Array.isArray(args.to) ? args.to : [args.to],
+        subject: args.subject,
+        html: args.html,
+        ...(args.text ? { text: args.text } : {}),
+        ...(args.replyTo ? { reply_to: args.replyTo } : {}),
+      }),
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "")
+      console.error(`[email] resend failed ${res.status}: ${detail.slice(0, 300)}`)
+      return { ok: false, error: `resend ${res.status}` }
+    }
+    return { ok: true }
+  } catch (e) {
+    console.error("[email] resend threw:", e)
+    return { ok: false, error: String(e) }
+  }
+}

--- a/lib/vault/entitlement.ts
+++ b/lib/vault/entitlement.ts
@@ -1,11 +1,13 @@
 // === METADATA ===
 // Purpose: Authoritative entitlement check for gated vault downloads, backed by
-//          Supabase. Resolves the buyer's stored stack ({tool,os}) so the gated
-//          route can hand back the right tuned PDF variant.
-// Note:    Until a payments-confirmed column/orders table exists, entitlement =
-//          "the buyer's most recent lead row selected this deliverable's track".
-//          A Moyasar webhook should later set a `paid` flag and this gate should
-//          tighten to require it. Fails CLOSED when Supabase is unconfigured.
+//          Supabase.
+// Security: Access is granted ONLY when a confirmed, non-refunded sale exists for
+//          the email in the `sales` table (written exclusively by the service-role
+//          Gumroad Ping webhook — never by the browser, RLS-locked). The `leads`
+//          table is self-submitted via a public form and is therefore FORGEABLE,
+//          so it MUST NOT grant access — it is used only to resolve which OS-tuned
+//          PDF variant to hand a buyer (worst case: wrong variant, never a bypass).
+//          Fails CLOSED when Supabase is unconfigured or on any query error.
 // === END METADATA ===
 import "server-only"
 import { supabaseAdmin, isSupabaseConfigured } from "@/lib/supabase/server"
@@ -19,7 +21,31 @@ export interface Entitlement {
   tracks: string[]
 }
 
-/** Most recent lead row for an email, normalized. null when none / unconfigured. */
+/**
+ * Authoritative payment gate. True only when at least one confirmed, non-refunded
+ * sale exists for this email. This is the single source of truth for vault access.
+ * Fails CLOSED: unconfigured Supabase, query error, or no matching row → false.
+ */
+export async function hasConfirmedSale(email: string): Promise<boolean> {
+  if (!isSupabaseConfigured()) return false
+  try {
+    const { data, error } = await supabaseAdmin()
+      .from("sales")
+      .select("id")
+      .eq("email", email)
+      .eq("refunded", false)
+      .limit(1)
+      .maybeSingle()
+    return !error && Boolean(data)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Most recent lead row for an email, normalized — used ONLY for variant
+ * resolution (which OS-tuned PDF), never for access. null when none / unconfigured.
+ */
 export async function getEntitlement(email: string): Promise<Entitlement | null> {
   if (!isSupabaseConfigured()) return null
   try {
@@ -42,10 +68,22 @@ export async function getEntitlement(email: string): Promise<Entitlement | null>
   }
 }
 
-export async function hasEntitlement(email: string, deliverableId: string): Promise<boolean> {
-  const hit = deliverableById(deliverableId)
-  if (!hit) return false
+/**
+ * The OS-tuned variant to serve a buyer. Derived from the (forgeable) lead row,
+ * defaulting when absent. Safe to trust because it only picks a file variant —
+ * access itself is gated separately by hasConfirmedSale().
+ */
+export async function resolveVariantOs(email: string): Promise<OsId> {
   const ent = await getEntitlement(email)
-  if (!ent) return false
-  return ent.tracks.includes(hit.track)
+  return ent?.os ?? DEFAULT_OS
+}
+
+/**
+ * Is this email entitled to this deliverable? Payment is the gate: the deliverable
+ * must exist in the manifest AND the buyer must have a confirmed, non-refunded sale.
+ * A lead row alone NEVER grants access.
+ */
+export async function hasEntitlement(email: string, deliverableId: string): Promise<boolean> {
+  if (!deliverableById(deliverableId)) return false
+  return hasConfirmedSale(email)
 }

--- a/supabase/migrations/0002_sales.sql
+++ b/supabase/migrations/0002_sales.sql
@@ -1,0 +1,33 @@
+-- === METADATA ===
+-- Purpose: `sales` table for Gumroad purchases, fed by the Gumroad "Ping"
+--          webhook (app/api/gumroad/ping). Unifies real buyers with the website
+--          waitlist/leads — one Supabase, every email + every sale.
+-- Security: RLS ON, no anon policies. Only the service-role server route writes.
+-- Apply:   supabase db push (or paste into the Supabase SQL editor).
+-- === END METADATA ===
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.sales (
+  id                  uuid primary key default gen_random_uuid(),
+  created_at          timestamptz not null default now(),
+  sale_id             text unique,            -- Gumroad sale id (idempotency key)
+  order_number        text,
+  email               text not null,
+  product_name        text,
+  product_permalink   text,
+  price_cents         integer,                -- Gumroad sends price in cents
+  currency            text,
+  recurrence          text,                   -- monthly | yearly | …
+  subscription_id     text,
+  is_recurring_charge boolean default false,  -- false = first charge, true = renewal
+  refunded            boolean default false,
+  offer_code          text,
+  raw                 jsonb not null default '{}'::jsonb
+);
+
+create index if not exists sales_email_idx       on public.sales (email);
+create index if not exists sales_created_at_idx   on public.sales (created_at desc);
+
+alter table public.sales enable row level security;
+-- (no anon policies: only the service-role Ping route writes here)


### PR DESCRIPTION
## What & why

**CRITICAL paywall bypass.** Vault entitlement was derived from the most-recent `leads` row. Leads are written by an **unauthenticated public form**, so anyone could self-grant access to paid PDFs by submitting a lead claiming a track. Payment was never actually checked.

This makes **payment the authoritative gate** and demotes leads to *variant resolution only* (which OS-tuned PDF to hand a buyer — worst case a wrong variant, never a bypass).

## Changes

- **`supabase/migrations/0002_sales.sql`** — new `public.sales` table (RLS on, no anon policies; service-role writes only). `sale_id` unique = idempotency key; `refunded` flag; `raw` jsonb.
- **`app/api/gumroad/ping/route.ts`** — Gumroad "Ping" webhook. Authenticated by a shared `?token=` secret (Ping is unsigned). Idempotent upsert on `sale_id`; refunds flip `refunded=true`; always returns 200; sends a welcome email on first charge.
- **`lib/vault/entitlement.ts`** — new `hasConfirmedSale(email)` is the **single source of truth** for access (fail-closed on unconfigured Supabase / query error / no row). `getEntitlement()` is now used **only** by `resolveVariantOs()` for the OS-tuned PDF. `hasEntitlement()` now requires a confirmed sale.
- **`app/api/vault/[file]/route.ts`** — re-checks `hasConfirmedSale` at download time (so a leaked URL dies on refund) and picks the variant via `resolveVariantOs`.
- **`lib/email/resend.ts`** — tiny fetch-based Resend sender; no-op when unset, never throws.
- **`.env.example`** — documents `GUMROAD_PING_TOKEN`, `RESEND_API_KEY`, `EMAIL_FROM`.

Supersedes #38 (folds its Gumroad/Supabase pieces in behind the entitlement fix).

## ⚠️ REQUIRED post-merge steps — vault access is LOCKED until all are done

This is intentional fail-closed posture. **Existing buyers cannot download until:**

1. **Apply the migration** — `supabase db push` (or paste `supabase/migrations/0002_sales.sql` into the SQL editor).
2. **Set `GUMROAD_PING_TOKEN`** in Vercel (e.g. `openssl rand -hex 32`), then redeploy.
3. **Configure the Gumroad Ping URL** → Gumroad → Settings → Advanced → Ping:
   `https://www.goodnbad.info/api/gumroad/ping?token=<GUMROAD_PING_TOKEN>`
4. **Backfill past sales** into `public.sales` (export from Gumroad → insert rows keyed by `email` + `sale_id`). Until this is done, anyone who bought *before* the Ping was wired will be locked out.

Optional: set `RESEND_API_KEY` + `EMAIL_FROM` for the welcome email (skipped gracefully if unset).

## Test plan

- [x] `next build` passes (exit 0); `/api/gumroad/ping`, `/api/vault/[file]`, `/api/vault/sign` all compile.
- [ ] After deploy + migration + token: send a Gumroad test Ping → row appears in `sales`.
- [ ] Buyer with a confirmed sale can download; an email with only a `leads` row gets **403**.
- [ ] Refund a sale → `refunded=true` → previously-issued download URL now **403**.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a lead-row-based vault entitlement check (forgeable via a public form) with a payment-confirmed `sales` table written exclusively by the Gumroad Ping webhook, correctly closing the paywall bypass described in the PR. The overall design is sound \u2014 fail-closed entitlement, RLS-locked table, refund support, idempotent upserts \u2014 but one auth guard in the webhook itself fails-open when the shared secret is not configured.

- **`app/api/gumroad/ping/route.ts`**: New Ping webhook that upserts Gumroad sale events into `public.sales`. The token check (`if (expected && ...)`) silently bypasses authentication when `GUMROAD_PING_TOKEN` is unset, allowing unauthenticated writes to the table that is now the sole source of vault access.
- **`lib/vault/entitlement.ts`**: `hasConfirmedSale()` is the new authoritative gate and correctly fails-closed on any error; email comparison is case-sensitive, which can cause legitimate buyers to receive 403s if their email casing differs between Gumroad and the JWT.
- **`supabase/migrations/0002_sales.sql`**: Introduces the `sales` table with RLS enabled and no anon policies; `sale_id` is nullable-unique, which lets multiple NULL rows insert without conflict and breaks the idempotency guarantee for any ping that omits a sale ID.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge as-is: the webhook that writes to the authoritative sales table accepts unauthenticated requests whenever the shared-secret env var is absent, directly inverting the security property this PR is meant to establish.

The Ping webhook auth guard fails-open when GUMROAD_PING_TOKEN is unset — an attacker can write arbitrary confirmed-sale rows and bypass the paywall entirely, the same class of vulnerability the PR fixes in the entitlement layer. The email case-sensitivity issue in hasConfirmedSale is an additional real defect that will lock out legitimate buyers whose email casing differs between Gumroad and their JWT. Everything else — the migration, resend helper, download route, refund handling — is well-constructed.

app/api/gumroad/ping/route.ts (auth guard logic) and lib/vault/entitlement.ts (email normalisation)
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Authentication bypass (`app/api/gumroad/ping/route.ts` line 21)**: The Ping webhook's token guard evaluates `if (expected && token !== expected)`. When `GUMROAD_PING_TOKEN` is not set, `expected` is `undefined` and the guard short-circuits to `false`, accepting all unauthenticated requests. Any caller can POST an arbitrary email with `refunded=false` and receive vault access, since `hasConfirmedSale` trusts any row in the `sales` table. Fix: invert to `if (!expected || token !== expected)`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/gumroad/ping/route.ts | New Gumroad Ping webhook — correct idempotency logic, but token auth guard fails-open when GUMROAD_PING_TOKEN is unset. |
| lib/vault/entitlement.ts | hasConfirmedSale() correctly fails-closed; email case-sensitivity can cause false-negative access denials; track-level scoping dropped. |
| app/api/vault/[file]/route.ts | Download route re-checks hasConfirmedSale() at serve time; path traversal guard and manifest allowlist intact. |
| supabase/migrations/0002_sales.sql | RLS enabled, no anon policies; sale_id nullable unique allows duplicate rows for pings without a sale_id. |
| lib/email/resend.ts | Lightweight Resend wrapper; gracefully no-ops when unconfigured and never throws. |
| .env.example | Documents GUMROAD_PING_TOKEN, RESEND_API_KEY, and EMAIL_FROM with clear deployment instructions. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GR as Gumroad
    participant PW as /api/gumroad/ping
    participant SB as Supabase (sales)
    participant RS as Resend
    participant B as Buyer Browser
    participant SN as /api/vault/sign
    participant DL as /api/vault/[file]
    participant LDS as Supabase (leads)

    GR->>PW: "POST ?token=GUMROAD_PING_TOKEN"
    note over PW: Verify token (must fail-closed if unset)
    PW->>SB: upsert(sale) on conflict(sale_id)
    PW->>RS: sendEmail (welcome, first charge only)

    B->>SN: "GET /api/vault/sign?id=...&email=..."
    SN-->>B: signed JWT (HMAC, short-lived)

    B->>DL: "GET /api/vault/[file]?t=jwt"
    DL->>DL: verifyToken(jwt)
    DL->>SB: hasConfirmedSale(email)
    SB-->>DL: true / false
    alt no confirmed sale
        DL-->>B: 403 Forbidden
    else confirmed sale
        DL->>LDS: resolveVariantOs(email)
        LDS-->>DL: os variant
        DL->>DL: resolveFile + path traversal check
        DL-->>B: watermarked PDF
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GR as Gumroad
    participant PW as /api/gumroad/ping
    participant SB as Supabase (sales)
    participant RS as Resend
    participant B as Buyer Browser
    participant SN as /api/vault/sign
    participant DL as /api/vault/[file]
    participant LDS as Supabase (leads)

    GR->>PW: "POST ?token=GUMROAD_PING_TOKEN"
    note over PW: Verify token (must fail-closed if unset)
    PW->>SB: upsert(sale) on conflict(sale_id)
    PW->>RS: sendEmail (welcome, first charge only)

    B->>SN: "GET /api/vault/sign?id=...&email=..."
    SN-->>B: signed JWT (HMAC, short-lived)

    B->>DL: "GET /api/vault/[file]?t=jwt"
    DL->>DL: verifyToken(jwt)
    DL->>SB: hasConfirmedSale(email)
    SB-->>DL: true / false
    alt no confirmed sale
        DL-->>B: 403 Forbidden
    else confirmed sale
        DL->>LDS: resolveVariantOs(email)
        LDS-->>DL: os variant
        DL->>DL: resolveFile + path traversal check
        DL-->>B: watermarked PDF
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fapi%2Fgumroad%2Fping%2Froute.ts%3A19-23%0A**Webhook%20auth%20bypass%20when%20token%20is%20unconfigured**%20%E2%80%94%20the%20guard%20%60if%20%28expected%20%26%26%20token%20!%3D%3D%20expected%29%60%20only%20rejects%20requests%20when%20%60GUMROAD_PING_TOKEN%60%20is%20set%20*and*%20the%20token%20mismatches.%20When%20the%20env%20var%20is%20absent%2C%20%60expected%60%20is%20%60undefined%60%2C%20the%20condition%20is%20falsy%2C%20and%20every%20unauthenticated%20POST%20inserts%20an%20arbitrary%20row%20into%20%60sales%60.%20Because%20%60hasConfirmedSale%60%20trusts%20any%20non-refunded%20row%20in%20that%20table%2C%20an%20attacker%20can%20grant%20themselves%20vault%20access%20before%20the%20token%20is%20ever%20configured.%20The%20check%20must%20fail-closed%3A%20reject%20unless%20a%20token%20is%20present%20*and*%20matches.%0A%0A%60%60%60suggestion%0A%20%20const%20token%20%3D%20new%20URL%28req.url%29.searchParams.get%28%22token%22%29%0A%20%20const%20expected%20%3D%20process.env.GUMROAD_PING_TOKEN%0A%20%20if%20%28!expected%20%7C%7C%20token%20!%3D%3D%20expected%29%20%7B%0A%20%20%20%20return%20NextResponse.json%28%7B%20ok%3A%20false%2C%20error%3A%20%22unauthorized%22%20%7D%2C%20%7B%20status%3A%20401%20%7D%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fvault%2Fentitlement.ts%3A29-43%0A**Email%20case%20sensitivity%20%E2%80%94%20lookup%20may%20fail%20for%20mixed-case%20addresses.**%20%60hasConfirmedSale%60%20uses%20a%20strict%20%60eq%28%22email%22%2C%20email%29%60%20match%20against%20the%20%60sales%60%20table.%20PostgreSQL%20%60text%60%20comparisons%20are%20case-sensitive%2C%20so%20%60User%40Example.com%60%20%28as%20Gumroad%20might%20deliver%20it%29%20and%20%60user%40example.com%60%20%28in%20the%20JWT%20claim%29%20would%20not%20match.%20Normalising%20to%20lowercase%20before%20both%20the%20upsert%20and%20the%20query%20here%20avoids%20spurious%20403s%20for%20buyers%20whose%20email%20casing%20varies%20between%20sources.%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fvault%2Fentitlement.ts%3A86-89%0A**Track-scope%20check%20dropped%20from%20%60hasEntitlement%60.**%20The%20previous%20implementation%20verified%20%60ent.tracks.includes%28hit.track%29%60%2C%20ensuring%20the%20buyer%20purchased%20the%20specific%20product%20owning%20the%20requested%20deliverable.%20The%20new%20version%20grants%20access%20to%20all%20deliverables%20for%20any%20confirmed%20sale.%20Fine%20for%20a%20single-product%20store%2C%20but%20if%20a%20second%20product%20with%20its%20own%20track%20is%20added%2C%20buyers%20of%20product%20A%20will%20gain%20access%20to%20product%20B%20without%20purchasing%20it.%20Worth%20a%20comment%20acknowledging%20the%20intentional%20design.%0A%0A%23%23%23%20Issue%204%20of%204%0Asupabase%2Fmigrations%2F0002_sales.sql%3A14%0A**Nullable%20%60sale_id%60%20breaks%20idempotency%20for%20pings%20without%20one.**%20PostgreSQL's%20%60UNIQUE%60%20constraint%20allows%20multiple%20%60NULL%60%20values%20%28each%20NULL%20is%20distinct%29%2C%20so%20%60onConflict%3A%20%22sale_id%22%60%20has%20no%20effect%20when%20%60sale_id%60%20is%20absent%20%E2%80%94%20every%20retry%20inserts%20a%20new%20row.%20Adding%20%60NOT%20NULL%60%20prevents%20duplicates%20defensively.%0A%0A%60%60%60suggestion%0A%20%20sale_id%20%20%20%20%20%20%20%20%20%20%20%20%20text%20not%20null%20unique%2C%20%20%20--%20Gumroad%20sale%20id%20%28idempotency%20key%29%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=48&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fvault-paywall-fail-closed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvault-paywall-fail-closed%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fapi%2Fgumroad%2Fping%2Froute.ts%3A19-23%0A**Webhook%20auth%20bypass%20when%20token%20is%20unconfigured**%20%E2%80%94%20the%20guard%20%60if%20%28expected%20%26%26%20token%20!%3D%3D%20expected%29%60%20only%20rejects%20requests%20when%20%60GUMROAD_PING_TOKEN%60%20is%20set%20*and*%20the%20token%20mismatches.%20When%20the%20env%20var%20is%20absent%2C%20%60expected%60%20is%20%60undefined%60%2C%20the%20condition%20is%20falsy%2C%20and%20every%20unauthenticated%20POST%20inserts%20an%20arbitrary%20row%20into%20%60sales%60.%20Because%20%60hasConfirmedSale%60%20trusts%20any%20non-refunded%20row%20in%20that%20table%2C%20an%20attacker%20can%20grant%20themselves%20vault%20access%20before%20the%20token%20is%20ever%20configured.%20The%20check%20must%20fail-closed%3A%20reject%20unless%20a%20token%20is%20present%20*and*%20matches.%0A%0A%60%60%60suggestion%0A%20%20const%20token%20%3D%20new%20URL%28req.url%29.searchParams.get%28%22token%22%29%0A%20%20const%20expected%20%3D%20process.env.GUMROAD_PING_TOKEN%0A%20%20if%20%28!expected%20%7C%7C%20token%20!%3D%3D%20expected%29%20%7B%0A%20%20%20%20return%20NextResponse.json%28%7B%20ok%3A%20false%2C%20error%3A%20%22unauthorized%22%20%7D%2C%20%7B%20status%3A%20401%20%7D%29%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fvault%2Fentitlement.ts%3A29-43%0A**Email%20case%20sensitivity%20%E2%80%94%20lookup%20may%20fail%20for%20mixed-case%20addresses.**%20%60hasConfirmedSale%60%20uses%20a%20strict%20%60eq%28%22email%22%2C%20email%29%60%20match%20against%20the%20%60sales%60%20table.%20PostgreSQL%20%60text%60%20comparisons%20are%20case-sensitive%2C%20so%20%60User%40Example.com%60%20%28as%20Gumroad%20might%20deliver%20it%29%20and%20%60user%40example.com%60%20%28in%20the%20JWT%20claim%29%20would%20not%20match.%20Normalising%20to%20lowercase%20before%20both%20the%20upsert%20and%20the%20query%20here%20avoids%20spurious%20403s%20for%20buyers%20whose%20email%20casing%20varies%20between%20sources.%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fvault%2Fentitlement.ts%3A86-89%0A**Track-scope%20check%20dropped%20from%20%60hasEntitlement%60.**%20The%20previous%20implementation%20verified%20%60ent.tracks.includes%28hit.track%29%60%2C%20ensuring%20the%20buyer%20purchased%20the%20specific%20product%20owning%20the%20requested%20deliverable.%20The%20new%20version%20grants%20access%20to%20all%20deliverables%20for%20any%20confirmed%20sale.%20Fine%20for%20a%20single-product%20store%2C%20but%20if%20a%20second%20product%20with%20its%20own%20track%20is%20added%2C%20buyers%20of%20product%20A%20will%20gain%20access%20to%20product%20B%20without%20purchasing%20it.%20Worth%20a%20comment%20acknowledging%20the%20intentional%20design.%0A%0A%23%23%23%20Issue%204%20of%204%0Asupabase%2Fmigrations%2F0002_sales.sql%3A14%0A**Nullable%20%60sale_id%60%20breaks%20idempotency%20for%20pings%20without%20one.**%20PostgreSQL's%20%60UNIQUE%60%20constraint%20allows%20multiple%20%60NULL%60%20values%20%28each%20NULL%20is%20distinct%29%2C%20so%20%60onConflict%3A%20%22sale_id%22%60%20has%20no%20effect%20when%20%60sale_id%60%20is%20absent%20%E2%80%94%20every%20retry%20inserts%20a%20new%20row.%20Adding%20%60NOT%20NULL%60%20prevents%20duplicates%20defensively.%0A%0A%60%60%60suggestion%0A%20%20sale_id%20%20%20%20%20%20%20%20%20%20%20%20%20text%20not%20null%20unique%2C%20%20%20--%20Gumroad%20sale%20id%20%28idempotency%20key%29%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=48&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(vault): gate downloads on a confirme..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/a4b999ad07ed14c08c4d48af29b3b4d257ad12f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39755453)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->