### PR TITLE
feat: add 30 SAR workflow-tools checkout (Gumroad + Supabase)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,19 @@ NEXT_PUBLIC_GUMROAD_ALL_MACOS=
 # Optional fallback used when nothing above is set:
 NEXT_PUBLIC_GUMROAD_STORE=
 
+# ── Workflow Tools — standalone one-time pack (30 SAR ≈ $8) ───────────────────
+# A single Gumroad product sold at /workflow-tools. Create the product in Gumroad
+# (price it so the buyer pays ~30 SAR — see the PR notes on SAR→Gumroad currency),
+# then paste its checkout URL here. NEXT_PUBLIC_* = inlined at build → REDEPLOY
+# after changing. When empty, the buy button shows "coming soon" (no fake checkout).
+NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS=
+# Server-only. The product's Gumroad permalink/short code (the part after /l/, e.g.
+# "wflow" for hamzahramli.gumroad.com/l/wflow). Used to SCOPE entitlement: the
+# unlock check only grants access to buyers of THIS product. The existing Gumroad
+# Ping webhook already records the sale into `sales` — no new webhook is needed.
+# When unset, the unlock gate fails CLOSED (nobody is granted access).
+WORKFLOW_TOOLS_PERMALINK=
+
 # ── Gumroad Ping webhook → Supabase `sales` (authoritative entitlement) ───────
 # Gumroad → Settings → Advanced → Ping: set the URL to
 #   https://www.goodnbad.info/api/gumroad/ping?token=<GUMROAD_PING_TOKEN>

--- a/app/api/workflow-tools/access/route.ts
+++ b/app/api/workflow-tools/access/route.ts
@@ -1,0 +1,30 @@
+// === METADATA ===
+// Purpose: Check whether an email owns the Workflow Tools pack. POST { email }.
+// Security: read-only; reuses the service-role-gated `sales` entitlement
+//           (hasWorkflowToolsAccess) and returns ONLY a boolean — never leaks
+//           sale data, prices, or catalog info. Fails closed via the lib helper.
+// === END METADATA ===
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { hasWorkflowToolsAccess } from "@/lib/vault/entitlement"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const Body = z.object({ email: z.string().trim().email().max(160) })
+
+export async function POST(req: Request) {
+  let raw: unknown
+  try {
+    raw = await req.json()
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 })
+  }
+  const parsed = Body.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: "invalid request" }, { status: 422 })
+  }
+
+  const access = await hasWorkflowToolsAccess(parsed.data.email)
+  return NextResponse.json({ ok: true, access })
+}

--- a/app/workflow-tools/WorkflowToolsPurchase.tsx
+++ b/app/workflow-tools/WorkflowToolsPurchase.tsx
@@ -1,0 +1,133 @@
+// === METADATA ===
+// Purpose: Client UI for the Workflow Tools one-time purchase (30 SAR). Buy CTA
+//          opens the Gumroad overlay checkout (same mechanism as /subscribe); an
+//          "already bought?" form verifies ownership via POST /api/workflow-tools
+//          /access and reveals unlock instructions.
+// Security: no secrets here. The checkout link is the public NEXT_PUBLIC_* var;
+//           ownership is verified server-side against the Supabase `sales` table.
+// === END METADATA ===
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  WORKFLOW_TOOLS,
+  workflowToolsCheckoutUrl,
+  isWorkflowToolsCheckoutConfigured,
+} from "@/lib/workflow-tools/config"
+
+type CheckState = "idle" | "loading" | "granted" | "denied" | "error"
+
+export function WorkflowToolsPurchase() {
+  const buyUrl = workflowToolsCheckoutUrl()
+  const checkoutReady = isWorkflowToolsCheckoutConfigured()
+  const [email, setEmail] = useState("")
+  const [state, setState] = useState<CheckState>("idle")
+
+  // Load Gumroad's overlay script so the buy button opens an in-page checkout.
+  useEffect(() => {
+    if (!checkoutReady) return
+    if (document.querySelector("script[data-gumroad]")) return
+    const s = document.createElement("script")
+    s.src = "https://gumroad.com/js/gumroad.js"
+    s.setAttribute("data-gumroad", "1")
+    s.async = true
+    document.body.appendChild(s)
+  }, [checkoutReady])
+
+  async function checkAccess(e: React.FormEvent) {
+    e.preventDefault()
+    setState("loading")
+    try {
+      const res = await fetch("/api/workflow-tools/access", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      })
+      const data = (await res.json()) as { ok?: boolean; access?: boolean }
+      if (!res.ok || !data.ok) {
+        setState("error")
+        return
+      }
+      setState(data.access ? "granted" : "denied")
+    } catch {
+      setState("error")
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Price + buy CTA */}
+      <div className="rounded-xl border border-zinc-800/70 bg-zinc-900/40 p-5">
+        <div className="flex items-baseline gap-2">
+          <span className="text-3xl font-bold text-zinc-100">{WORKFLOW_TOOLS.priceSar} SAR</span>
+          <span className="font-mono text-sm text-zinc-500">≈ ${WORKFLOW_TOOLS.priceUsd} · one-time</span>
+        </div>
+
+        {checkoutReady ? (
+          <a
+            href={buyUrl}
+            data-gumroad-overlay-checkout="true"
+            className="gumroad-button mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500 px-4 py-4 font-mono text-sm font-bold uppercase tracking-wide text-emerald-950 transition-all hover:-translate-y-px hover:bg-emerald-400"
+          >
+            Get the workflow tools
+          </a>
+        ) : (
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            title="Checkout not configured yet"
+            className="mt-4 flex w-full cursor-not-allowed items-center justify-center rounded-md bg-zinc-800 px-4 py-4 font-mono text-sm font-bold uppercase tracking-wide text-zinc-500"
+          >
+            Checkout coming soon
+          </button>
+        )}
+        <p className="mt-3 text-center font-mono text-[11px] text-zinc-600">
+          instant access · secure payment via Gumroad
+        </p>
+      </div>
+
+      {/* Already bought? → verify + unlock */}
+      <form onSubmit={checkAccess} className="rounded-xl border border-zinc-800/70 bg-zinc-900/40 p-5">
+        <p className="mb-3 font-mono text-[10px] uppercase tracking-widest text-zinc-600">
+          already bought? unlock here
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="the email you paid with"
+            className="flex-1 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2.5 text-sm text-zinc-100 outline-none focus:border-emerald-600"
+          />
+          <button
+            type="submit"
+            disabled={state === "loading"}
+            className="rounded-md border border-emerald-700 bg-emerald-950/40 px-4 py-2.5 font-mono text-sm font-bold text-emerald-300 transition-colors hover:bg-emerald-900/40 disabled:opacity-50"
+          >
+            {state === "loading" ? "Checking…" : "Unlock"}
+          </button>
+        </div>
+
+        {state === "granted" && (
+          <div className="mt-4 rounded-md border border-emerald-800 bg-emerald-950/30 p-4 text-sm text-emerald-200">
+            <p className="font-semibold">Access confirmed — you own the Workflow Tools pack.</p>
+            <p className="mt-1 text-emerald-300/80">
+              Your download is on your Gumroad receipt and in your email. Open it and start with one tool today.
+            </p>
+          </div>
+        )}
+        {state === "denied" && (
+          <p className="mt-3 text-sm text-zinc-400">
+            No purchase found for that email yet. If you just paid, give it a minute and try again, or use the
+            buy button above.
+          </p>
+        )}
+        {state === "error" && (
+          <p className="mt-3 text-sm text-amber-400">Something went wrong checking your access. Please try again.</p>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/app/workflow-tools/page.tsx
+++ b/app/workflow-tools/page.tsx
@@ -1,0 +1,62 @@
+// === METADATA ===
+// Purpose: Buy + unlock page for the standalone "Workflow Tools" one-time pack
+//          (30 SAR). Server component for metadata; the interactive purchase /
+//          unlock UI lives in WorkflowToolsPurchase (client).
+// Payment: Gumroad product checkout (NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS) +
+//          Supabase `sales` entitlement — the same pattern the rest of the site
+//          uses. Set the Gumroad product "Redirect after purchase" to
+//          /workflow-tools so buyers land back here to unlock.
+// === END METADATA ===
+import type { Metadata } from "next"
+import { WORKFLOW_TOOLS } from "@/lib/workflow-tools/config"
+import { WorkflowToolsPurchase } from "./WorkflowToolsPurchase"
+
+export const metadata: Metadata = {
+  title: `${WORKFLOW_TOOLS.nameEn} · ${WORKFLOW_TOOLS.priceSar} SAR`,
+  description: WORKFLOW_TOOLS.taglineEn,
+}
+
+const INCLUDES = [
+  "Ready-to-run workflow templates you drop straight into your stack",
+  "Automations that wire your tools together so the busywork runs itself",
+  "Setup notes tuned for a lean, one-person side business",
+]
+
+export default function WorkflowToolsPage() {
+  return (
+    <main className="relative min-h-screen bg-zinc-950 text-zinc-100">
+      <div
+        className="pointer-events-none fixed inset-0 z-0"
+        style={{ background: "radial-gradient(ellipse 70% 50% at 50% 0%, rgba(16,185,129,0.10) 0%, transparent 60%)" }}
+        aria-hidden
+      />
+      <div className="relative z-10 mx-auto flex min-h-screen max-w-lg flex-col justify-center px-5 py-16">
+        <header className="text-center">
+          <span className="mb-4 inline-block rounded border border-emerald-900 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-emerald-700">
+            goodnbad · workflow tools
+          </span>
+          <h1 className="text-3xl font-bold leading-tight text-zinc-100 sm:text-4xl">
+            {WORKFLOW_TOOLS.nameEn}
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-zinc-400">{WORKFLOW_TOOLS.taglineEn}</p>
+          <p className="mt-2 text-sm leading-relaxed text-zinc-500" dir="rtl">
+            {WORKFLOW_TOOLS.taglineAr}
+          </p>
+        </header>
+
+        <ul className="mt-8 space-y-2 text-sm text-zinc-300">
+          {INCLUDES.map((line) => (
+            <li key={line} className="flex items-start gap-2">
+              <span className="text-emerald-500">→</span>
+              {line}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-8">
+          <WorkflowToolsPurchase />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/lib/vault/entitlement.ts
+++ b/lib/vault/entitlement.ts
@@ -43,6 +43,32 @@ export async function hasConfirmedSale(email: string): Promise<boolean> {
 }
 
 /**
+ * Product-scoped gate for the standalone Workflow Tools pack. True ONLY when a
+ * confirmed, non-refunded sale exists for this email whose `product_permalink`
+ * matches WORKFLOW_TOOLS_PERMALINK. Fails CLOSED when the permalink is unset,
+ * Supabase is unconfigured, or on any query error — a sale of a DIFFERENT product
+ * never unlocks this one (unlike the catalog-wide hasConfirmedSale).
+ */
+export async function hasWorkflowToolsAccess(email: string): Promise<boolean> {
+  const permalink = (process.env.WORKFLOW_TOOLS_PERMALINK ?? "").trim()
+  if (!permalink) return false
+  if (!isSupabaseConfigured()) return false
+  try {
+    const { data, error } = await supabaseAdmin()
+      .from("sales")
+      .select("id")
+      .eq("email", email)
+      .eq("refunded", false)
+      .eq("product_permalink", permalink)
+      .limit(1)
+      .maybeSingle()
+    return !error && Boolean(data)
+  } catch {
+    return false
+  }
+}
+
+/**
  * Most recent lead row for an email, normalized — used ONLY for variant
  * resolution (which OS-tuned PDF), never for access. null when none / unconfigured.
  */

--- a/lib/workflow-tools/config.ts
+++ b/lib/workflow-tools/config.ts
@@ -1,0 +1,42 @@
+// === METADATA ===
+// Purpose: Product config for the standalone "Workflow Tools" one-time purchase
+//          (30 SAR). Mirrors the Gumroad-link + Supabase-entitlement pattern the
+//          rest of the site already uses to gate paid content. Pure constants +
+//          a build-inlined checkout URL — NO secrets live here.
+// Payment: NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS holds the Gumroad product checkout
+//          link (inlined at build → REDEPLOY after changing). When unset, the buy
+//          button is disabled instead of opening a broken/fake checkout.
+// Entitlement: scoped server-side by WORKFLOW_TOOLS_PERMALINK (see
+//          lib/vault/entitlement.ts) against the `sales` table that the EXISTING
+//          Gumroad Ping webhook (app/api/gumroad/ping) already populates — so NO
+//          new webhook is required for this product.
+// === END METADATA ===
+import { SAR_PER_USD } from "@/lib/subscribe/config"
+
+/** One-time price for the Workflow Tools pack, in SAR. */
+export const WORKFLOW_TOOLS_PRICE_SAR = 30
+
+/** Honest USD equivalent, derived from the repo-wide SAR/USD rate (≈ $8). */
+export const WORKFLOW_TOOLS_PRICE_USD = Math.round(WORKFLOW_TOOLS_PRICE_SAR / SAR_PER_USD)
+
+export const WORKFLOW_TOOLS = {
+  id: "workflow-tools",
+  nameEn: "Side-Business Workflow Tools",
+  nameAr: "أدوات سير العمل للأعمال الجانبية",
+  taglineEn:
+    "A one-time pack of the workflow tools, templates & automations that run a lean side business.",
+  taglineAr:
+    "حزمة لمرة واحدة من أدوات وقوالب وأتمتة سير العمل التي تدير عملاً جانبياً خفيفاً.",
+  priceSar: WORKFLOW_TOOLS_PRICE_SAR,
+  priceUsd: WORKFLOW_TOOLS_PRICE_USD,
+} as const
+
+/** Gumroad checkout link (build-inlined). Empty string when unconfigured. */
+export function workflowToolsCheckoutUrl(): string {
+  return (process.env.NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS ?? "").trim()
+}
+
+/** True when a real checkout link is configured. */
+export function isWorkflowToolsCheckoutConfigured(): boolean {
+  return workflowToolsCheckoutUrl().length > 0
+}

--- a/tests/workflow-tools.test.ts
+++ b/tests/workflow-tools.test.ts
@@ -1,0 +1,47 @@
+// === METADATA ===
+// Purpose: Pin the Workflow Tools product config — fixed 30 SAR price, honest USD
+//          derivation, and the checkout-link configured/unconfigured behavior.
+// Tests:   npm test -- -t workflow-tools
+// === END METADATA ===
+import { describe, it, expect, afterEach } from "vitest"
+import {
+  WORKFLOW_TOOLS,
+  WORKFLOW_TOOLS_PRICE_SAR,
+  WORKFLOW_TOOLS_PRICE_USD,
+  workflowToolsCheckoutUrl,
+  isWorkflowToolsCheckoutConfigured,
+} from "@/lib/workflow-tools/config"
+import { SAR_PER_USD } from "@/lib/subscribe/config"
+
+const ORIGINAL = process.env.NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS
+  else process.env.NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS = ORIGINAL
+})
+
+describe("workflow-tools · price", () => {
+  it("is locked at 30 SAR", () => {
+    expect(WORKFLOW_TOOLS_PRICE_SAR).toBe(30)
+    expect(WORKFLOW_TOOLS.priceSar).toBe(30)
+  })
+
+  it("derives USD honestly from the repo SAR/USD rate", () => {
+    expect(WORKFLOW_TOOLS_PRICE_USD).toBe(Math.round(30 / SAR_PER_USD))
+    expect(WORKFLOW_TOOLS.priceUsd).toBe(WORKFLOW_TOOLS_PRICE_USD)
+  })
+})
+
+describe("workflow-tools · checkout link", () => {
+  it("is unconfigured (empty) when the env var is absent", () => {
+    delete process.env.NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS
+    expect(workflowToolsCheckoutUrl()).toBe("")
+    expect(isWorkflowToolsCheckoutConfigured()).toBe(false)
+  })
+
+  it("trims and reports configured when the env var is set", () => {
+    process.env.NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS = "  https://hamzahramli.gumroad.com/l/wflow  "
+    expect(workflowToolsCheckoutUrl()).toBe("https://hamzahramli.gumroad.com/l/wflow")
+    expect(isWorkflowToolsCheckoutConfigured()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Adds a standalone, one-time **Side-Business Workflow Tools** purchase priced at **30 SAR (≈ $8 USD)**, extending the site's **existing Gumroad + Supabase entitlement** flow instead of introducing a new payment provider.

**DRAFT — financial code. Do not merge until the owner confirms the decisions below.**

## Approach & why
- **Provider: Gumroad product checkout link + Supabase `sales` entitlement.** This is the live storefront the rest of the site already gates content with. It needs no Commercial Registration, and the existing **Gumroad Ping webhook** (`app/api/gumroad/ping`) already records *every* sale into the `sales` table — so **no new webhook was added**.
- Considered but not used: the in-page **Moyasar** card form already in the repo. It needs a `pk_live_` key (CR-gated) to actually charge, so it is not production-ready for a net-new product without that step. Extending Gumroad is the minimal, proven path.

## Files changed
- `lib/workflow-tools/config.ts` — product config; price locked at 30 SAR, USD derived honestly from the repo `SAR_PER_USD`; checkout URL from `NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS`.
- `app/workflow-tools/page.tsx` + `WorkflowToolsPurchase.tsx` — buy entry point (Gumroad overlay CTA) + "already bought?" email unlock check.
- `app/api/workflow-tools/access/route.ts` — server-side, zod-validated; returns only a boolean.
- `lib/vault/entitlement.ts` — `hasWorkflowToolsAccess()`: **fails closed**, product-scoped by `WORKFLOW_TOOLS_PERMALINK` (a generic sale of a different product never unlocks this).
- `.env.example` — two new documented vars.
- `tests/workflow-tools.test.ts` — pins price + checkout-link behavior.

## Security
- No hardcoded secrets/links/price IDs — everything via `process.env`.
- Service-role Supabase access stays server-only; the access API leaks only a boolean.
- No new webhook; the existing Ping route already validates its shared-secret token.

## Build / tests
- `npm install` PASS · `npm run build` PASS (Turbopack "Compiled successfully"; only pre-existing middleware-deprecation warning).
- `npm test -- -t workflow-tools` PASS (4 passed).

## Env vars the owner must set in Vercel
- `NEXT_PUBLIC_GUMROAD_WORKFLOW_TOOLS` — the Gumroad product checkout URL (inlined at build → **redeploy** after setting).
- `WORKFLOW_TOOLS_PERMALINK` — server-only; the product Gumroad permalink/short code, used to scope entitlement.
- (Already in prod, reused as-is: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `GUMROAD_PING_TOKEN`.)

## Decisions to confirm before going live
1. **Price discrepancy:** the brief says "30 SAR (~$20)" but 30 SAR is about **$8** at the repo 3.75 SAR/USD rate. Code uses **30 SAR / ~$8**. Confirm whether the target is 30 SAR (~$8) or ~$20 (~75 SAR).
2. **SAR to Gumroad currency:** Gumroad may not charge in SAR directly. Decide the listed currency so the buyer pays ~30 SAR equivalent.
3. **Permalink matching:** `WORKFLOW_TOOLS_PERMALINK` must equal exactly what the Ping stores in `sales.product_permalink` (Gumroad sends both a short code and a full URL). Verify with one real/test sale.
4. **What the buyer receives:** the actual product (which workflow tools / file) and the Gumroad "Redirect after purchase" URL (suggest `/workflow-tools` so they land on the unlock view).

Generated with Claude Code