### PR TITLE
fix(home): honor the Arabic language toggle on the landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { OSDesktop, OSTaskbar, AmbientFeed } from "@/components/os"
 import { cn } from "@/lib/utils"
 import type { FeedEntry } from "@/components/os"
 import type { ThreatIoc } from "@/app/api/threats/route"
+import { useLanguage } from "@/components/language-provider"
 import { IocInspector } from "@/components/signal/IocInspector"
 import { MobileSignalOverlay } from "@/components/signal/MobileSignalOverlay"
 import { GlobeLegend } from "@/components/signal/GlobeLegend"
@@ -47,14 +48,6 @@ const MODULE_ITEMS: { href: string; code: string; label: string; sub: string; Ic
   { href: "/signal",      code: "03", label: "SIGNAL",      sub: "Live activity · Feed",         Icon: Radio    },
   { href: "/contact",     code: "04", label: "CONTACT",     sub: "Encrypted channel",            Icon: Mail     },
   { href: "/terminal",    code: "05", label: "TERMINAL",    sub: "Command interface",            Icon: Terminal },
-]
-
-// Hero credential chips
-const HERO_META = [
-  "CEH (pursuing)",
-  "Security+ (pursuing)",
-  "Google Cybersecurity",
-  "BSc CS · Taylor's University",
 ]
 
 // All layer labels (used to seed the default active set)
@@ -151,6 +144,7 @@ interface LayerPanelProps {
 }
 
 function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
+  const { t } = useLanguage()
   const [expanded, setExpanded] = useState(false)
 
   return (
@@ -163,7 +157,7 @@ function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
           className="flex items-center gap-2 rounded border border-zinc-800 bg-zinc-950/70 px-3 py-1.5 font-mono text-[9px] uppercase tracking-widest text-zinc-500 backdrop-blur-sm transition-all hover:border-zinc-700 hover:text-zinc-300"
         >
           <Layers className="h-3 w-3" />
-          LAYERS
+          {t("الطبقات", "LAYERS")}
           <span className="ml-1 text-[8px] text-zinc-600">
             {activeLayers.size}/{ALL_LAYER_LABELS.length}
           </span>
@@ -181,7 +175,7 @@ function LayerPanel({ activeLayers, onToggle }: LayerPanelProps) {
           <div className="flex items-center justify-between border-b border-zinc-800/80 px-3 py-2">
             <div className="flex items-center gap-2">
               <Layers className="h-3 w-3 text-zinc-500" />
-              <span className="font-mono text-[9px] uppercase tracking-widest text-zinc-500">World Layers</span>
+              <span className="font-mono text-[9px] uppercase tracking-widest text-zinc-500">{t("طبقات العالم", "World Layers")}</span>
             </div>
             <button
               type="button"
@@ -326,6 +320,27 @@ function LiveAttacksStrip({ iocs }: { iocs: ThreatIoc[] }) {
 // Page
 // ---------------------------------------------------------------------------
 export default function HomePage() {
+  const { t, dir } = useLanguage()
+
+  // Localized hero credential chips — cert names stay as proper nouns; only the
+  // human-readable qualifiers translate.
+  const heroMeta = [
+    t("CEH (قيد الدراسة)", "CEH (pursuing)"),
+    t("Security+ (قيد الدراسة)", "Security+ (pursuing)"),
+    "Google Cybersecurity",
+    t("بكالوريوس علوم حاسب · جامعة تايلورز", "BSc CS · Taylor's University"),
+  ]
+
+  // Localized module descriptions, keyed by route. The uppercase module labels
+  // (PERSONNEL, SIGNAL…) stay as terminal-style codes; only the sub-line is prose.
+  const moduleSub: Record<string, string> = {
+    "/personnel":   t("ملف · سيرة ذاتية · تصريح",   "Dossier · CV · Clearance"),
+    "/deployments": t("ملفات المهام · المعمارية",    "Mission files · Architecture"),
+    "/signal":      t("نشاط حيّ · موجز",             "Live activity · Feed"),
+    "/contact":     t("قناة مشفّرة",                 "Encrypted channel"),
+    "/terminal":    t("واجهة الأوامر",               "Command interface"),
+  }
+
   const [liveEntries,  setLiveEntries]  = useState<FeedEntry[]>([])
   const [recentIocs,   setRecentIocs]   = useState<ThreatIoc[]>([])
   const [hoveredIoc,   setHoveredIoc]   = useState<ThreatIoc | null>(null)
@@ -508,7 +523,7 @@ export default function HomePage() {
             className="flex items-center gap-2 rounded border border-emerald-900 bg-zinc-950/70 px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-emerald-400 backdrop-blur-md transition-all hover:border-emerald-700 hover:bg-emerald-950/40"
           >
             <Maximize2 className="h-3.5 w-3.5" />
-            Inspect Globe
+            {t("فحص الكرة الأرضية", "Inspect Globe")}
           </button>
           {/* On-globe legend + live indicator counter (color key · count · feeds) */}
           <div className="hidden lg:block">
@@ -524,7 +539,7 @@ export default function HomePage() {
           className="fixed right-4 top-16 z-40 flex items-center gap-2 rounded border border-zinc-800 bg-zinc-950/75 px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-zinc-400 backdrop-blur-md transition-colors hover:border-zinc-600 hover:text-zinc-200"
         >
           <X className="h-3.5 w-3.5" />
-          exit globe preview
+          {t("خروج من معاينة الكرة", "exit globe preview")}
         </button>
       )}
 
@@ -542,11 +557,11 @@ export default function HomePage() {
 
         {/* ── HERO IDENTITY ─────────────────────────────────── */}
         <section className={wrap(globeInspect, globeInspect ? "pt-4 pb-3" : "pt-[9vh] pb-[7vh]")}>
-          <div className="w-full pointer-events-auto">
+          <div className="w-full pointer-events-auto" dir={dir}>
             {/* Kicker */}
             <span className="inline-flex items-center gap-2.5 mb-[30px] rounded-[5px] border border-zinc-800 bg-zinc-900/50 px-3.5 py-[7px] font-mono text-[11px] uppercase tracking-[0.26em] text-zinc-400 backdrop-blur-sm">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_theme(colors.emerald.500)]" />
-              SUBJECT VERIFIED · RIYADH, SA
+              {t("تم التحقق من الهوية · الرياض، السعودية", "SUBJECT VERIFIED · RIYADH, SA")}
             </span>
 
             {/* Identity — display scale (sized to fit the left column), restrained
@@ -564,13 +579,13 @@ export default function HomePage() {
               className="mt-[26px] max-w-[48ch] leading-[1.5] text-zinc-300"
               style={{ fontSize: globeInspect ? "1rem" : "clamp(17px, 2vw, 21px)" }}
             >
-              Hamzah Al-Ramli — <span className="font-semibold text-zinc-100">Cybersecurity &amp; Automation Architect.</span>{" "}
-              I build defensive systems, threat tooling, and the automation that runs them.
+              {t("حمزة الرملي — ", "Hamzah Al-Ramli — ")}<span className="font-semibold text-zinc-100">{t("مهندس أمن سيبراني وأتمتة.", "Cybersecurity & Automation Architect.")}</span>{" "}
+              {t("أبني الأنظمة الدفاعية وأدوات رصد التهديدات والأتمتة التي تُشغّلها.", "I build defensive systems, threat tooling, and the automation that runs them.")}
             </p>
 
             {/* Credential chips */}
             <div className="mt-[22px] flex flex-wrap gap-2.5 font-mono text-[11px] text-zinc-400">
-              {HERO_META.map((m) => (
+              {heroMeta.map((m) => (
                 <span key={m} className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
                   {m}
                 </span>
@@ -584,13 +599,13 @@ export default function HomePage() {
                 className="inline-flex items-center gap-2.5 rounded-md bg-emerald-500 px-6 py-3.5 font-mono text-[13px] font-semibold uppercase tracking-[0.1em] text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
               >
                 <Mail className="h-4 w-4" />
-                Open encrypted channel
+                {t("افتح قناة مشفّرة", "Open encrypted channel")}
               </Link>
               <Link
                 href="/personnel"
                 className="inline-flex items-center gap-2.5 rounded-md border border-zinc-800 bg-zinc-950/40 px-6 py-3.5 font-mono text-[13px] font-medium uppercase tracking-[0.1em] text-zinc-300 backdrop-blur-sm transition-all hover:border-zinc-600 hover:text-zinc-100"
               >
-                View full dossier
+                {t("عرض الملف الكامل", "View full dossier")}
                 <ArrowRight className="h-4 w-4" />
               </Link>
             </div>
@@ -622,7 +637,7 @@ export default function HomePage() {
                     <Icon className="h-[19px] w-[19px]" />
                   </div>
                   <div className="font-mono text-sm font-semibold tracking-wide text-zinc-100">{label}</div>
-                  <div className="mt-1.5 font-mono text-[11px] leading-[1.5] text-zinc-500">{sub}</div>
+                  <div className="mt-1.5 font-mono text-[11px] leading-[1.5] text-zinc-500" dir={dir}>{moduleSub[href] ?? sub}</div>
                 </Link>
               ))}
             </div>
@@ -642,17 +657,23 @@ export default function HomePage() {
                 <span className="ml-auto text-zinc-500">live · ambient</span>
               </div>
               <div className="px-4 py-4">
-                <AmbientFeed
-                  entries={STATIC_ENTRIES}
-                  liveEntries={liveEntries}
-                  interval={8000}
-                  maxLines={6}
-                />
+                {/* Feed + IOC surface sit SIDE BY SIDE (50/50) on md+; they stack
+                    on mobile. Left = live signal feed, right = live IOC surface. */}
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5">
+                  <div className="min-w-0">
+                    <AmbientFeed
+                      entries={STATIC_ENTRIES}
+                      liveEntries={liveEntries}
+                      interval={8000}
+                      maxLines={6}
+                    />
+                  </div>
 
-                {/* Live IOC surface — docked here beside the signal feed
-                    (was a floating right-edge rail). Click a row to inspect. */}
-                <div className="mt-4 border-t border-zinc-900 pt-3.5">
-                  <IocInspector placement="inline" recent={recentIocs} hovered={hoveredIoc} pinned={pinnedIoc} onPin={setPinnedIoc} onClose={() => setGlobeInspect(false)} />
+                  {/* Live IOC surface — docked beside the signal feed (was a
+                      floating right-edge rail). Click a row to inspect. */}
+                  <div className="min-w-0 border-t border-zinc-900 pt-3.5 md:border-l md:border-t-0 md:pl-5 md:pt-0">
+                    <IocInspector placement="inline" recent={recentIocs} hovered={hoveredIoc} pinned={pinnedIoc} onPin={setPinnedIoc} onClose={() => setGlobeInspect(false)} />
+                  </div>
                 </div>
 
                 <div className="mt-4 border-t border-zinc-900 pt-3.5">
@@ -661,7 +682,7 @@ export default function HomePage() {
                     className="flex items-center gap-1.5 font-mono text-[12px] text-zinc-500 transition-colors hover:text-emerald-500"
                   >
                     <ArrowRight className="h-3 w-3" />
-                    open full signal feed
+                    {t("افتح موجز الإشارة الكامل", "open full signal feed")}
                   </Link>
                 </div>
               </div>
@@ -683,7 +704,7 @@ export default function HomePage() {
         <div className="px-4">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-3">
             <span className="font-mono text-[10px] text-zinc-700 uppercase tracking-widest">
-              GOODNBAD.EXE © {new Date().getFullYear()} — live cyberattack monitor
+              GOODNBAD.EXE © {new Date().getFullYear()} — {t("مراقب الهجمات السيبرانية الحيّة", "live cyberattack monitor")}
             </span>
             <div className="flex items-center gap-4">
               {[


### PR DESCRIPTION
## What & why

The site has a working language toggle (`LanguageProvider` flips `<html dir>` and persists the choice), but **`app/page.tsx` hardcoded every string in English** — so switching to Arabic did nothing on the first page users see.

This threads `useLanguage()`'s `t(ar, en)` + `dir` through the landing surface:

- Hero kicker, bio line, and both CTAs (`Open encrypted channel`, `View full dossier`)
- Credential chips and per-module sub-lines — labels/cert names stay as proper nouns; only human-readable prose translates
- Layers panel (`LAYERS` / `World Layers`) and globe inspect/exit buttons
- `dir={dir}` on the hero + module blocks so Arabic lays out RTL

Also docks the live IOC surface beside the signal feed in a 50/50 grid on `md+` (stacks on mobile) — the same landing-page pass.

## Supersedes #41 — and why a re-cut was necessary

#41 carried the identical `app/page.tsx` work but its branch had drifted **2 commits behind main**. Merging it as-is would have **reverted PRs #44 and #45** (the `/signal` route fix + easter-egg/login-counter wiring) — ~145 deletions across `signal/page.tsx`, `hacker-terminal.tsx`, `commands.ts`, `GameStateManager.ts`, `next.config.mjs`.

This branch is re-cut from current `main` and contains **only `app/page.tsx`**. Verified: main's `app/page.tsx` is byte-identical to #41's base, so nothing is clobbered; `/signal` and the easter-egg wiring remain intact in the build. **Close #41 in favor of this.**

## Test plan

- [x] `next build` passes; `/signal` route still present (no #44/#45 regression).
- [ ] Toggle to Arabic → hero, CTAs, chips, layers panel, globe buttons render in Arabic and the hero/module blocks flip to RTL.
- [ ] Toggle back to English → original copy restored.
- [ ] `md+` viewport shows signal feed + IOC surface side by side; mobile stacks them.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR threads Arabic i18n through `app/page.tsx` — the only file changed — by calling `useLanguage()`'s `t(ar, en)` helper and `dir` throughout the hero, module launcher, layers panel, and globe controls, fixing the broken language toggle on the landing page. It also restructures the signal-feed + IOC panel from a vertically stacked layout into a responsive 50/50 grid.

- All hero strings (kicker, role line, credential chips, CTAs), module sub-lines, layers panel labels ("LAYERS" / "World Layers"), and globe inspect/exit buttons are now translated; `dir={dir}` is applied to the hero wrapper and per-module sub-line so Arabic renders RTL.
- The signal feed and IOC inspector are moved into a `grid-cols-2 md:grid-cols-2` layout so they sit side-by-side on `md+` viewports and stack on mobile.
- Three minor prose strings remain untranslated: "all on"/"all off" in the `LayerPanel` footer and the "live attacks" label in `LiveAttacksStrip`; the `heroMeta` chips use translated strings as React keys, causing remounts on language toggle.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is scoped to a single presentational file, the translation logic is correct, and nothing in the routing or data layer is touched.

The translation wiring is straightforward and the `useLanguage` hook's fallback ensures the page renders correctly even outside the provider. The only gaps are a handful of prose strings left in English ("all on"/"all off", "live attacks") and the minor React-key instability in the chip list — none of which break functionality or cause incorrect data. The IOC/feed layout restructure is visually significant but mechanically simple CSS-grid work with no logic changes.

Only `app/page.tsx` changed. The `LayerPanel` footer and `LiveAttacksStrip` widget are worth a second look for the remaining untranslated labels.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/page.tsx | Adds Arabic i18n via `useLanguage()` across the landing page — hero, CTAs, credential chips, module sub-lines, layers panel, and globe buttons. Also restructures the signal feed + IOC panel into a responsive side-by-side grid. Three minor untranslated strings remain ("all on"/"all off" in LayerPanel footer, "live attacks" ticker label) and heroMeta uses translated strings as React keys. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    LP[LanguageProvider\nlang · dir · t] --> HP[HomePage\nuseLanguage]
    LP --> LayP[LayerPanel\nuseLanguage]

    HP --> heroMeta["heroMeta[]\nt(ar, en) per chip"]
    HP --> moduleSub["moduleSub{}\nt(ar, en) per route"]
    HP --> HeroSection["Hero section\ndir={dir}"]
    HP --> ModSection["Module cards\nsub-line dir={dir}"]
    HP --> GlobeCtrl["Globe buttons\nt(ar, en)"]
    HP --> FeedGrid["Signal feed + IOC\n50/50 grid on md+"]
    HP --> Footer["Footer text\nt(ar, en)"]

    LayP --> LayerBtn["LAYERS button\nt(ar, en)"]
    LayP --> LayerHdr["Panel header\nt(ar, en)"]
    LayP --> LayerFtr["Footer buttons\nall on / all off\n(not yet translated)"]

    LAST[LiveAttacksStrip] --> LiveLabel["live attacks label\n(not yet translated)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    LP[LanguageProvider\nlang · dir · t] --> HP[HomePage\nuseLanguage]
    LP --> LayP[LayerPanel\nuseLanguage]

    HP --> heroMeta["heroMeta[]\nt(ar, en) per chip"]
    HP --> moduleSub["moduleSub{}\nt(ar, en) per route"]
    HP --> HeroSection["Hero section\ndir={dir}"]
    HP --> ModSection["Module cards\nsub-line dir={dir}"]
    HP --> GlobeCtrl["Globe buttons\nt(ar, en)"]
    HP --> FeedGrid["Signal feed + IOC\n50/50 grid on md+"]
    HP --> Footer["Footer text\nt(ar, en)"]

    LayP --> LayerBtn["LAYERS button\nt(ar, en)"]
    LayP --> LayerHdr["Panel header\nt(ar, en)"]
    LayP --> LayerFtr["Footer buttons\nall on / all off\n(not yet translated)"]

    LAST[LiveAttacksStrip] --> LiveLabel["live attacks label\n(not yet translated)"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `app/page.tsx`, line 588-592 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/ebaaac25db6536244791c959e7ec727c1e42a93c/app/page.tsx#L588-L592)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `heroMeta` array uses its translated strings as React keys. When the language toggles, every key in the list changes (e.g. `"CEH (pursuing)"` → `"CEH (قيد الدراسة)"`), causing React to unmount and remount all four chip spans on every language switch. The old static `HERO_META` constant avoided this because the keys were stable. Using index-based keys for a static, never-reordered list is safe here and prevents unnecessary remounting.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20588-592%0A%0AComment%3A%0AThe%20%60heroMeta%60%20array%20uses%20its%20translated%20strings%20as%20React%20keys.%20When%20the%20language%20toggles%2C%20every%20key%20in%20the%20list%20changes%20%28e.g.%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20causing%20React%20to%20unmount%20and%20remount%20all%20four%20chip%20spans%20on%20every%20language%20switch.%20The%20old%20static%20%60HERO_META%60%20constant%20avoided%20this%20because%20the%20keys%20were%20stable.%20Using%20index-based%20keys%20for%20a%20static%2C%20never-reordered%20list%20is%20safe%20here%20and%20prevents%20unnecessary%20remounting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhome-arabic-i18n-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhome-arabic-i18n-v2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20588-592%0A%0AComment%3A%0AThe%20%60heroMeta%60%20array%20uses%20its%20translated%20strings%20as%20React%20keys.%20When%20the%20language%20toggles%2C%20every%20key%20in%20the%20list%20changes%20%28e.g.%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20causing%20React%20to%20unmount%20and%20remount%20all%20four%20chip%20spans%20on%20every%20language%20switch.%20The%20old%20static%20%60HERO_META%60%20constant%20avoided%20this%20because%20the%20keys%20were%20stable.%20Using%20index-based%20keys%20for%20a%20static%2C%20never-reordered%20list%20is%20safe%20here%20and%20prevents%20unnecessary%20remounting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `app/page.tsx`, line 254-267 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/ebaaac25db6536244791c959e7ec727c1e42a93c/app/page.tsx#L254-L267)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `LayerPanel` already pulls `useLanguage()` in this PR but its footer buttons ("all on" / "all off") remain in English. Since the surrounding "LAYERS" / "World Layers" labels are now translated, leaving these two actionable buttons untranslated is an inconsistency that a user switching to Arabic will immediately notice.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20254-267%0A%0AComment%3A%0A%60LayerPanel%60%20already%20pulls%20%60useLanguage%28%29%60%20in%20this%20PR%20but%20its%20footer%20buttons%20%28%22all%20on%22%20%2F%20%22all%20off%22%29%20remain%20in%20English.%20Since%20the%20surrounding%20%22LAYERS%22%20%2F%20%22World%20Layers%22%20labels%20are%20now%20translated%2C%20leaving%20these%20two%20actionable%20buttons%20untranslated%20is%20an%20inconsistency%20that%20a%20user%20switching%20to%20Arabic%20will%20immediately%20notice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%AA%D8%B4%D8%BA%D9%8A%D9%84%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20on%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22font-mono%20text-%5B8px%5D%20text-zinc-800%22%3E%C2%B7%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ALL_LAYER_LABELS.forEach%28%28l%29%20%3D%3E%20%7B%20if%20%28activeLayers.has%28l%29%29%20onToggle%28l%29%20%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%A5%D9%8A%D9%82%D8%A7%D9%81%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20off%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhome-arabic-i18n-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhome-arabic-i18n-v2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20254-267%0A%0AComment%3A%0A%60LayerPanel%60%20already%20pulls%20%60useLanguage%28%29%60%20in%20this%20PR%20but%20its%20footer%20buttons%20%28%22all%20on%22%20%2F%20%22all%20off%22%29%20remain%20in%20English.%20Since%20the%20surrounding%20%22LAYERS%22%20%2F%20%22World%20Layers%22%20labels%20are%20now%20translated%2C%20leaving%20these%20two%20actionable%20buttons%20untranslated%20is%20an%20inconsistency%20that%20a%20user%20switching%20to%20Arabic%20will%20immediately%20notice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%AA%D8%B4%D8%BA%D9%8A%D9%84%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20on%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22font-mono%20text-%5B8px%5D%20text-zinc-800%22%3E%C2%B7%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ALL_LAYER_LABELS.forEach%28%28l%29%20%3D%3E%20%7B%20if%20%28activeLayers.has%28l%29%29%20onToggle%28l%29%20%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%A5%D9%8A%D9%82%D8%A7%D9%81%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20off%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


3. `app/page.tsx`, line 292-295 ([link](https://github.com/goodnbadexe/dev-hamzah-alramli/blob/ebaaac25db6536244791c959e7ec727c1e42a93c/app/page.tsx#L292-L295)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The "live attacks" label in `LiveAttacksStrip` is the only user-facing prose string in the ticker not wrapped in `t()`. All other content in the widget is technical identifiers (type labels, country codes, source names), but "live attacks" is plain prose and will stay in English regardless of the language toggle.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20292-295%0A%0AComment%3A%0AThe%20%22live%20attacks%22%20label%20in%20%60LiveAttacksStrip%60%20is%20the%20only%20user-facing%20prose%20string%20in%20the%20ticker%20not%20wrapped%20in%20%60t%28%29%60.%20All%20other%20content%20in%20the%20widget%20is%20technical%20identifiers%20%28type%20labels%2C%20country%20codes%2C%20source%20names%29%2C%20but%20%22live%20attacks%22%20is%20plain%20prose%20and%20will%20stay%20in%20English%20regardless%20of%20the%20language%20toggle.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22flex%20shrink-0%20items-center%20gap-1.5%20font-mono%20text-%5B10px%5D%20uppercase%20tracking-widest%20text-rose-400%22%3E%0A%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22h-1.5%20w-1.5%20rounded-full%20bg-rose-500%20shadow-%5B0_0_6px_theme%28colors.rose.500%29%5D%20animate-pulse%20motion-reduce%3Aanimate-none%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D9%87%D8%AC%D9%85%D8%A7%D8%AA%20%D9%85%D8%A8%D8%A7%D8%B4%D8%B1%D8%A9%22%2C%20%22live%20attacks%22%29%7D%0A%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhome-arabic-i18n-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhome-arabic-i18n-v2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fpage.tsx%0ALine%3A%20292-295%0A%0AComment%3A%0AThe%20%22live%20attacks%22%20label%20in%20%60LiveAttacksStrip%60%20is%20the%20only%20user-facing%20prose%20string%20in%20the%20ticker%20not%20wrapped%20in%20%60t%28%29%60.%20All%20other%20content%20in%20the%20widget%20is%20technical%20identifiers%20%28type%20labels%2C%20country%20codes%2C%20source%20names%29%2C%20but%20%22live%20attacks%22%20is%20plain%20prose%20and%20will%20stay%20in%20English%20regardless%20of%20the%20language%20toggle.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22flex%20shrink-0%20items-center%20gap-1.5%20font-mono%20text-%5B10px%5D%20uppercase%20tracking-widest%20text-rose-400%22%3E%0A%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22h-1.5%20w-1.5%20rounded-full%20bg-rose-500%20shadow-%5B0_0_6px_theme%28colors.rose.500%29%5D%20animate-pulse%20motion-reduce%3Aanimate-none%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D9%87%D8%AC%D9%85%D8%A7%D8%AA%20%D9%85%D8%A8%D8%A7%D8%B4%D8%B1%D8%A9%22%2C%20%22live%20attacks%22%29%7D%0A%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fpage.tsx%3A588-592%0AThe%20%60heroMeta%60%20array%20uses%20its%20translated%20strings%20as%20React%20keys.%20When%20the%20language%20toggles%2C%20every%20key%20in%20the%20list%20changes%20%28e.g.%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20causing%20React%20to%20unmount%20and%20remount%20all%20four%20chip%20spans%20on%20every%20language%20switch.%20The%20old%20static%20%60HERO_META%60%20constant%20avoided%20this%20because%20the%20keys%20were%20stable.%20Using%20index-based%20keys%20for%20a%20static%2C%20never-reordered%20list%20is%20safe%20here%20and%20prevents%20unnecessary%20remounting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fpage.tsx%3A254-267%0A%60LayerPanel%60%20already%20pulls%20%60useLanguage%28%29%60%20in%20this%20PR%20but%20its%20footer%20buttons%20%28%22all%20on%22%20%2F%20%22all%20off%22%29%20remain%20in%20English.%20Since%20the%20surrounding%20%22LAYERS%22%20%2F%20%22World%20Layers%22%20labels%20are%20now%20translated%2C%20leaving%20these%20two%20actionable%20buttons%20untranslated%20is%20an%20inconsistency%20that%20a%20user%20switching%20to%20Arabic%20will%20immediately%20notice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%AA%D8%B4%D8%BA%D9%8A%D9%84%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20on%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22font-mono%20text-%5B8px%5D%20text-zinc-800%22%3E%C2%B7%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ALL_LAYER_LABELS.forEach%28%28l%29%20%3D%3E%20%7B%20if%20%28activeLayers.has%28l%29%29%20onToggle%28l%29%20%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%A5%D9%8A%D9%82%D8%A7%D9%81%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20off%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fpage.tsx%3A292-295%0AThe%20%22live%20attacks%22%20label%20in%20%60LiveAttacksStrip%60%20is%20the%20only%20user-facing%20prose%20string%20in%20the%20ticker%20not%20wrapped%20in%20%60t%28%29%60.%20All%20other%20content%20in%20the%20widget%20is%20technical%20identifiers%20%28type%20labels%2C%20country%20codes%2C%20source%20names%29%2C%20but%20%22live%20attacks%22%20is%20plain%20prose%20and%20will%20stay%20in%20English%20regardless%20of%20the%20language%20toggle.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22flex%20shrink-0%20items-center%20gap-1.5%20font-mono%20text-%5B10px%5D%20uppercase%20tracking-widest%20text-rose-400%22%3E%0A%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22h-1.5%20w-1.5%20rounded-full%20bg-rose-500%20shadow-%5B0_0_6px_theme%28colors.rose.500%29%5D%20animate-pulse%20motion-reduce%3Aanimate-none%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D9%87%D8%AC%D9%85%D8%A7%D8%AA%20%D9%85%D8%A8%D8%A7%D8%B4%D8%B1%D8%A9%22%2C%20%22live%20attacks%22%29%7D%0A%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22fix%2Fhome-arabic-i18n-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhome-arabic-i18n-v2%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapp%2Fpage.tsx%3A588-592%0AThe%20%60heroMeta%60%20array%20uses%20its%20translated%20strings%20as%20React%20keys.%20When%20the%20language%20toggles%2C%20every%20key%20in%20the%20list%20changes%20%28e.g.%20%60%22CEH%20%28pursuing%29%22%60%20%E2%86%92%20%60%22CEH%20%28%D9%82%D9%8A%D8%AF%20%D8%A7%D9%84%D8%AF%D8%B1%D8%A7%D8%B3%D8%A9%29%22%60%29%2C%20causing%20React%20to%20unmount%20and%20remount%20all%20four%20chip%20spans%20on%20every%20language%20switch.%20The%20old%20static%20%60HERO_META%60%20constant%20avoided%20this%20because%20the%20keys%20were%20stable.%20Using%20index-based%20keys%20for%20a%20static%2C%20never-reordered%20list%20is%20safe%20here%20and%20prevents%20unnecessary%20remounting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7BheroMeta.map%28%28m%2C%20i%29%20%3D%3E%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20key%3D%7Bi%7D%20className%3D%22rounded%20border%20border-zinc-800%20bg-zinc-950%2F40%20px-3%20py-2%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bm%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%29%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fpage.tsx%3A254-267%0A%60LayerPanel%60%20already%20pulls%20%60useLanguage%28%29%60%20in%20this%20PR%20but%20its%20footer%20buttons%20%28%22all%20on%22%20%2F%20%22all%20off%22%29%20remain%20in%20English.%20Since%20the%20surrounding%20%22LAYERS%22%20%2F%20%22World%20Layers%22%20labels%20are%20now%20translated%2C%20leaving%20these%20two%20actionable%20buttons%20untranslated%20is%20an%20inconsistency%20that%20a%20user%20switching%20to%20Arabic%20will%20immediately%20notice.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%AA%D8%B4%D8%BA%D9%8A%D9%84%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20on%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22font-mono%20text-%5B8px%5D%20text-zinc-800%22%3E%C2%B7%3C%2Fspan%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ALL_LAYER_LABELS.forEach%28%28l%29%20%3D%3E%20%7B%20if%20%28activeLayers.has%28l%29%29%20onToggle%28l%29%20%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22font-mono%20text-%5B8px%5D%20uppercase%20tracking-widest%20text-zinc-700%20hover%3Atext-zinc-400%20transition-colors%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D8%A5%D9%8A%D9%82%D8%A7%D9%81%20%D8%A7%D9%84%D9%83%D9%84%22%2C%20%22all%20off%22%29%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fbutton%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fpage.tsx%3A292-295%0AThe%20%22live%20attacks%22%20label%20in%20%60LiveAttacksStrip%60%20is%20the%20only%20user-facing%20prose%20string%20in%20the%20ticker%20not%20wrapped%20in%20%60t%28%29%60.%20All%20other%20content%20in%20the%20widget%20is%20technical%20identifiers%20%28type%20labels%2C%20country%20codes%2C%20source%20names%29%2C%20but%20%22live%20attacks%22%20is%20plain%20prose%20and%20will%20stay%20in%20English%20regardless%20of%20the%20language%20toggle.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22flex%20shrink-0%20items-center%20gap-1.5%20font-mono%20text-%5B10px%5D%20uppercase%20tracking-widest%20text-rose-400%22%3E%0A%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22h-1.5%20w-1.5%20rounded-full%20bg-rose-500%20shadow-%5B0_0_6px_theme%28colors.rose.500%29%5D%20animate-pulse%20motion-reduce%3Aanimate-none%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%7Bt%28%22%D9%87%D8%AC%D9%85%D8%A7%D8%AA%20%D9%85%D8%A8%D8%A7%D8%B4%D8%B1%D8%A9%22%2C%20%22live%20attacks%22%29%7D%0A%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%60%60%60%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(home): honor the Arabic language tog..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/ebaaac25db6536244791c959e7ec727c1e42a93c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39755961)</sub>

<!-- /greptile_comment -->