### PR TITLE
feat(personnel): redesign Personnel Dossier with editorial intelligence-file layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1301,3 +1301,54 @@ Complexity: O(1) styling
     animation: none !important;
   }
 }
+
+/* ==========================================================
+   PERSONNEL DOSSIER — declassified case-file primitives
+   Additive layer on the OS tokens. Static / compositor-only;
+   all motion is transform/opacity and reduced-motion safe.
+   ========================================================== */
+
+/* Paper-grain atmosphere for the cover sheet — static layered noise,
+   kept extremely subtle so it reads as "document", not texture. */
+.dossier-grain {
+  position: relative;
+}
+.dossier-grain::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.5;
+  background:
+    radial-gradient(circle at 18% 22%, rgb(16 185 129 / 0.05), transparent 38%),
+    radial-gradient(circle at 88% 8%, rgb(255 255 255 / 0.025), transparent 30%);
+}
+.dossier-grain > * { position: relative; z-index: 1; }
+
+/* Vertical barcode strip — decorative identity flourish (aria-hidden). */
+.dossier-barcode {
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--os-text-2) 0, var(--os-text-2) 1px,
+    transparent 1px, transparent 3px,
+    var(--os-text-3) 3px, var(--os-text-3) 4px,
+    transparent 4px, transparent 5px,
+    var(--os-text-2) 5px, var(--os-text-2) 7px,
+    transparent 7px, transparent 9px
+  );
+  opacity: 0.6;
+}
+
+/* Rubber-stamp verdict — rotated, distressed double ring. Static. */
+.dossier-stamp {
+  font-family: var(--font-mono), ui-monospace, "Cascadia Code", monospace;
+  color: var(--os-signal);
+  border: 2px solid var(--os-signal);
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 2px rgb(16 185 129 / 0.18);
+  background: rgb(16 185 129 / 0.04);
+  text-shadow: 0 0 10px rgb(16 185 129 / 0.25);
+  opacity: 0.92;
+}
+

--- a/app/personnel/personnel-content.tsx
+++ b/app/personnel/personnel-content.tsx
@@ -7,6 +7,7 @@ import {
   Code2,
   Download,
   ExternalLink,
+  Fingerprint,
   Github,
   LineChart,
   Linkedin,
@@ -68,6 +69,15 @@ const STAT_LABELS: Bilingual[] = [
   { ar: "القدرات", en: "Capabilities" },
 ]
 
+// Section register — every section is filed as a numbered form reference.
+const SECTIONS: { idx: string; code: string; title: Bilingual }[] = [
+  { idx: "01", code: "capability.matrix", title: { ar: "مصفوفة القدرات", en: "Capability Matrix" } },
+  { idx: "02", code: "credentials.ledger", title: { ar: "سجلّ الاعتمادات", en: "Credential Register" } },
+  { idx: "03", code: "service.record", title: { ar: "سجلّ الخدمة", en: "Service Record" } },
+  { idx: "04", code: "active.builds", title: { ar: "العمليات الجارية", en: "Active Operations" } },
+  { idx: "05", code: "direct.channels", title: { ar: "قنوات الاتصال", en: "Establish Contact" } },
+]
+
 export function PersonnelContent() {
   const { t, dir } = useLanguage()
   const { name, alias, title, tagline, location, contact } = personnelIdentity
@@ -87,68 +97,58 @@ export function PersonnelContent() {
     return m
   }, {})
   const issuerOrder = Object.keys(issuerCounts).sort((a, b) => issuerCounts[b] - issuerCounts[a])
+  const initials = name.split(/\s+/).map((w) => w[0]).slice(0, 2).join("").toUpperCase()
 
   return (
     <>
       <div className="mx-auto max-w-[1240px] px-5 py-8 sm:px-8 md:py-10" dir={dir}>
         <div className="flex flex-col gap-[18px]">
 
-          {/* ── HERO IDENTITY ──────────────────────────────────────────── */}
-          <Win label="personnel.exe" status="dossier · authorized access" flush className="os-panel-in">
-            <div className="grid lg:grid-cols-[1.55fr_0.9fr]">
-              {/* Left — identity */}
-              <div className="border-b border-zinc-800/70 p-[30px] lg:border-b-0 lg:border-r rtl:lg:border-r-0 rtl:lg:border-l">
-                <div className="flex items-center gap-2.5 rounded-md border border-emerald-900/70 bg-emerald-950/15 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-500">
-                  <span className="flex items-center gap-2">
-                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_theme(colors.emerald.500)]" />
-                    {t("الموضوع موثّق", "subject verified")}
-                  </span>
-                  <span className="ml-auto tracking-[0.16em] text-zinc-600">file&nbsp;#GNB-01</span>
-                </div>
+          {/* ── COVER SHEET ─────────────────────────────────────────────── */}
+          <Win label="personnel.exe" status="dossier · authorized access" flush className="os-panel-in dossier-grain">
+            {/* classification banner — semantic emerald = cleared */}
+            <ClassificationBanner />
 
-                <div className="mt-[22px]">
-                  <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-zinc-700">{t("الموضوع / الموظف", "Subject / Personnel")}</p>
-                  <h1 className="mt-2 text-balance text-[clamp(40px,6vw,68px)] font-bold leading-[0.94] tracking-[-0.035em] text-zinc-100">
-                    {name}
-                    <span className="mt-3.5 block font-mono text-[clamp(13px,1.5vw,16px)] font-medium tracking-[0.04em] text-emerald-500">
-                      {t("اسم مستعار", "alias")} <span className="text-zinc-600">:</span> {alias}
-                    </span>
-                  </h1>
-                </div>
+            <div className="relative grid lg:grid-cols-[1.6fr_0.95fr]">
+              {/* Left — subject brief */}
+              <div className="border-b border-zinc-800/70 p-[30px] sm:p-[38px] lg:border-b-0 lg:border-r rtl:lg:border-r-0 rtl:lg:border-l">
+                <FieldLabel>{t("الموضوع / الملف", "Subject / Case File")}</FieldLabel>
+                <h1 className="mt-2 text-balance text-[clamp(42px,6.4vw,72px)] font-bold leading-[0.92] tracking-[-0.038em] text-zinc-100">
+                  {name}
+                </h1>
+                <p className="mt-3.5 font-mono text-[clamp(13px,1.5vw,16px)] font-medium tracking-[0.04em] text-emerald-500">
+                  {t("اسم مستعار", "alias")} <span className="text-zinc-700">/</span> {alias}
+                </p>
 
-                <p className="mt-[18px] text-[clamp(15px,1.7vw,18px)] font-medium text-zinc-400">{title}</p>
+                <p className="mt-[22px] text-[clamp(15px,1.7vw,18px)] font-medium text-zinc-400">{title}</p>
 
-                <p className="mt-[18px] max-w-[60ch] text-pretty text-[14.5px] leading-[1.72] text-zinc-500">
+                <p className="mt-[18px] max-w-[58ch] text-pretty text-[14.5px] leading-[1.72] text-zinc-500">
                   {t(
                     "خبير أمن سيبراني ومصمم وسائط متعددة مبدع — يجمع بين معرفة أمنية عميقة وعين للتصميم والسرد. من تحليل التهديدات والتحقيق في البرمجيات الخبيثة إلى هوية العلامة التجارية وبناء full-stack، يدور العمل دائماً حول صنع شيء ذي قيمة.",
                     "Cybersecurity expert and creative multimedia designer — combining deep security knowledge with an eye for design and storytelling. From threat analysis and malware investigation to brand identity and full-stack builds, the work is always about making something that matters.",
                   )}
                 </p>
 
-                <p className="mt-5 inline-flex items-center gap-2.5 font-mono text-[12px] tracking-[0.04em] text-emerald-400">
+                <p className="mt-6 inline-flex items-center gap-2.5 font-mono text-[12px] tracking-[0.04em] text-emerald-400">
                   <span className="font-bold text-emerald-500 rtl:rotate-180">›</span> {tagline}
                 </p>
               </div>
 
-              {/* Right — availability + facts */}
-              <div className="flex flex-col gap-4 bg-zinc-950/30 p-[30px]">
-                <div className="flex items-center gap-2.5 rounded-[7px] border border-emerald-900/70 bg-emerald-950/25 px-3 py-2.5">
-                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_theme(colors.emerald.500)] animate-pulse" />
-                  <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-400">{t("متاح", "Available")}</span>
-                  <span className="ml-auto font-mono text-[9px] uppercase tracking-[0.14em] text-zinc-700">{t("الحالة: نشط", "status: active")}</span>
-                </div>
+              {/* Right — identity card (raised surface for depth) */}
+              <div className="bg-zinc-950/55 p-[26px] sm:p-[30px]">
+                <IdentityCard
+                  initials={initials}
+                  location={location}
+                  focus={t("أمن + تصميم + أتمتة", "Security + design + automation")}
+                  clearance={t("مفتوح · جاهز لجهات التوظيف", "Open · recruiter-ready")}
+                />
+              </div>
 
-                <p className="font-mono text-[11px] leading-[1.7] text-zinc-600">
-                  {t(
-                    "متاح لفرص الأمن السيبراني واستخبارات التهديدات وتصميم الوسائط المتعددة وتطوير full-stack — عن بُعد وفي الموقع في دول الخليج.",
-                    "Open to cybersecurity, threat intelligence, multimedia design, and full-stack development — remote & on-site across the GCC.",
-                  )}
-                </p>
-
-                <div className="flex flex-col gap-2">
-                  <Fact Icon={MapPin} k={t("الموقع", "Location")} v={location} />
-                  <Fact Icon={ShieldCheck} k={t("التركيز", "Focus")} v={t("أمن + تصميم + أتمتة", "Security + design + automation")} />
-                  <Fact Icon={UserRound} k={t("التصريح", "Clearance")} v={t("مفتوح · جاهز لجهات التوظيف", "Open · recruiter-ready")} />
+              {/* Verdict stamp — overlaps the column seam for depth */}
+              <div className="pointer-events-none absolute left-1/2 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 -rotate-[9deg] lg:block">
+                <div className="dossier-stamp px-4 py-2 text-center">
+                  <div className="text-[15px] font-bold uppercase tracking-[0.18em] leading-none">{t("تم التحقق", "Verified")}</div>
+                  <div className="mt-1 text-[8px] uppercase tracking-[0.28em] text-emerald-500/70">subject · GNB-01</div>
                 </div>
               </div>
             </div>
@@ -158,7 +158,7 @@ export function PersonnelContent() {
 
           {/* ── 01 · CAPABILITY MATRIX ─────────────────────────────────── */}
           <section className="os-panel-in [animation-delay:80ms]">
-            <SecLabel idx="01">capability.matrix</SecLabel>
+            <SecLabel section={SECTIONS[0]} />
             <div className="grid gap-3.5 md:grid-cols-2">
               {technicalCapabilities.map((group) => (
                 <DomainCard key={group.key} groupKey={group.key} label={t(group.label.ar, group.label.en)} items={group.items.map((it) => t(it.ar, it.en))} />
@@ -166,9 +166,9 @@ export function PersonnelContent() {
             </div>
           </section>
 
-          {/* ── 02 · CREDENTIAL LEDGER ─────────────────────────────────── */}
+          {/* ── 02 · CREDENTIAL REGISTER ───────────────────────────────── */}
           <section className="os-panel-in [animation-delay:120ms]">
-            <SecLabel idx="02">credentials.ledger</SecLabel>
+            <SecLabel section={SECTIONS[1]} />
             <Win label="credentials.ledger" status={t("موثّق", "verified")} statusDot={false}>
               {/* summary + issuer distribution */}
               <div className="mb-[18px] flex flex-wrap items-center gap-[18px]">
@@ -212,7 +212,7 @@ export function PersonnelContent() {
 
           {/* ── 03 · SERVICE RECORD ────────────────────────────────────── */}
           <section className="os-panel-in [animation-delay:160ms]">
-            <SecLabel idx="03">service.record</SecLabel>
+            <SecLabel section={SECTIONS[2]} />
             <div className="grid gap-3.5 lg:grid-cols-2">
               <Win label="experience.timeline" status={t("سجلّ العمل", "work history")}>
                 <Timeline items={experienceTimeline} />
@@ -223,9 +223,9 @@ export function PersonnelContent() {
             </div>
           </section>
 
-          {/* ── 04 · ACTIVE BUILDS (roadmap) ───────────────────────────── */}
+          {/* ── 04 · ACTIVE OPERATIONS (roadmap) ───────────────────────── */}
           <section className="os-panel-in [animation-delay:200ms]">
-            <SecLabel idx="04" trailing={t("— ما نبنيه", "— what we're building")}>active.builds</SecLabel>
+            <SecLabel section={SECTIONS[3]} trailing={t("— ما نبنيه", "— what we're building")} />
             <Win label="active.builds" status={t("المسار", "trajectory")} statusDot={false}>
               <p className="mb-4 max-w-[70ch] font-mono text-[11.5px] leading-[1.7] text-zinc-600">
                 {t(
@@ -243,7 +243,7 @@ export function PersonnelContent() {
 
           {/* ── 05 · DIRECT CHANNELS ───────────────────────────────────── */}
           <section className="os-panel-in [animation-delay:240ms]">
-            <SecLabel idx="05">direct.channels</SecLabel>
+            <SecLabel section={SECTIONS[4]} />
             <Win label="direct.channels" status={t("مفتوح", "open")} statusDot={false}>
               <div className="grid items-center gap-[30px] lg:grid-cols-[1fr_auto]">
                 <div className="grid gap-2.5 sm:grid-cols-2">
@@ -261,7 +261,7 @@ export function PersonnelContent() {
                   <Link
                     href={resumeHref}
                     target="_blank"
-                    className="inline-flex items-center justify-center gap-2.5 rounded-[7px] border border-emerald-500 bg-emerald-500 px-[22px] py-[13px] font-mono text-[12px] font-semibold uppercase tracking-[0.08em] text-emerald-950 transition-all duration-200 hover:-translate-y-px hover:bg-emerald-400 hover:shadow-[0_0_22px_rgba(16,185,129,0.22)]"
+                    className="inline-flex items-center justify-center gap-2.5 rounded-[7px] border border-emerald-500 bg-emerald-500 px-[22px] py-[13px] font-mono text-[12px] font-semibold uppercase tracking-[0.08em] text-emerald-950 transition-all duration-200 hover:-translate-y-px hover:bg-emerald-400 hover:shadow-[0_0_22px_rgba(16,185,129,0.22)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                   >
                     <Download className="h-[15px] w-[15px]" />
                     {t("تحميل السيرة الذاتية", "Download resume")}
@@ -288,6 +288,76 @@ export function PersonnelContent() {
         </div>
       </footer>
     </>
+  )
+}
+
+// ── Classification banner — edge-to-edge cleared strip ──────────────────────
+function ClassificationBanner() {
+  const { t } = useLanguage()
+  return (
+    <div className="flex items-center gap-3 border-b border-emerald-900/60 bg-emerald-950/20 px-4 py-2 font-mono text-[9.5px] uppercase tracking-[0.22em] text-emerald-500/90 sm:px-[38px]">
+      <span className="flex items-center gap-2">
+        <span className="os-signal-dot" aria-hidden />
+        {t("سري · مُصرّح للإفراج", "Confidential · Cleared for Release")}
+      </span>
+      <span aria-hidden className="hidden flex-1 truncate text-emerald-900/70 sm:block">
+        {"// ".repeat(18)}
+      </span>
+      <span className="ml-auto shrink-0 tracking-[0.18em] text-zinc-600">file&nbsp;#GNB-01</span>
+    </div>
+  )
+}
+
+// ── Identity card — raised passport-style panel with barcode (depth) ────────
+function IdentityCard({
+  initials,
+  location,
+  focus,
+  clearance,
+}: {
+  initials: string
+  location: string
+  focus: string
+  clearance: string
+}) {
+  const { t } = useLanguage()
+  return (
+    <div className="flex flex-col gap-4 rounded-[10px] border border-zinc-800 bg-zinc-900/55 p-[18px] shadow-[0_24px_60px_-26px_rgba(0,0,0,0.85)]">
+      {/* card header */}
+      <div className="flex items-center gap-2 border-b border-zinc-800/70 pb-2.5">
+        <Fingerprint className="h-3.5 w-3.5 text-emerald-500" />
+        <span className="font-mono text-[9px] uppercase tracking-[0.2em] text-zinc-500">{t("بطاقة الهوية", "Identity Card")}</span>
+        <span className="ml-auto flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_theme(colors.emerald.500)] animate-pulse" />
+          <span className="font-mono text-[8.5px] uppercase tracking-[0.16em] text-emerald-400">{t("متاح", "Available")}</span>
+        </span>
+      </div>
+
+      {/* monogram + barcode */}
+      <div className="flex items-stretch gap-3">
+        <div className="grid h-[60px] w-[60px] shrink-0 place-items-center rounded-[8px] border border-emerald-900/70 bg-emerald-950/20 font-mono text-[22px] font-bold tracking-[0.04em] text-emerald-400">
+          {initials}
+        </div>
+        <div className="flex flex-1 flex-col justify-between py-0.5">
+          <div className="dossier-barcode h-[26px] w-full rounded-[3px]" aria-hidden />
+          <span className="font-mono text-[8.5px] uppercase tracking-[0.16em] text-zinc-700" dir="ltr">SUBJECT&nbsp;ID&nbsp;·&nbsp;GNB-01-HA</span>
+        </div>
+      </div>
+
+      {/* field rows */}
+      <div className="flex flex-col gap-2">
+        <Fact Icon={MapPin} k={t("الموقع", "Location")} v={location} />
+        <Fact Icon={ShieldCheck} k={t("التركيز", "Focus")} v={focus} />
+        <Fact Icon={UserRound} k={t("التصريح", "Clearance")} v={clearance} />
+      </div>
+
+      <p className="font-mono text-[9.5px] leading-[1.7] text-zinc-600">
+        {t(
+          "متاح لفرص الأمن السيبراني واستخبارات التهديدات وتصميم الوسائط المتعددة وتطوير full-stack — عن بُعد وفي الموقع في دول الخليج.",
+          "Open to cybersecurity, threat intelligence, multimedia design & full-stack work — remote & on-site across the GCC.",
+        )}
+      </p>
+    </div>
   )
 }
 
@@ -335,17 +405,27 @@ function Win({
   )
 }
 
-function SecLabel({ idx, trailing, children }: { idx: string; trailing?: string; children: ReactNode }) {
+// ── Section header — filed as a numbered form reference (tab + code + title) ──
+function SecLabel({ section, trailing }: { section: { idx: string; code: string; title: Bilingual }; trailing?: string }) {
+  const { t } = useLanguage()
   return (
-    <div className="mb-3.5 flex items-center gap-3.5 font-mono text-[11px] uppercase tracking-[0.24em] text-zinc-600">
-      <span className="text-emerald-500">{idx}</span>
-      <span>
-        {children}
-        {trailing && <span className="ml-2 text-zinc-700">{trailing}</span>}
+    <div className="mb-3.5 flex items-center gap-3">
+      <span className="inline-flex items-center gap-2 rounded-[5px] border border-emerald-900/70 bg-emerald-950/15 px-2.5 py-[5px]">
+        <span className="font-mono text-[11px] font-semibold tracking-[0.1em] text-emerald-500">{section.idx}</span>
+        <span className="h-3 w-px bg-emerald-900/70" />
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-500">{section.code}</span>
+      </span>
+      <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-zinc-400">
+        {t(section.title.ar, section.title.en)}
+        {trailing && <span className="ml-2 normal-case tracking-normal text-zinc-700">{trailing}</span>}
       </span>
       <span className="h-px flex-1 bg-zinc-800/70" />
     </div>
   )
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-zinc-700">{children}</p>
 }
 
 function Fact({ Icon, k, v }: { Icon: ElementType; k: string; v: string }) {
@@ -403,7 +483,7 @@ function CertCard({ cert }: { cert: Certification }) {
     <>
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 left-0 w-0.5 opacity-0 transition-opacity duration-200 group-hover/cert:opacity-70 rtl:left-auto rtl:right-0"
+        className="pointer-events-none absolute inset-y-0 left-0 w-0.5 opacity-0 transition-opacity duration-200 group-hover/cert:opacity-70 group-focus-visible/cert:opacity-70 rtl:left-auto rtl:right-0"
         style={{ backgroundColor: color }}
       />
       <div className="flex items-start justify-between gap-2.5">
@@ -414,7 +494,7 @@ function CertCard({ cert }: { cert: Certification }) {
           {cert.issuer}
         </span>
         {cert.href && (
-          <ExternalLink className="h-[13px] w-[13px] shrink-0 text-zinc-700 transition-colors group-hover/cert:text-emerald-500" />
+          <ExternalLink className="h-[13px] w-[13px] shrink-0 text-zinc-700 transition-colors group-hover/cert:text-emerald-500 group-focus-visible/cert:text-emerald-500" />
         )}
       </div>
       <h4 className="mt-3 flex-1 text-[13.5px] font-semibold leading-[1.35] text-zinc-100">{cert.name}</h4>
@@ -432,7 +512,7 @@ function CertCard({ cert }: { cert: Certification }) {
   )
 
   const cardClass =
-    "group/cert relative flex flex-col overflow-hidden rounded-[9px] border border-zinc-800 bg-zinc-950/40 p-[15px] transition-all duration-200 hover:-translate-y-0.5 hover:bg-zinc-800/40"
+    "group/cert relative flex flex-col overflow-hidden rounded-[9px] border border-zinc-800 bg-zinc-950/40 p-[15px] transition-all duration-200 hover:-translate-y-0.5 hover:bg-zinc-800/40 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
 
   return cert.href ? (
     <Link href={cert.href} target="_blank" rel="noopener noreferrer" className={cardClass}>
@@ -515,7 +595,7 @@ function Channel({ Icon, k, v, href, external }: { Icon: ElementType; k: string;
       href={href}
       target={external ? "_blank" : undefined}
       rel={external ? "noopener noreferrer" : undefined}
-      className="flex items-center gap-2.5 rounded-lg border border-zinc-800 bg-zinc-950/40 px-3.5 py-3 transition-all duration-200 hover:-translate-y-px hover:border-emerald-900/70 hover:bg-emerald-950/15"
+      className="flex items-center gap-2.5 rounded-lg border border-zinc-800 bg-zinc-950/40 px-3.5 py-3 transition-all duration-200 hover:-translate-y-px hover:border-emerald-900/70 hover:bg-emerald-950/15 focus-visible:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60"
     >
       <Icon className="h-4 w-4 shrink-0 text-emerald-500" />
       <span className="min-w-0">


### PR DESCRIPTION
## Personnel Dossier — editorial intelligence-file redesign

Reworks `/personnel` from a stack of OS windows into a single, intentional **declassified case-file**. Same visual language as the rest of the site (zinc-950 OS surfaces, emerald signal, mono-label + sans-display pairing, the `Win` window chrome, `os-panel-in` entrances) — only the composition and narrative framing change. No new theme, no new dependencies.

### Design direction
A recruiter opens an actual classified dossier on the subject:

- **Cover sheet** — an edge-to-edge classification banner (`CONFIDENTIAL · CLEARED FOR RELEASE`, semantic emerald = cleared) over a bento split: an oversized subject name (strong scale contrast) beside a **raised, overlapping identity card** (monogram, decorative barcode strip, status LED, field rows). Depth comes from the card shadow plus a rotated **`VERIFIED` rubber-stamp** sitting on the column seam.
- **Form-style section tabs** — each section is filed as a numbered reference (`01 / capability.matrix -> Capability Matrix`) instead of a plain label, reinforcing the document metaphor.
- **Retained, intact** — capability matrix, credential register (with the issuer-distribution data-viz bar), service/academic timelines, active operations, and contact channels — all still driven by the same `lib/content/personnel` + `lib/memory/plan` data and bilingual `t()` i18n.

### Quality bar
- Hierarchy via scale contrast, intentional spacing rhythm, depth/layering, mono+sans typography pairing, semantic color, designed hover **and keyboard `focus-visible`** states, editorial/bento composition.
- Motion stays on **transform/opacity only**; all new CSS primitives (grain, barcode, stamp in `globals.css`) are additive and **reduced-motion safe**.
- Responsive (320/768/1024/1440): the ID card stacks under the brief and the seam stamp hides below `lg` so nothing overlaps on mobile/RTL.

### Files changed
- `app/personnel/personnel-content.tsx` — redesigned layout + new `ClassificationBanner` / `IdentityCard` / form-tab `SecLabel` helpers.
- `app/globals.css` — additive `.dossier-grain` / `.dossier-barcode` / `.dossier-stamp` primitives.

### Verification
- `npm install` + `npm run build` -> compiled successfully; `/personnel` prerenders as static. The only build warning (`next.config.mjs` NFT trace) is pre-existing and unrelated.

### Notes for review
- **Do not merge yet** — visual change to review via the Vercel preview.
- Open questions: (1) keep the decorative barcode, or swap for a real cred/QR? (2) the `VERIFIED` seam stamp is `lg`-only — want a mobile-visible variant? (3) comfortable with the `CONFIDENTIAL · CLEARED FOR RELEASE` wording, or prefer something less literal?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reworks the `/personnel` page from a multi-OS-window stack into a single declassified case-file layout while staying entirely within the existing design system (zinc-950/emerald tokens, `Win` chrome, `os-panel-in` animations). No new dependencies are introduced; the two new CSS primitives in `globals.css` are additive and reduced-motion safe.

- **Cover sheet redesign**: adds `ClassificationBanner`, an overlapping `IdentityCard` with monogram + decorative barcode, and a rotated `VERIFIED` stamp that sits on the column seam at `lg` breakpoints; all sections get a numbered form-tab `SecLabel`.
- **Accessibility improvements**: `focus-visible` ring and `-translate-y` states added to `CertCard`, `Channel`, and the resume download link, bringing keyboard navigation in line with the hover styles.
- **Two layout details to confirm visually**: the stamp's `left-1/2` placement targets 50% of the container width rather than the `1.6fr / 0.95fr` seam (~62.7%), and the `ml-auto` on the file-reference in `ClassificationBanner` may misalign in RTL.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to preview; the visual changes are well-contained to the personnel page and all data paths remain unchanged.

The refactor touches only layout and presentation — no data mutations, no auth, no new dependencies. The two observations (stamp centering and RTL margin) are visual polish issues the author already flagged as needing a preview pass before merging.

The ClassificationBanner RTL margin and the stamp left-1/2 position in personnel-content.tsx are both worth a second look against the Vercel preview before merge.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/personnel/personnel-content.tsx | Redesigned cover-sheet layout with ClassificationBanner, IdentityCard, and form-tab SecLabel helpers; focus-visible states added throughout; minor stamp positioning and RTL concerns. |
| app/globals.css | Additive dossier CSS primitives (grain, barcode, stamp); the .dossier-grain > * rule sets position:relative z-index:1 on all direct children, which is functional but broad in scope. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PC[PersonnelContent] --> WIN["Win (cover sheet)\ndossier-grain"]
    WIN --> CB[ClassificationBanner]
    WIN --> GRID["relative grid\nlg:cols [1.6fr / 0.95fr]"]
    WIN --> SB[StatBand]

    GRID --> LEFT["Left pane\nSubject brief + tagline"]
    GRID --> RIGHT["Right pane\nIdentityCard"]
    GRID --> STAMP["Verdict stamp\nabsolute · lg:block\n⚠ left-1/2 ≠ seam"]

    RIGHT --> IC["IdentityCard\nmonogram · barcode · Fact rows"]

    PC --> S1["§01 Capability Matrix\nSecLabel + DomainCard grid"]
    PC --> S2["§02 Credential Register\nSecLabel + Win + CertCard grid"]
    PC --> S3["§03 Service Record\nSecLabel + Timeline ×2"]
    PC --> S4["§04 Active Operations\nSecLabel + BuildCard grid"]
    PC --> S5["§05 Direct Channels\nSecLabel + Channel grid + resume CTA"]

    style STAMP fill:#f97316,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    PC[PersonnelContent] --> WIN["Win (cover sheet)\ndossier-grain"]
    WIN --> CB[ClassificationBanner]
    WIN --> GRID["relative grid\nlg:cols [1.6fr / 0.95fr]"]
    WIN --> SB[StatBand]

    GRID --> LEFT["Left pane\nSubject brief + tagline"]
    GRID --> RIGHT["Right pane\nIdentityCard"]
    GRID --> STAMP["Verdict stamp\nabsolute · lg:block\n⚠ left-1/2 ≠ seam"]

    RIGHT --> IC["IdentityCard\nmonogram · barcode · Fact rows"]

    PC --> S1["§01 Capability Matrix\nSecLabel + DomainCard grid"]
    PC --> S2["§02 Credential Register\nSecLabel + Win + CertCard grid"]
    PC --> S3["§03 Service Record\nSecLabel + Timeline ×2"]
    PC --> S4["§04 Active Operations\nSecLabel + BuildCard grid"]
    PC --> S5["§05 Direct Channels\nSecLabel + Channel grid + resume CTA"]

    style STAMP fill:#f97316,color:#fff
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fpersonnel%2Fpersonnel-content.tsx%3A148%0A**Stamp%20placement%20doesn't%20reach%20the%20column%20seam**%0A%0AThe%20PR%20description%20says%20the%20stamp%20%22sits%20on%20the%20column%20seam%20for%20depth%22%2C%20but%20%60left-1%2F2%60%20%2850%25%20of%20the%20container%29%20doesn't%20match%20the%20seam%20position%20for%20a%20%601.6fr%20%2F%200.95fr%60%20grid%20split.%20The%20seam%20falls%20at%20%601.6%20%2F%20%281.6%20%2B%200.95%29%20%E2%89%88%2062.7%25%60%20of%20the%20container%20width%2C%20so%20at%20common%20viewport%20sizes%20the%20stamp%20will%20hover%20inside%20the%20left%20content%20column%20rather%20than%20straddling%20the%20dividing%20line.%20A%20value%20closer%20to%20%60left-%5B63%25%5D%60%20%28or%20a%20CSS%20%60calc%60%29%20would%20correctly%20target%20the%20seam.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fpersonnel%2Fpersonnel-content.tsx%3A306%0A**%60ml-auto%60%20breaks%20RTL%20alignment%20in%20the%20classification%20banner**%0A%0A%60ml-auto%60%20is%20%60margin-left%3A%20auto%60%20and%20always%20pushes%20the%20file-reference%20span%20to%20the%20physical%20right%2C%20regardless%20of%20text%20direction.%20In%20an%20RTL%20context%20the%20%22end%22%20of%20the%20row%20is%20the%20left%20edge%2C%20so%20the%20file%20number%20will%20appear%20at%20the%20LTR%20start%20rather%20than%20the%20reading-order%20end.%20The%20rest%20of%20the%20codebase%20uses%20explicit%20%60rtl%3A%60%20variants%20%28e.g.%2C%20%60rtl%3Amr-auto%20rtl%3Aml-0%60%29%20or%20logical%20properties%20to%20handle%20this.%20Using%20%60ms-auto%60%20%28margin-inline-start%29%20would%20push%20to%20the%20correct%20end%20in%20both%20LTR%20and%20RTL%20without%20a%20separate%20override.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=52&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fpersonnel-dossier-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpersonnel-dossier-redesign%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fpersonnel%2Fpersonnel-content.tsx%3A148%0A**Stamp%20placement%20doesn't%20reach%20the%20column%20seam**%0A%0AThe%20PR%20description%20says%20the%20stamp%20%22sits%20on%20the%20column%20seam%20for%20depth%22%2C%20but%20%60left-1%2F2%60%20%2850%25%20of%20the%20container%29%20doesn't%20match%20the%20seam%20position%20for%20a%20%601.6fr%20%2F%200.95fr%60%20grid%20split.%20The%20seam%20falls%20at%20%601.6%20%2F%20%281.6%20%2B%200.95%29%20%E2%89%88%2062.7%25%60%20of%20the%20container%20width%2C%20so%20at%20common%20viewport%20sizes%20the%20stamp%20will%20hover%20inside%20the%20left%20content%20column%20rather%20than%20straddling%20the%20dividing%20line.%20A%20value%20closer%20to%20%60left-%5B63%25%5D%60%20%28or%20a%20CSS%20%60calc%60%29%20would%20correctly%20target%20the%20seam.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fpersonnel%2Fpersonnel-content.tsx%3A306%0A**%60ml-auto%60%20breaks%20RTL%20alignment%20in%20the%20classification%20banner**%0A%0A%60ml-auto%60%20is%20%60margin-left%3A%20auto%60%20and%20always%20pushes%20the%20file-reference%20span%20to%20the%20physical%20right%2C%20regardless%20of%20text%20direction.%20In%20an%20RTL%20context%20the%20%22end%22%20of%20the%20row%20is%20the%20left%20edge%2C%20so%20the%20file%20number%20will%20appear%20at%20the%20LTR%20start%20rather%20than%20the%20reading-order%20end.%20The%20rest%20of%20the%20codebase%20uses%20explicit%20%60rtl%3A%60%20variants%20%28e.g.%2C%20%60rtl%3Amr-auto%20rtl%3Aml-0%60%29%20or%20logical%20properties%20to%20handle%20this.%20Using%20%60ms-auto%60%20%28margin-inline-start%29%20would%20push%20to%20the%20correct%20end%20in%20both%20LTR%20and%20RTL%20without%20a%20separate%20override.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=52&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(personnel): redesign Personnel Doss..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/561c0601736f8ee2d6699cfec3f167011ad3f256) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40072524)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->