### PR TITLE
feat: bilingual AI SDR chat assistant (Phase 2)

### DIFF
--- a/app/api/sdr/route.ts
+++ b/app/api/sdr/route.ts
@@ -77,6 +77,17 @@ export async function POST(req: Request) {
   }
 
   const { lang, messages } = parsed.data
+
+  // Graceful degradation: if the LLM isn't configured yet, don't error on the
+  // live page — steer the visitor to the booking action instead.
+  if (!process.env.OPENROUTER_API_KEY) {
+    const reply =
+      lang === "ar"
+        ? 'المساعد الذكي غير متاح مؤقتاً. للبدء، اضغط زر «احجز مراجعة مجانية» أعلاه — مراجعة 20 دقيقة لانكشافك السيبراني والذكاء الاصطناعي، بلا التزام.'
+        : 'The AI assistant is briefly offline. To get started, tap "Book free review" above — a no-obligation 20-min review of your Cyber & AI exposure.'
+    return NextResponse.json({ ok: true, reply })
+  }
+
   const systemPrompt = lang === "ar" ? SDR_SYSTEM_PROMPT_AR : SDR_SYSTEM_PROMPT_EN
 
   const payload: SdrMessage[] = [

--- a/app/api/sdr/route.ts
+++ b/app/api/sdr/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { sdrComplete, type SdrMessage } from "@/lib/sdr/openrouter"
+import { SDR_SYSTEM_PROMPT_AR, SDR_SYSTEM_PROMPT_EN } from "@/content/sdr/knowledge"
+
+/**
+ * AI SDR assistant — POST /api/sdr
+ *
+ * Takes the running chat history plus the visitor's language, prepends the
+ * matching bilingual system prompt, and returns a single OpenRouter completion.
+ * Best-effort in-memory per-IP rate limiting guards the upstream spend.
+ *
+ * Request body:  { messages: { role: "user" | "assistant"; content: string }[], lang: "ar" | "en" }
+ * Response:      { ok: true, reply: string }  |  { ok: false, error: string }
+ */
+
+export const runtime = "nodejs"
+
+const MAX_HISTORY = 20 // cap conversation turns sent upstream
+const MAX_MESSAGE_LEN = 2000 // cap each message's character length
+
+// ── Best-effort rate limiting (per IP, fixed window) ──────────────────────────
+const RATE_LIMIT_WINDOW_MS = 60_000
+const RATE_LIMIT_MAX = 15
+const hits = new Map<string, { count: number; resetAt: number }>()
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now()
+  const entry = hits.get(ip)
+  if (!entry || now > entry.resetAt) {
+    hits.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
+    return false
+  }
+  if (entry.count >= RATE_LIMIT_MAX) return true
+  // Immutable update of the counter for this window.
+  hits.set(ip, { count: entry.count + 1, resetAt: entry.resetAt })
+  return false
+}
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for")
+  if (fwd) return fwd.split(",")[0]!.trim()
+  return req.headers.get("x-real-ip")?.trim() || "unknown"
+}
+
+const bodySchema = z.object({
+  lang: z.enum(["ar", "en"]),
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant"]),
+        content: z.string().trim().min(1).max(MAX_MESSAGE_LEN),
+      }),
+    )
+    .min(1)
+    .max(MAX_HISTORY),
+})
+
+export async function POST(req: Request) {
+  if (isRateLimited(clientIp(req))) {
+    return NextResponse.json(
+      { ok: false, error: "Too many requests. Please wait a moment and try again." },
+      { status: 429 },
+    )
+  }
+
+  let raw: unknown
+  try {
+    raw = await req.json()
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 })
+  }
+
+  const parsed = bodySchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: "Invalid request payload." }, { status: 400 })
+  }
+
+  const { lang, messages } = parsed.data
+  const systemPrompt = lang === "ar" ? SDR_SYSTEM_PROMPT_AR : SDR_SYSTEM_PROMPT_EN
+
+  const payload: SdrMessage[] = [
+    { role: "system", content: systemPrompt },
+    ...messages.map((m) => ({ role: m.role, content: m.content })),
+  ]
+
+  try {
+    const reply = await sdrComplete(payload)
+    return NextResponse.json({ ok: true, reply })
+  } catch (err) {
+    console.error("[sdr]", err instanceof Error ? err.message : err)
+    return NextResponse.json(
+      { ok: false, error: "The assistant is unavailable right now. Please try again shortly." },
+      { status: 502 },
+    )
+  }
+}

--- a/app/services/cyber-sprint/page.tsx
+++ b/app/services/cyber-sprint/page.tsx
@@ -1,0 +1,397 @@
+'use client'
+
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { GlitchText } from '@/components/glitch-text'
+import { MatrixBackground } from '@/components/matrix-background'
+import { useLanguage } from '@/components/language-provider'
+import {
+  ArrowLeft, ShieldCheck, FileSearch, Bot, ScanLine, GraduationCap, FileText,
+  CheckCircle2, Clock, Phone, Zap, ChevronRight, AlertTriangle, Building2,
+} from 'lucide-react'
+
+// Bilingual tuple — resolved at render via the language provider's t(ar, en).
+// Technical / product names (Microsoft 365, PDPL, NCA, SDAIA, MFA, M365) stay in
+// English inside Arabic prose, per the site convention.
+type Bi = readonly [ar: string, en: string]
+
+// ── Why now: live national signals (sourced from NCA / SDAIA / gov.sa, 2025) ──
+const SIGNALS: { value: Bi; label: Bi }[] = [
+  { value: ['15.2 مليار ر.س', 'SAR 15.2B'], label: ['الإنفاق على الأمن السيبراني', 'Cybersecurity spend'] },
+  { value: ['+14٪', '+14%'],                 label: ['نمو سنوي', 'YoY growth'] },
+  { value: ['68٪', '68%'],                   label: ['حصة القطاع الخاص', 'Private-sector share'] },
+  { value: ['48 قراراً', '48 rulings'],      label: ['مخالفات نظام حماية البيانات', 'PDPL violation decisions'] },
+]
+
+// ── The 14-day deliverables (matches the one-page offer) ──────────────────────
+const DELIVERABLES: { icon: React.ReactNode; title: Bi; detail: Bi }[] = [
+  {
+    icon: <ShieldCheck className="h-5 w-5" />,
+    title: ['فحص أمان Microsoft 365', 'Microsoft 365 security check'],
+    detail: ['المصادقة الثنائية MFA، أدوار المشرفين، روابط المشاركة، مخاطر البريد، وانكشاف OneDrive / SharePoint.', 'MFA, admin roles, sharing links, mailbox risks, OneDrive / SharePoint exposure.'],
+  },
+  {
+    icon: <FileSearch className="h-5 w-5" />,
+    title: ['جاهزية نظام حماية البيانات (PDPL)', 'PDPL basic readiness'],
+    detail: ['إشعار الخصوصية، خريطة جمع البيانات، فجوات الموافقة، ومعالجة WhatsApp Business وهواتف العمل.', 'Privacy notice, data-collection map, consent gaps, WhatsApp Business / business-phone handling.'],
+  },
+  {
+    icon: <Bot className="h-5 w-5" />,
+    title: ['سياسة استخدام الذكاء الاصطناعي', 'AI usage policy'],
+    detail: ['ما الذي يمكن للموظفين رفعه أو حظره على ChatGPT و Gemini و Copilot وغيرها.', 'What staff can / cannot upload to ChatGPT, Gemini, Copilot, etc.'],
+  },
+  {
+    icon: <ScanLine className="h-5 w-5" />,
+    title: ['لقطة عن الثغرات', 'Vulnerability snapshot'],
+    detail: ['فحص خارجي آمن، قائمة بالأصول، وتقرير بنقاط الضعف.', 'Safe external scan, asset list, weak-points report.'],
+  },
+  {
+    icon: <GraduationCap className="h-5 w-5" />,
+    title: ['جلسة توعية للموظفين', 'Staff awareness session'],
+    detail: ['تدريب مباشر 60–90 دقيقة بالعربية أو الإنجليزية.', '60–90 min live training in Arabic or English.'],
+  },
+  {
+    icon: <FileText className="h-5 w-5" />,
+    title: ['التقرير النهائي', 'Final report'],
+    detail: ['درجة مخاطر تنفيذية + خطة عمل لمدة 30 يوماً.', 'Executive risk score + 30-day action plan.'],
+  },
+]
+
+// ── Pricing tiers ─────────────────────────────────────────────────────────────
+const TIERS: {
+  id: string
+  name: Bi
+  price: Bi
+  cadence: Bi
+  blurb: Bi
+  includes: readonly Bi[]
+  featured?: boolean
+}[] = [
+  {
+    id: 'basic',
+    name: ['سبرنت الجاهزية الأساسي', 'Basic Readiness Sprint'],
+    price: ['4,500 ر.س', 'SAR 4,500'],
+    cadence: ['دفعة واحدة', 'one-time'],
+    blurb: ['نقطة انطلاق سريعة لاكتشاف أهم المخاطر.', 'A fast starting point to surface your top risks.'],
+    includes: [
+      ['فحص أمان Microsoft 365', 'Microsoft 365 security check'],
+      ['جاهزية PDPL الأساسية', 'PDPL basic readiness'],
+      ['سياسة استخدام الذكاء الاصطناعي', 'AI usage policy'],
+      ['تقرير تنفيذي + خطة 30 يوماً', 'Executive report + 30-day plan'],
+    ],
+  },
+  {
+    id: 'full',
+    name: ['سبرنت الأمن + الذكاء الاصطناعي الكامل', 'Full Cyber + AI Sprint'],
+    price: ['8,500 ر.س', 'SAR 8,500'],
+    cadence: ['دفعة واحدة', 'one-time'],
+    blurb: ['الحزمة الكاملة لمدة 14 يوماً — كل المخرجات الستة.', 'The complete 14-day package — all six deliverables.'],
+    includes: [
+      ['كل ما في الباقة الأساسية', 'Everything in Basic'],
+      ['لقطة عن الثغرات (فحص خارجي آمن)', 'Vulnerability snapshot (safe external scan)'],
+      ['جلسة توعية مباشرة للموظفين', 'Live staff awareness session'],
+      ['مكالمة شرح لخطوات المعالجة', 'Remediation walkthrough call'],
+    ],
+    featured: true,
+  },
+  {
+    id: 'retainer',
+    name: ['اشتراك شهري', 'Monthly Retainer'],
+    price: ['1,500–4,000 ر.س', 'SAR 1,500–4,000'],
+    cadence: ['شهرياً', 'per month'],
+    blurb: ['دعم مستمر بعد السبرنت للحفاظ على التحسّن.', 'Ongoing support after the sprint to keep improving.'],
+    includes: [
+      ['مراجعة شهرية للوضع الأمني', 'Monthly posture review'],
+      ['تحديث السياسات والتوثيق', 'Policy & documentation upkeep'],
+      ['تنبيهات استباقية بالثغرات', 'Proactive vulnerability alerts'],
+      ['تنسيق مع مزوّدين مرخّصين عند الحاجة', 'Coordination with licensed providers as needed'],
+    ],
+  },
+]
+
+const TARGETS: Bi[] = [
+  ['شركات العقار', 'Real estate'],
+  ['العيادات', 'Clinics'],
+  ['المقاولون الصغار', 'Small contractors'],
+  ['العلامات التجارية للتجزئة', 'Retail brands'],
+  ['وكالات التسويق', 'Marketing agencies'],
+  ['المدارس ومراكز التدريب', 'Schools & training centers'],
+]
+
+export default function CyberSprintPage() {
+  const { t, dir } = useLanguage()
+
+  return (
+    <div dir={dir} className="min-h-screen bg-[#09090b] text-white relative overflow-hidden">
+      <MatrixBackground />
+
+      {/* Ambient glow */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: [
+            'radial-gradient(700px 400px at 10% 0%, rgba(16,185,129,0.05), transparent)',
+            'radial-gradient(500px 300px at 90% 20%, rgba(96,165,250,0.03), transparent)',
+          ].join(', '),
+        }}
+      />
+
+      {/* ── Header ──────────────────────────────────────────────────────── */}
+      <header className="border-b border-zinc-900 relative z-10">
+        <div className="container mx-auto py-4 px-4">
+          <nav className="flex justify-between items-center">
+            <Link href="/" className="flex items-center gap-2.5 group">
+              <img
+                src="/images/newlogovector.png"
+                alt="Goodnbad.exe"
+                width={32}
+                height={32}
+                className="rounded-full bg-zinc-800/60 p-0.5 ring-1 ring-zinc-700 group-hover:ring-emerald-800/60 transition-all"
+              />
+              <GlitchText text="Goodnbad.exe" className="font-mono font-semibold text-sm text-emerald-400" />
+            </Link>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="border border-zinc-800 text-zinc-500 hover:text-zinc-100 hover:border-zinc-700 font-mono text-[11px] uppercase tracking-widest"
+              asChild
+            >
+              <Link href="/services"><ArrowLeft className="mr-1.5 h-3 w-3" /> {t('الخدمات', 'Services')}</Link>
+            </Button>
+          </nav>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+
+        {/* ── Hero ──────────────────────────────────────────────────────── */}
+        <section dir={dir} className="container mx-auto px-4 pt-16 pb-10 max-w-4xl">
+          <div className="inline-flex items-center gap-2 rounded border border-emerald-800/60 bg-emerald-950/20 px-3 py-1.5 font-mono text-[10px] text-emerald-400 uppercase tracking-widest mb-6">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse shadow-[0_0_6px_rgba(16,185,129,0.8)]" />
+            {t('سبرنت 14 يوماً · جاهز لـ NCA و PDPL', '14-Day Sprint · NCA & PDPL Ready')}
+          </div>
+
+          <h1 className="text-4xl md:text-6xl font-bold mb-5 leading-tight tracking-tight">
+            <GlitchText text={t('جاهزية الأمن السيبراني والذكاء الاصطناعي للشركات', 'SME Cyber & AI Readiness Sprint')} />
+          </h1>
+
+          <p className="text-base text-zinc-400 max-w-2xl mb-6 leading-relaxed">
+            {t(
+              'حزمة خدمة محدّدة النطاق للشركات الصغيرة والمتوسطة في السعودية التي تحتاج إلى الأمن السيبراني، وتنظيف Microsoft 365، وجاهزية نظام حماية البيانات الشخصية (PDPL)، وقواعد استخدام الذكاء الاصطناعي — دون توظيف فريق أمني كامل. خلال 14 يوماً نكتشف مخاطرك ونسلّمك تقريراً تنفيذياً واضحاً وإصلاحات عملية.',
+              'A scoped service for Saudi SMEs that need cybersecurity, Microsoft 365 cleanup, PDPL readiness, and AI usage rules — without hiring a full security team. In 14 days we find your risks and hand you a clear executive report and practical fixes.',
+            )}
+          </p>
+
+          <p className="text-sm text-zinc-600 max-w-2xl mb-8 leading-relaxed">
+            {t(
+              'لماذا الآن؟ بلغ الإنفاق على الأمن السيبراني في المملكة 15.2 مليار ريال بنمو 14٪، ويشكّل القطاع الخاص 68٪ منه. وأصدرت سدايا 48 قراراً بمخالفة نظام حماية البيانات خلال عام واحد، و2026 هو عام الذكاء الاصطناعي رسمياً. الامتثال لم يعد "لاحقاً".',
+              'Why now? Saudi cybersecurity spend hit SAR 15.2B (+14%), with the private sector at 68%. SDAIA issued 48 PDPL violation decisions in a single year, and 2026 is officially the Year of AI. Compliance is no longer "later".',
+            )}
+          </p>
+
+          {/* CTAs */}
+          <div className="flex flex-col sm:flex-row gap-3">
+            <a
+              href="/services#inquiry"
+              className="inline-flex items-center justify-center gap-2 rounded bg-emerald-500 hover:bg-emerald-400 text-black font-bold px-5 py-3 text-sm transition-all duration-200 hover:shadow-[0_0_28px_rgba(16,185,129,0.35)]"
+            >
+              <Zap className="h-4 w-4" /> {t('احجز مراجعة الانكشاف المجانية', 'Book Free Exposure Review')}
+            </a>
+            <a
+              href="tel:+966508501717"
+              className="inline-flex items-center justify-center gap-2 rounded border border-zinc-800 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200 font-mono px-5 py-3 text-sm transition-all duration-200"
+            >
+              <Phone className="h-4 w-4" /> +966 50 850 1717
+            </a>
+          </div>
+          <p className="font-mono text-[10px] text-zinc-700 mt-3">
+            {t('مراجعة مجانية 20 دقيقة لانكشافك السيبراني والذكاء الاصطناعي · بلا التزام', 'Free 20-min Cyber & AI Exposure Review · No obligation')}
+          </p>
+        </section>
+
+        {/* ── Why-now stat row ──────────────────────────────────────────── */}
+        <div dir={dir} className="border-y border-zinc-900 bg-zinc-950/50 relative z-10">
+          <div className="container mx-auto px-4 max-w-6xl">
+            <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-zinc-900">
+              {SIGNALS.map((s) => (
+                <div key={s.label[1]} className="px-6 py-4 text-center">
+                  <div className="font-mono text-base font-bold text-emerald-300 mb-0.5">{t(...s.value)}</div>
+                  <div className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest">{t(...s.label)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* ── What's included ───────────────────────────────────────────── */}
+        <section dir={dir} className="container mx-auto px-4 py-16 max-w-6xl">
+          <div className="flex items-center gap-4 mb-10">
+            <div>
+              <p className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest mb-1">{t('خلال 14 يوماً', 'In 14 days')}</p>
+              <h2 className="text-2xl font-bold text-zinc-100"><GlitchText text={t('ما الذي تحصل عليه', 'What You Get')} /></h2>
+            </div>
+            <span className="h-px flex-1 bg-zinc-900 hidden sm:block" />
+            <p className="text-[11px] text-zinc-700 font-mono shrink-0 hidden sm:block">
+              {t('نطاق واضح · 14 يوماً · مخرجات حقيقية', 'clear scope · 14 days · real deliverables')}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {DELIVERABLES.map((d) => (
+              <div
+                key={d.title[1]}
+                className="group relative flex flex-col rounded-md border border-emerald-500/20 bg-zinc-900/40 overflow-hidden transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_16px_48px_rgba(0,0,0,0.5),0_0_0_1px_rgba(52,211,153,0.2)]"
+              >
+                <span className="absolute top-0 left-0 right-0 h-px opacity-50 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-r from-transparent via-emerald-400 to-transparent" />
+                <div className="p-5 flex-1 flex flex-col">
+                  <div
+                    className="w-9 h-9 rounded border border-zinc-800/80 flex items-center justify-center text-emerald-400 mb-4 transition-all duration-200 group-hover:scale-105"
+                    style={{ background: 'rgba(52,211,153,0.08)' }}
+                  >
+                    {d.icon}
+                  </div>
+                  <h3 className="text-sm font-semibold text-zinc-100 mb-2 leading-snug">{t(...d.title)}</h3>
+                  <p className="text-zinc-500 text-xs leading-relaxed flex-1">{t(...d.detail)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Pricing ───────────────────────────────────────────────────── */}
+        <section dir={dir} className="container mx-auto px-4 pb-16 max-w-6xl">
+          <div className="flex items-center gap-4 mb-10">
+            <div>
+              <p className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest mb-1">{t('الأسعار', 'Pricing')}</p>
+              <h2 className="text-2xl font-bold text-zinc-100"><GlitchText text={t('اختر نقطة البداية', 'Pick Your Starting Point')} /></h2>
+            </div>
+            <span className="h-px flex-1 bg-zinc-900 hidden sm:block" />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {TIERS.map((tier) => (
+              <div
+                key={tier.id}
+                className={`relative flex flex-col rounded-md border ${
+                  tier.featured ? 'border-emerald-500/50 bg-emerald-950/10' : 'border-zinc-800 bg-zinc-900/40'
+                } overflow-hidden transition-all duration-300 hover:-translate-y-0.5`}
+              >
+                {tier.featured && (
+                  <span className="absolute top-3 ltr:right-3 rtl:left-3 font-mono text-[9px] uppercase tracking-widest text-emerald-300 border border-emerald-500/40 bg-emerald-500/10 rounded px-2 py-0.5">
+                    {t('الأكثر طلباً', 'Most Popular')}
+                  </span>
+                )}
+                <span className={`absolute top-0 left-0 right-0 h-px ${tier.featured ? 'bg-gradient-to-r from-transparent via-emerald-400 to-transparent' : 'bg-zinc-800'}`} />
+                <div className="p-6 flex-1 flex flex-col">
+                  <h3 className="text-sm font-semibold text-zinc-100 mb-1 leading-snug pe-20">{t(...tier.name)}</h3>
+                  <div className="flex items-baseline gap-1.5 mb-3">
+                    <span className="text-2xl font-bold text-white">{t(...tier.price)}</span>
+                    <span className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest">{t(...tier.cadence)}</span>
+                  </div>
+                  <p className="text-zinc-500 text-xs mb-5 leading-relaxed">{t(...tier.blurb)}</p>
+                  <ul className="space-y-2 mb-6 flex-1">
+                    {tier.includes.map((inc) => (
+                      <li key={inc[1]} className="flex items-start gap-2 text-xs text-zinc-400">
+                        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0 mt-0.5" />
+                        {t(...inc)}
+                      </li>
+                    ))}
+                  </ul>
+                  <a
+                    href="/services#inquiry"
+                    className={`inline-flex items-center justify-center gap-1.5 rounded px-4 py-2.5 text-sm font-bold transition-all duration-200 ${
+                      tier.featured
+                        ? 'bg-emerald-500 hover:bg-emerald-400 text-black hover:shadow-[0_0_24px_rgba(16,185,129,0.3)]'
+                        : 'border border-zinc-700 text-zinc-300 hover:border-emerald-600 hover:text-emerald-300'
+                    }`}
+                  >
+                    {t('ابدأ', 'Get Started')} <ChevronRight className="h-3.5 w-3.5 rtl:rotate-180" />
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Who it's for ──────────────────────────────────────────────── */}
+        <section dir={dir} className="container mx-auto px-4 pb-12 max-w-4xl">
+          <div className="flex items-center gap-2 mb-4">
+            <Building2 className="h-4 w-4 text-zinc-600" />
+            <p className="font-mono text-[10px] text-zinc-600 uppercase tracking-widest">{t('الأنسب لـ', 'Best for')}</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {TARGETS.map((target) => (
+              <span
+                key={target[1]}
+                className="inline-flex items-center gap-1.5 font-mono text-[11px] text-zinc-400 border border-zinc-800 rounded px-2.5 py-1 bg-zinc-900/50 hover:border-zinc-700 transition-colors"
+              >
+                <CheckCircle2 className="h-3 w-3 text-emerald-500 shrink-0" />
+                {t(...target)}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Positioning / scope disclaimer (compliance honesty) ───────── */}
+        <section dir={dir} className="container mx-auto px-4 pb-16 max-w-4xl">
+          <div className="rounded-md border border-zinc-800 bg-zinc-950/60 p-5 flex items-start gap-3">
+            <AlertTriangle className="h-4 w-4 text-yellow-500 shrink-0 mt-0.5" />
+            <p className="text-xs text-zinc-500 leading-relaxed">
+              {t(
+                'هذه الخدمة جاهزية وتحصين وتوعية وتوثيق وتنسيق — وليست مركز عمليات أمنية مُدار (MSOC) أو خدمة مراقبة مرخّصة. أعمال المراقبة الأكبر تُنفّذ بالشراكة مع مزوّدين مرخّصين من الهيئة الوطنية للأمن السيبراني (NCA).',
+                'This is a readiness, hardening, awareness, documentation, and coordination service — not a licensed MSOC or monitoring provider. Larger monitoring work is delivered in partnership with NCA-licensed providers.',
+              )}
+            </p>
+          </div>
+        </section>
+
+        {/* ── Final CTA ─────────────────────────────────────────────────── */}
+        <section dir={dir} className="container mx-auto px-4 pb-20 max-w-2xl text-center">
+          <h2 className="text-3xl font-bold mb-3 tracking-tight">
+            <GlitchText text={t('ابدأ بمراجعة مجانية', 'Start With a Free Review')} />
+          </h2>
+          <p className="text-zinc-500 text-sm mb-7 max-w-md mx-auto leading-relaxed">
+            {t(
+              'مراجعة 20 دقيقة لانكشافك السيبراني والذكاء الاصطناعي. بلا إزعاج، بلا التزام — فقط صورة واضحة عن وضعك وأهم 3 إصلاحات.',
+              'A 20-min review of your Cyber & AI exposure. No spam, no obligation — just a clear picture of where you stand and your top 3 fixes.',
+            )}
+          </p>
+          <a
+            href="/services#inquiry"
+            className="inline-flex items-center justify-center gap-2 rounded bg-emerald-500 hover:bg-emerald-400 text-black font-bold px-6 py-3 text-sm transition-all duration-200 hover:shadow-[0_0_28px_rgba(16,185,129,0.35)]"
+          >
+            <Zap className="h-4 w-4" /> {t('احجز مراجعة الانكشاف المجانية', 'Book Free Exposure Review')}
+          </a>
+          <p className="font-mono text-[10px] text-zinc-700 mt-4 flex items-center justify-center gap-1.5">
+            <Clock className="h-3 w-3" /> {t('استجابة خلال 24 ساعة · عربي + إنجليزي', '24h response · Arabic + English')}
+          </p>
+        </section>
+      </main>
+
+      {/* ── Footer ──────────────────────────────────────────────────────── */}
+      <footer dir={dir} className="border-t border-zinc-900 py-6 relative z-10">
+        <div className="container mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-3">
+          <span className="font-mono text-[10px] text-zinc-700 uppercase tracking-widest">
+            GOODNBAD.EXE © {new Date().getFullYear()}
+          </span>
+          <div className="flex gap-5">
+            {[
+              { href: '/services',  label: t('الخدمات', 'Services')      },
+              { href: '/',          label: t('الأعمال', 'Portfolio')      },
+              { href: '/security',  label: t('أطلس الأمن', 'Security Atlas') },
+              { href: 'mailto:alramli.hamzah@gmail.com', label: t('البريد', 'Email') },
+            ].map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className="font-mono text-[10px] text-zinc-700 hover:text-zinc-400 uppercase tracking-widest transition-colors"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/services/layout.tsx
+++ b/app/services/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { SdrAssistant } from "@/components/sdr/sdr-assistant"
 
 export const metadata: Metadata = {
   title: "Services | Hamzah Al-Ramli",
@@ -16,5 +17,10 @@ export const metadata: Metadata = {
 }
 
 export default function ServicesLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>
+  return (
+    <>
+      {children}
+      <SdrAssistant />
+    </>
+  )
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -354,7 +354,7 @@ export default function ServicesPage() {
           <div className="container mx-auto px-4 max-w-6xl">
             <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-zinc-900">
               {[
-                { value: t('6', '6'), label: t('أنواع الخدمات', 'Service types') },
+                { value: t('7', '7'), label: t('أنواع الخدمات', 'Service types') },
                 { value: t('السعودية + الخليج', 'KSA + GCC'), label: t('التغطية', 'Coverage') },
                 { value: t('عربي / إنجليزي', 'Arabic / EN'), label: t('اللغات', 'Languages') },
                 { value: t('24 ساعة', '24 h'), label: t('زمن الاستجابة', 'Response SLA') },
@@ -367,6 +367,46 @@ export default function ServicesPage() {
             </div>
           </div>
         </div>
+
+        {/* ── Flagship: SME Cyber & AI Readiness Sprint (sub-page) ──────── */}
+        <section dir={dir} className="container mx-auto px-4 pt-16 max-w-6xl">
+          <Link
+            href="/services/cyber-sprint"
+            className="group relative block rounded-md border border-emerald-500/40 bg-emerald-950/10 overflow-hidden transition-all duration-300 hover:-translate-y-0.5 hover:border-emerald-500/70 hover:shadow-[0_16px_48px_rgba(0,0,0,0.5),0_0_0_1px_rgba(16,185,129,0.3)]"
+          >
+            <span className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-emerald-400 to-transparent opacity-60 group-hover:opacity-100 transition-opacity" />
+            <div className="p-6 md:p-7 flex flex-col md:flex-row md:items-center gap-5">
+              <div className="flex-1">
+                <div className="flex flex-wrap items-center gap-2 mb-3">
+                  <span className="font-mono text-[9px] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 rounded px-2 py-0.5 uppercase tracking-widest">
+                    {t('حزمة 14 يوماً · الأبرز', '14-Day Package · Flagship')}
+                  </span>
+                  <span className="font-mono text-[9px] border border-zinc-700 text-zinc-400 rounded px-2 py-0.5 uppercase tracking-widest">
+                    {t('للشركات الصغيرة والمتوسطة', 'For SMEs')}
+                  </span>
+                </div>
+                <h3 className="text-lg md:text-xl font-bold text-zinc-100 mb-1.5 leading-snug">
+                  {t('جاهزية الأمن السيبراني والذكاء الاصطناعي للشركات', 'SME Cyber & AI Readiness Sprint')}
+                </h3>
+                <p className="text-zinc-500 text-xs md:text-sm leading-relaxed max-w-2xl">
+                  {t(
+                    'فحص Microsoft 365، جاهزية PDPL، سياسة استخدام الذكاء الاصطناعي، لقطة عن الثغرات، وجلسة توعية — تقرير تنفيذي خلال 14 يوماً.',
+                    'Microsoft 365 check, PDPL readiness, AI usage policy, vulnerability snapshot, and an awareness session — executive report in 14 days.',
+                  )}
+                </p>
+              </div>
+              <div className="flex items-center gap-4 md:flex-col md:items-end md:text-right shrink-0">
+                <div>
+                  <div className="font-mono text-[9px] text-zinc-600 uppercase tracking-widest">{t('يبدأ من', 'From')}</div>
+                  <div className="text-xl font-bold text-emerald-300">{t('4,500 ر.س', 'SAR 4,500')}</div>
+                </div>
+                <span className="inline-flex items-center gap-1.5 rounded bg-emerald-500 group-hover:bg-emerald-400 text-black font-bold px-4 py-2.5 text-sm transition-all duration-200">
+                  {t('عرض الحزمة', 'View Package')} <ChevronRight className="h-4 w-4 rtl:rotate-180" />
+                </span>
+              </div>
+            </div>
+          </Link>
+        </section>
 
         {/* ── Services Grid ─────────────────────────────────────────────── */}
         <section dir={dir} className="container mx-auto px-4 py-16 max-w-6xl">
@@ -586,6 +626,7 @@ export default function ServicesPage() {
                       required
                     >
                       <option value="">{t('اختر خدمة...', 'Select a service...')}</option>
+                      <option value="SME Cyber & AI Readiness Sprint (14-Day)">{t('سبرنت جاهزية الأمن والذكاء الاصطناعي (14 يوماً)', 'SME Cyber & AI Readiness Sprint (14-Day)')}</option>
                       <option value="Penetration Testing">{t('اختبار الاختراق', 'Penetration Testing')}</option>
                       <option value="Security Audit (NCA/SAMA/ISO)">{t('تدقيق أمني (NCA/SAMA/ISO)', 'Security Audit (NCA/SAMA/ISO)')}</option>
                       <option value="Microsoft Security Setup (Azure/M365)">{t('إعداد أمن Microsoft (Azure/M365)', 'Microsoft Security Setup (Azure/M365)')}</option>

--- a/components/sdr/sdr-assistant.tsx
+++ b/components/sdr/sdr-assistant.tsx
@@ -1,0 +1,452 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
+import { Terminal, X, Send, CalendarCheck, Loader2, ArrowRight } from 'lucide-react'
+import { toast } from 'sonner'
+import { useLanguage } from '@/components/language-provider'
+import { cn } from '@/lib/utils'
+
+/**
+ * Floating bilingual AI SDR chat widget.
+ *
+ * Mounted on the /services routes. Chats against POST /api/sdr and can open an
+ * inline booking form that reuses POST /api/book-meeting. All copy is bilingual
+ * via the language provider's t(ar, en) helper and the layout follows `dir`.
+ */
+
+const SPRINT_SERVICE = 'SME Cyber & AI Readiness Sprint (14-Day)'
+const BOOKING_DURATION_MINS = 20
+const TIME_SLOTS = ['09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00', '17:00'] as const
+
+type ChatRole = 'user' | 'assistant'
+interface ChatMessage {
+  role: ChatRole
+  content: string
+}
+
+/** Tomorrow (AST) as a yyyy-mm-dd string — the earliest bookable date. */
+function minBookingDate(): string {
+  const d = new Date()
+  d.setDate(d.getDate() + 1)
+  return d.toISOString().slice(0, 10)
+}
+
+export function SdrAssistant() {
+  const { t, lang, dir } = useLanguage()
+  const isRtl = dir === 'rtl'
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [showBooking, setShowBooking] = useState(false)
+  const [messages, setMessages] = useState<readonly ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [isSending, setIsSending] = useState(false)
+
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const launcherRef = useRef<HTMLButtonElement | null>(null)
+
+  const greeting = t(
+    'مرحباً 👋 أنا مساعد الأمن. اسألني عن جاهزيتك الأمنية أو احجز مراجعة مجانية لمدة 20 دقيقة.',
+    "Hi 👋 I'm the Security Assistant. Ask me about your security readiness, or book a free 20-minute review.",
+  )
+
+  // Seed the greeting the first time the panel opens.
+  useEffect(() => {
+    if (isOpen && messages.length === 0) {
+      setMessages([{ role: 'assistant', content: greeting }])
+    }
+    // greeting depends on lang; we only want to seed once on open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
+  // Focus management: move focus into the panel on open.
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus()
+    else launcherRef.current?.focus()
+  }, [isOpen])
+
+  // Keep the transcript scrolled to the latest message.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [messages, isSending])
+
+  // Close on Escape while open.
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isOpen])
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed || isSending) return
+
+      const nextHistory: ChatMessage[] = [...messages, { role: 'user', content: trimmed }]
+      // Strip the seeded greeting (assistant-first) before sending; the API
+      // requires a user-led history.
+      const apiHistory = nextHistory.filter((m, i) => !(i === 0 && m.role === 'assistant'))
+
+      setMessages(nextHistory)
+      setInput('')
+      setIsSending(true)
+
+      try {
+        const res = await fetch('/api/sdr', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: apiHistory.slice(-20), lang }),
+        })
+        const data: { ok?: boolean; reply?: string; error?: string } = await res.json()
+        if (!res.ok || !data.ok || !data.reply) {
+          throw new Error(data.error ?? 'Request failed')
+        }
+        setMessages((prev) => [...prev, { role: 'assistant', content: data.reply! }])
+      } catch {
+        toast.error(t('تعذّر الوصول إلى المساعد. حاول مرة أخرى.', 'Could not reach the assistant. Please try again.'))
+      } finally {
+        setIsSending(false)
+        inputRef.current?.focus()
+      }
+    },
+    [isSending, messages, lang, t],
+  )
+
+  const onSubmit = useCallback(
+    (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      void sendMessage(input)
+    },
+    [input, sendMessage],
+  )
+
+  const launcherSide = isRtl ? 'left-5' : 'right-5'
+
+  return (
+    <>
+      {/* Launcher */}
+      {!isOpen && (
+        <button
+          ref={launcherRef}
+          type="button"
+          onClick={() => setIsOpen(true)}
+          dir={dir}
+          aria-label={t('افتح مساعد الأمن', 'Open the Security Assistant')}
+          className={cn(
+            'fixed bottom-5 z-50 flex items-center gap-2 rounded-full border border-emerald-500/40 bg-[#09090b]/90 px-4 py-3',
+            'font-mono text-sm text-emerald-300 shadow-[0_0_25px_-4px_rgba(52,211,153,0.6)] backdrop-blur',
+            'transition-all hover:border-emerald-400 hover:text-emerald-200 hover:shadow-[0_0_35px_-2px_rgba(52,211,153,0.75)]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#09090b]',
+            launcherSide,
+          )}
+        >
+          <Terminal className="h-4 w-4" aria-hidden />
+          <span className="hidden sm:inline">{t('مساعد الأمن', 'Security Assistant')}</span>
+          <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" aria-hidden />
+        </button>
+      )}
+
+      {/* Chat panel */}
+      {isOpen && (
+        <div
+          ref={panelRef}
+          dir={dir}
+          role="dialog"
+          aria-modal="false"
+          aria-label={t('مساعد الأمن', 'Security Assistant')}
+          className={cn(
+            'fixed bottom-0 z-50 flex flex-col border border-zinc-800 bg-[#09090b] font-mono text-zinc-200 shadow-2xl',
+            'inset-x-0 h-[85vh] rounded-t-xl',
+            'sm:inset-x-auto sm:bottom-5 sm:h-[560px] sm:w-[360px] sm:rounded-xl',
+            isRtl ? 'sm:left-5' : 'sm:right-5',
+          )}
+        >
+          {/* Header */}
+          <header className="flex items-center justify-between gap-2 border-b border-zinc-800 bg-zinc-950/60 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" aria-hidden />
+              <span className="text-xs uppercase tracking-widest text-emerald-400">
+                {t('مساعد الأمن', 'Security Assistant')}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => setShowBooking((v) => !v)}
+                aria-pressed={showBooking}
+                className="flex items-center gap-1.5 rounded-md border border-emerald-500/30 px-2 py-1 text-[11px] text-emerald-300 transition-colors hover:border-emerald-400 hover:text-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              >
+                <CalendarCheck className="h-3.5 w-3.5" aria-hidden />
+                {t('مراجعة مجانية', 'Free review')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                aria-label={t('إغلاق', 'Close')}
+                className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              >
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+          </header>
+
+          {showBooking && <BookingForm onDone={() => setShowBooking(false)} />}
+
+          {/* Transcript */}
+          <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-4" aria-live="polite">
+            {messages.map((m, i) => (
+              <div key={i} className={cn('flex', m.role === 'user' ? 'justify-end' : 'justify-start')}>
+                <div
+                  className={cn(
+                    'max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm leading-relaxed',
+                    m.role === 'user'
+                      ? 'bg-emerald-500/15 text-emerald-100 ring-1 ring-emerald-500/30'
+                      : 'bg-zinc-900 text-zinc-200 ring-1 ring-zinc-800',
+                  )}
+                >
+                  {m.content}
+                </div>
+              </div>
+            ))}
+            {isSending && (
+              <div className="flex justify-start">
+                <div className="flex items-center gap-2 rounded-lg bg-zinc-900 px-3 py-2 text-sm text-zinc-400 ring-1 ring-zinc-800">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                  {t('يكتب…', 'Typing…')}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Composer */}
+          <form onSubmit={onSubmit} className="flex items-center gap-2 border-t border-zinc-800 px-3 py-3">
+            <label htmlFor="sdr-input" className="sr-only">
+              {t('اكتب رسالتك', 'Type your message')}
+            </label>
+            <input
+              id="sdr-input"
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              disabled={isSending}
+              placeholder={t('اكتب رسالتك…', 'Type your message…')}
+              className="min-w-0 flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/60 focus:outline-none focus:ring-1 focus:ring-emerald-500/40 disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={isSending || !input.trim()}
+              aria-label={t('إرسال', 'Send')}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/30 transition-colors hover:bg-emerald-500/25 hover:text-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 disabled:opacity-40"
+            >
+              <Send className="h-4 w-4" aria-hidden />
+            </button>
+          </form>
+        </div>
+      )}
+    </>
+  )
+}
+
+// ── Inline booking form ───────────────────────────────────────────────────────
+
+interface BookingFormProps {
+  onDone: () => void
+}
+
+function BookingForm({ onDone }: BookingFormProps) {
+  const { t } = useLanguage()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState<string>(TIME_SLOTS[0])
+  const [isBooking, setIsBooking] = useState(false)
+  const [meetLink, setMeetLink] = useState<string | null>(null)
+
+  const minDate = minBookingDate()
+
+  const onSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      if (isBooking) return
+      if (!name.trim() || !email.trim() || !date) {
+        toast.error(t('يرجى تعبئة الاسم والبريد والتاريخ.', 'Please fill in name, email and date.'))
+        return
+      }
+
+      setIsBooking(true)
+      const startISO = `${date}T${time}:00+03:00`
+      try {
+        const res = await fetch('/api/book-meeting', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: name.trim(),
+            email: email.trim(),
+            company: company.trim(),
+            service: SPRINT_SERVICE,
+            message: t(
+              'حجز عبر مساعد الأمن — مراجعة مجانية 20 دقيقة.',
+              'Booked via the Security Assistant — free 20-minute review.',
+            ),
+            startISO,
+            durationMins: BOOKING_DURATION_MINS,
+          }),
+        })
+        const data: { ok?: boolean; meetLink?: string; error?: string } = await res.json()
+        if (!res.ok || !data.ok) {
+          throw new Error(data.error ?? 'Booking failed')
+        }
+        setMeetLink(data.meetLink ?? null)
+        toast.success(t('تم الحجز بنجاح ✅', 'Booked successfully ✅'))
+      } catch (err) {
+        toast.error(
+          err instanceof Error && err.message
+            ? err.message
+            : t('فشل الحجز. حاول مرة أخرى.', 'Booking failed. Please try again.'),
+        )
+      } finally {
+        setIsBooking(false)
+      }
+    },
+    [isBooking, name, email, company, date, time, t],
+  )
+
+  if (meetLink !== null) {
+    return (
+      <div className="border-b border-zinc-800 bg-emerald-500/5 px-4 py-4 text-sm">
+        <p className="mb-2 font-semibold text-emerald-300">{t('تم تأكيد موعدك', 'Your review is confirmed')}</p>
+        <p className="mb-3 text-zinc-400">
+          {t('سيصلك تأكيد على بريدك. رابط الاجتماع:', "You'll get a confirmation email. Meeting link:")}
+        </p>
+        <a
+          href={meetLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 break-all text-emerald-400 underline-offset-4 hover:underline"
+        >
+          {meetLink}
+          <ArrowRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        </a>
+        <button
+          type="button"
+          onClick={onDone}
+          className="mt-3 block text-xs text-zinc-500 transition-colors hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+        >
+          {t('رجوع إلى المحادثة', 'Back to chat')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-2.5 border-b border-zinc-800 bg-zinc-950/40 px-4 py-4 text-sm">
+      <p className="text-xs uppercase tracking-widest text-emerald-400">
+        {t('احجز مراجعة مجانية (20 دقيقة)', 'Book a free review (20 min)')}
+      </p>
+
+      <FieldInput
+        id="sdr-name"
+        label={t('الاسم', 'Name')}
+        value={name}
+        onChange={setName}
+        required
+        autoComplete="name"
+      />
+      <FieldInput
+        id="sdr-email"
+        label={t('البريد الإلكتروني', 'Email')}
+        type="email"
+        value={email}
+        onChange={setEmail}
+        required
+        autoComplete="email"
+      />
+      <FieldInput
+        id="sdr-company"
+        label={t('الشركة (اختياري)', 'Company (optional)')}
+        value={company}
+        onChange={setCompany}
+        autoComplete="organization"
+      />
+
+      <div className="flex gap-2">
+        <div className="flex-1">
+          <label htmlFor="sdr-date" className="mb-1 block text-xs text-zinc-400">
+            {t('التاريخ', 'Date')}
+          </label>
+          <input
+            id="sdr-date"
+            type="date"
+            value={date}
+            min={minDate}
+            required
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-sm text-zinc-100 [color-scheme:dark] focus:border-emerald-500/60 focus:outline-none focus:ring-1 focus:ring-emerald-500/40"
+          />
+        </div>
+        <div className="flex-1">
+          <label htmlFor="sdr-time" className="mb-1 block text-xs text-zinc-400">
+            {t('الوقت (بتوقيت السعودية)', 'Time (AST)')}
+          </label>
+          <select
+            id="sdr-time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+            className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-sm text-zinc-100 focus:border-emerald-500/60 focus:outline-none focus:ring-1 focus:ring-emerald-500/40"
+          >
+            {TIME_SLOTS.map((slot) => (
+              <option key={slot} value={slot}>
+                {slot}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isBooking}
+        className="mt-1 flex w-full items-center justify-center gap-2 rounded-md bg-emerald-500/15 px-3 py-2 text-sm font-medium text-emerald-200 ring-1 ring-emerald-500/40 transition-colors hover:bg-emerald-500/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 disabled:opacity-50"
+      >
+        {isBooking ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <CalendarCheck className="h-4 w-4" aria-hidden />}
+        {t('تأكيد الحجز', 'Confirm booking')}
+      </button>
+    </form>
+  )
+}
+
+// ── Small labelled text input ────────────────────────────────────────────────
+
+interface FieldInputProps {
+  id: string
+  label: string
+  value: string
+  onChange: (v: string) => void
+  type?: string
+  required?: boolean
+  autoComplete?: string
+}
+
+function FieldInput({ id, label, value, onChange, type = 'text', required, autoComplete }: FieldInputProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="mb-1 block text-xs text-zinc-400">
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        required={required}
+        autoComplete={autoComplete}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/60 focus:outline-none focus:ring-1 focus:ring-emerald-500/40"
+      />
+    </div>
+  )
+}

--- a/content/sdr/knowledge.ts
+++ b/content/sdr/knowledge.ts
@@ -1,0 +1,308 @@
+/**
+ * content/sdr/knowledge.ts
+ *
+ * Brain (system prompt + knowledge base) for the Goodnbad.exe AI SDR /
+ * qualification assistant.
+ *
+ * Product sold: "14-Day SME Cyber & AI Readiness Sprint" by Goodnbad.exe
+ * (Hamzah Al-Ramli, certified cybersecurity professional, Riyadh, KSA).
+ *
+ * This module is consumed by the chat runtime. The export names below are an
+ * API contract — do not rename them.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Types                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export interface SdrFaq {
+  q: string;
+  a: string;
+}
+
+export interface SdrObjection {
+  objection: string;
+  response: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* System prompt — English                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const SDR_SYSTEM_PROMPT_EN = `You are the AI assistant for Goodnbad.exe, a Saudi cybersecurity consultancy founded by Hamzah Al-Ramli, a certified cybersecurity professional based in Riyadh, KSA. You act as a friendly, sharp Sales Development Representative (SDR). You are bilingual (Arabic and English) and always reply in the user's language.
+
+## Your one job
+Qualify the small/medium business you are talking to and book them into a FREE 20-minute "Cyber & AI Exposure Review". You are helpful first and a closer second — never pushy.
+
+## What Goodnbad.exe sells: the 14-Day SME Cyber & AI Readiness Sprint
+A fast, fixed-scope engagement that gets an SME from "we're not sure how exposed we are" to "we have a clear risk picture and a 30-day action plan". Six deliverables:
+1. Microsoft 365 security check — MFA, admin roles, sharing links, mailbox risks, OneDrive/SharePoint exposure.
+2. PDPL basic readiness — privacy notice, data-collection map, consent gaps, WhatsApp Business / business-phone handling.
+3. AI usage policy — clear rules for what staff can and cannot upload to ChatGPT, Gemini, and Copilot.
+4. Vulnerability snapshot — a safe external scan, an asset list, and a weak-points report.
+5. Staff awareness session — a live 60–90 minute session in Arabic or English.
+6. Final report — an executive risk score plus a prioritized 30-day action plan.
+
+## Pricing (quote plainly, in SAR, never invent discounts)
+- Basic Readiness Sprint: SAR 4,500 (one-time).
+- Full Cyber + AI Sprint: SAR 8,500 (one-time, all 6 deliverables).
+- Monthly Retainer: SAR 1,500–4,000 / month (ongoing support after the sprint).
+Recommend Basic vs Full from their needs: Basic suits a very small team that mainly wants an M365 + PDPL + AI-policy baseline; Full suits anyone who also wants the vulnerability snapshot, the live staff session, and the full executive report — or who is facing an audit, a client security questionnaire, or real breach/AI-misuse worry.
+
+## Who you help
+Real estate offices, clinics, small contractors, retail brands, marketing agencies, and schools/training centers — typically companies already using Microsoft 365, WhatsApp Business, Zoho, or Dynamics.
+
+## How to qualify (gather this naturally over the conversation — never interrogate)
+- Company type and rough size (how many staff).
+- What tools they run (Microsoft 365? WhatsApp Business? Zoho/Dynamics?).
+- Their main worry (compliance/PDPL, fear of a breach, AI misuse by staff, an upcoming audit or client security request).
+- Any deadline driving it (audit date, a deal, a regulator request).
+- Whether they have any in-house IT or security person.
+Weave one or two questions into each reply; let the answers shape your recommendation.
+
+## Why now (cite sparingly — at most one fact per reply, only when it adds weight)
+- Saudi cybersecurity spend reached SAR 15.2B (+14%), with the private sector at 68%.
+- SDAIA issued 48 PDPL violation decisions in a single year.
+- 2026 is Saudi Arabia's official Year of AI.
+
+## Booking
+When the user shows intent, steer gently to the free review. Tell them to click the "Book free review" button in this chat (the interface handles the actual scheduling), OR to drop their name + email + a preferred date/time and the team will confirm. Don't ask for payment in chat; the sprint starts after the free review.
+
+## Hard guardrails (never break these)
+- You are NOT a licensed MSOC/SOC and you NEVER claim to be one. Goodnbad.exe does readiness, hardening, awareness, documentation, and coordination — not 24/7 monitoring or managed detection. For full monitoring, you partner with NCA-licensed providers; say so plainly if asked.
+- Never guarantee compliance, never promise "you will pass PDPL/the audit", never give legal advice — you help them get ready and document, not certify.
+- Never invent certifications, client names, case studies, statistics, or features beyond what is listed here.
+- No fear-mongering and no overpromising. Be honest, calm, and specific.
+- Keep replies short: 2–5 sentences. Use a professional, Saudi-appropriate, respectful business tone. Mirror the user's formality.
+- If you don't know something or it's outside scope, say so and offer the free review as the next step.`;
+
+/* -------------------------------------------------------------------------- */
+/* System prompt — Arabic (Modern Standard, Saudi business tone)              */
+/* -------------------------------------------------------------------------- */
+
+export const SDR_SYSTEM_PROMPT_AR = `أنت المساعد الذكي لشركة Goodnbad.exe، وهي استشارات أمن سيبراني سعودية أسسها حمزة الرملي، متخصص أمن سيبراني معتمد ومقره الرياض بالمملكة العربية السعودية. تعمل كممثل تطوير مبيعات (SDR) ودود وذكي. أنت ثنائي اللغة (العربية والإنجليزية) وترد دائماً بلغة المستخدم.
+
+## مهمتك الوحيدة
+تأهيل المنشأة الصغيرة أو المتوسطة التي تتحدث معها، وحجز "مراجعة التعرّض السيبراني والذكاء الاصطناعي" المجانية ومدتها 20 دقيقة. كن مفيداً أولاً ومُغلِقاً للصفقة ثانياً — ولا تكن ملحاحاً أبداً.
+
+## ما تبيعه Goodnbad.exe: سبرنت جاهزية الأمن السيبراني والذكاء الاصطناعي للمنشآت في 14 يوماً
+خدمة سريعة ومحدّدة النطاق تنقل المنشأة من "لسنا متأكدين من حجم تعرّضنا" إلى "لدينا صورة واضحة للمخاطر وخطة عمل لـ30 يوماً". ستة مخرجات:
+1. فحص أمان Microsoft 365 — المصادقة الثنائية MFA، أدوار المسؤولين، روابط المشاركة، مخاطر البريد، انكشاف OneDrive/SharePoint.
+2. الجاهزية الأساسية لنظام PDPL — إشعار الخصوصية، خريطة جمع البيانات، فجوات الموافقة، التعامل مع WhatsApp Business وأرقام العمل.
+3. سياسة استخدام الذكاء الاصطناعي — قواعد واضحة لما يمكن وما لا يمكن للموظفين رفعه إلى ChatGPT وGemini وCopilot.
+4. لقطة الثغرات — فحص خارجي آمن، وقائمة بالأصول، وتقرير بنقاط الضعف.
+5. جلسة توعية للموظفين — جلسة مباشرة مدتها 60–90 دقيقة بالعربية أو الإنجليزية.
+6. التقرير النهائي — درجة مخاطر تنفيذية مع خطة عمل مرتّبة الأولويات لـ30 يوماً.
+
+## الأسعار (اذكرها بوضوح بالريال السعودي، ولا تختلق أي خصومات)
+- سبرنت الجاهزية الأساسي: 4,500 ريال (دفعة واحدة).
+- سبرنت الأمن السيبراني + الذكاء الاصطناعي الكامل: 8,500 ريال (دفعة واحدة، يشمل المخرجات الستة).
+- اشتراك شهري: 1,500–4,000 ريال شهرياً (دعم مستمر بعد السبرنت).
+اقترح الأساسي أو الكامل حسب احتياجهم: الأساسي يناسب فريقاً صغيراً جداً يريد خط أساس لـMicrosoft 365 وPDPL وسياسة الذكاء الاصطناعي؛ والكامل يناسب من يريد أيضاً لقطة الثغرات وجلسة الموظفين المباشرة والتقرير التنفيذي الكامل — أو من يواجه تدقيقاً أو استبيان أمان من عميل أو قلقاً حقيقياً من اختراق أو سوء استخدام للذكاء الاصطناعي.
+
+## من تخدمهم
+مكاتب العقار، العيادات، المقاولون الصغار، العلامات التجارية للتجزئة، وكالات التسويق، والمدارس/مراكز التدريب — غالباً منشآت تستخدم بالفعل Microsoft 365 أو WhatsApp Business أو Zoho أو Dynamics.
+
+## كيف تؤهّل العميل (اجمع هذه المعلومات بشكل طبيعي خلال الحوار — دون استجواب)
+- نوع المنشأة وحجمها التقريبي (عدد الموظفين).
+- الأدوات التي يستخدمونها (Microsoft 365؟ WhatsApp Business؟ Zoho/Dynamics؟).
+- همّهم الأساسي (الامتثال/PDPL، الخوف من اختراق، سوء استخدام الموظفين للذكاء الاصطناعي، تدقيق قادم أو طلب أمان من عميل).
+- أي موعد نهائي يدفعهم (موعد تدقيق، صفقة، طلب من جهة تنظيمية).
+- هل لديهم موظف داخلي لتقنية المعلومات أو الأمن.
+أدرج سؤالاً أو سؤالين في كل رد، ودع الإجابات تشكّل توصيتك.
+
+## لماذا الآن (استشهد باعتدال — حقيقة واحدة كحد أقصى في الرد، فقط حين تضيف وزناً)
+- بلغ الإنفاق السعودي على الأمن السيبراني 15.2 مليار ريال (+14%)، وحصة القطاع الخاص 68%.
+- أصدرت سدايا (SDAIA) 48 قراراً بمخالفات نظام PDPL خلال عام واحد.
+- عام 2026 هو عام الذكاء الاصطناعي الرسمي في المملكة.
+
+## الحجز
+عندما يُظهر المستخدم اهتماماً، وجّهه بلطف نحو المراجعة المجانية. اطلب منه الضغط على زر "احجز مراجعة مجانية" في هذه المحادثة (الواجهة تتولى جدولة الموعد فعلياً)، أو ترك الاسم + البريد الإلكتروني + الوقت والتاريخ المفضّل ليتولى الفريق التأكيد. لا تطلب الدفع في المحادثة؛ يبدأ السبرنت بعد المراجعة المجانية.
+
+## ضوابط صارمة (لا تكسرها أبداً)
+- لست مركز عمليات أمن مرخّصاً (MSOC/SOC) ولا تدّعي ذلك أبداً. Goodnbad.exe تقدّم الجاهزية والتحصين والتوعية والتوثيق والتنسيق — وليس المراقبة على مدار الساعة أو الكشف المُدار. للمراقبة الكاملة، نتشارك مع مزوّدين مرخّصين من الهيئة الوطنية للأمن السيبراني (NCA)؛ قُل ذلك بوضوح إذا سُئلت.
+- لا تضمن الامتثال أبداً، ولا تَعِد بـ"ستجتاز PDPL/التدقيق"، ولا تقدّم استشارة قانونية — أنت تساعدهم على الاستعداد والتوثيق، لا على الاعتماد.
+- لا تختلق شهادات أو أسماء عملاء أو دراسات حالة أو إحصاءات أو ميزات تتجاوز المذكور هنا.
+- لا تخويف ولا مبالغة في الوعود. كن صادقاً وهادئاً ودقيقاً.
+- اجعل ردودك قصيرة: من جملتين إلى خمس جمل. استخدم لهجة عمل مهنية محترمة تناسب السوق السعودي، وجارِ مستوى رسمية المستخدم.
+- إن لم تعرف شيئاً أو كان خارج النطاق، قُل ذلك واعرض المراجعة المجانية كخطوة تالية.
+
+ملاحظة: أبقِ المصطلحات التقنية بالإنجليزية كما هي: PDPL وNCA وM365 وMFA وMicrosoft 365.`;
+
+/* -------------------------------------------------------------------------- */
+/* FAQs — English                                                             */
+/* -------------------------------------------------------------------------- */
+
+export const SDR_FAQS_EN: SdrFaq[] = [
+  {
+    q: "What exactly do I get from the 14-Day Sprint?",
+    a: "Six deliverables: a Microsoft 365 security check, a PDPL basic-readiness review, a staff AI usage policy, a safe vulnerability snapshot, a live 60–90 minute awareness session, and a final report with an executive risk score and a 30-day action plan. It's fixed-scope and finished in about two weeks.",
+  },
+  {
+    q: "How much does it cost?",
+    a: "The Basic Readiness Sprint is SAR 4,500 one-time; the Full Cyber + AI Sprint (all six deliverables) is SAR 8,500 one-time. If you want ongoing support afterward, the monthly retainer runs SAR 1,500–4,000/month. The 20-minute Exposure Review is free.",
+  },
+  {
+    q: "What is the free Exposure Review?",
+    a: "It's a 20-minute call where we look at your setup at a high level, flag the most likely exposure points, and tell you honestly whether the Basic or Full sprint fits — or whether you need something else. No cost and no obligation.",
+  },
+  {
+    q: "Do you actually fix things, or just hand me a report?",
+    a: "Both. We assess and document, but we also harden your Microsoft 365 settings, help draft your privacy notice and AI policy, and run the staff session. The 30-day action plan is prioritized so you know exactly what to do next.",
+  },
+  {
+    q: "Is this only a vulnerability scan?",
+    a: "No. The vulnerability snapshot is just one of six parts. The bigger value is the M365 hardening, the PDPL readiness work, the staff AI policy, and the live awareness session — areas a scan alone never touches.",
+  },
+  {
+    q: "We use WhatsApp Business and Microsoft 365 — is that covered?",
+    a: "Yes. We review how customer data flows through WhatsApp Business and business phones for PDPL, and the M365 check covers MFA, admin roles, sharing links, mailbox risks, and OneDrive/SharePoint exposure. Those two are central to the sprint.",
+  },
+  {
+    q: "Do you provide 24/7 monitoring or a security operations center?",
+    a: "No — and we're upfront about that. Goodnbad.exe focuses on readiness, hardening, awareness, and documentation. For full monitoring or a managed SOC, we coordinate you with NCA-licensed providers.",
+  },
+  {
+    q: "Will this make us PDPL compliant?",
+    a: "It gets you ready and documented — a privacy notice, a data-collection map, and clear consent and AI-usage gaps to close. We don't certify or legally guarantee compliance, but you'll know exactly where you stand and what to fix.",
+  },
+  {
+    q: "We're a small team with no IT person — is this for us?",
+    a: "Especially for you. Most of our clients are SMEs without dedicated IT — real estate offices, clinics, agencies, schools. We handle the technical side and explain everything in plain language.",
+  },
+  {
+    q: "How do we start?",
+    a: "Book the free 20-minute Exposure Review using the \"Book free review\" button here, or share your name, email, and a preferred time and we'll confirm. The sprint starts after that call.",
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/* FAQs — Arabic                                                              */
+/* -------------------------------------------------------------------------- */
+
+export const SDR_FAQS_AR: SdrFaq[] = [
+  {
+    q: "ماذا أحصل بالضبط من سبرنت الـ14 يوماً؟",
+    a: "ستة مخرجات: فحص أمان Microsoft 365، ومراجعة الجاهزية الأساسية لنظام PDPL، وسياسة استخدام الذكاء الاصطناعي للموظفين، ولقطة ثغرات آمنة، وجلسة توعية مباشرة من 60–90 دقيقة، وتقرير نهائي بدرجة مخاطر تنفيذية وخطة عمل لـ30 يوماً. النطاق محدّد ويكتمل خلال أسبوعين تقريباً.",
+  },
+  {
+    q: "كم التكلفة؟",
+    a: "سبرنت الجاهزية الأساسي 4,500 ريال دفعة واحدة؛ والسبرنت الكامل (المخرجات الستة) 8,500 ريال دفعة واحدة. وإذا رغبت بدعم مستمر بعدها، فالاشتراك الشهري من 1,500 إلى 4,000 ريال شهرياً. ومراجعة التعرّض لمدة 20 دقيقة مجانية.",
+  },
+  {
+    q: "ما هي مراجعة التعرّض المجانية؟",
+    a: "مكالمة مدتها 20 دقيقة ننظر فيها إلى إعداداتكم بشكل عام، ونحدّد أبرز نقاط التعرّض المحتملة، ونخبركم بصدق هل يناسبكم السبرنت الأساسي أم الكامل — أو إن كنتم تحتاجون شيئاً آخر. بلا تكلفة وبلا التزام.",
+  },
+  {
+    q: "هل تصلحون الأمور فعلاً أم تسلّموني تقريراً فقط؟",
+    a: "الاثنان معاً. نقيّم ونوثّق، لكننا أيضاً نحصّن إعدادات Microsoft 365، ونساعد في صياغة إشعار الخصوصية وسياسة الذكاء الاصطناعي، وننفّذ جلسة الموظفين. وخطة الـ30 يوماً مرتّبة بالأولوية لتعرفوا تماماً الخطوة التالية.",
+  },
+  {
+    q: "هل هذا مجرد فحص ثغرات؟",
+    a: "لا. لقطة الثغرات جزء واحد من ستة. القيمة الأكبر في تحصين M365، وأعمال الجاهزية لـPDPL، وسياسة الذكاء الاصطناعي للموظفين، وجلسة التوعية المباشرة — وهي مجالات لا يلمسها الفحص وحده.",
+  },
+  {
+    q: "نستخدم WhatsApp Business وMicrosoft 365 — هل هذا مشمول؟",
+    a: "نعم. نراجع كيف تتدفق بيانات العملاء عبر WhatsApp Business وأرقام العمل من ناحية PDPL، وفحص M365 يغطي MFA وأدوار المسؤولين وروابط المشاركة ومخاطر البريد وانكشاف OneDrive/SharePoint. وهما محوريان في السبرنت.",
+  },
+  {
+    q: "هل تقدّمون مراقبة على مدار الساعة أو مركز عمليات أمن؟",
+    a: "لا — ونقولها بوضوح. تركّز Goodnbad.exe على الجاهزية والتحصين والتوعية والتوثيق. وللمراقبة الكاملة أو مركز عمليات مُدار، ننسّق لكم مع مزوّدين مرخّصين من الهيئة الوطنية للأمن السيبراني (NCA).",
+  },
+  {
+    q: "هل سيجعلنا هذا ممتثلين لنظام PDPL؟",
+    a: "يجعلكم جاهزين وموثَّقين — إشعار خصوصية، وخريطة جمع بيانات، وفجوات واضحة في الموافقة واستخدام الذكاء الاصطناعي لإغلاقها. لا نمنح اعتماداً ولا ضماناً قانونياً للامتثال، لكنكم ستعرفون موقعكم بدقة وما يجب إصلاحه.",
+  },
+  {
+    q: "نحن فريق صغير بلا موظف تقنية معلومات — هل هذا يناسبنا؟",
+    a: "يناسبكم خصوصاً. أغلب عملائنا منشآت صغيرة ومتوسطة بلا قسم تقنية مخصّص — مكاتب عقار، عيادات، وكالات، مدارس. نتولّى الجانب التقني ونشرح كل شيء بلغة بسيطة.",
+  },
+  {
+    q: "كيف نبدأ؟",
+    a: "احجزوا مراجعة التعرّض المجانية لمدة 20 دقيقة عبر زر \"احجز مراجعة مجانية\" هنا، أو شاركوا الاسم والبريد الإلكتروني والوقت المفضّل وسنؤكّد لكم. ويبدأ السبرنت بعد تلك المكالمة.",
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/* Objections — English                                                       */
+/* -------------------------------------------------------------------------- */
+
+export const SDR_OBJECTIONS_EN: SdrObjection[] = [
+  {
+    objection: "It's too expensive for a business our size.",
+    response:
+      "Fair concern — that's why the Basic Sprint is SAR 4,500 one-time and the Exposure Review is free. One mishandled mailbox or a PDPL gap usually costs far more than that. The free review will tell you which tier actually fits, with no pressure.",
+  },
+  {
+    objection: "We already have IT / an IT guy who handles this.",
+    response:
+      "Great — we work alongside them, not around them. General IT keeps things running; this is a focused security, PDPL, and AI-readiness check that most IT support doesn't cover. Many in-house teams welcome a second, specialist set of eyes.",
+  },
+  {
+    objection: "Isn't this just an automated scan I could run myself?",
+    response:
+      "The scan is one part of six. The real work is hardening your Microsoft 365 settings, your PDPL documentation, a staff AI usage policy, and a live awareness session — plus an executive report a tool won't produce. It's judgment, not just a checklist.",
+  },
+  {
+    objection: "Do we really need PDPL — it doesn't apply to us.",
+    response:
+      "If you collect customer names, numbers, or files — through WhatsApp Business, M365, or a CRM — PDPL applies. SDAIA issued 48 violation decisions in one year, so it's worth knowing your gaps. The review shows you where you stand in 20 minutes.",
+  },
+  {
+    objection: "We don't have time for this right now.",
+    response:
+      "Understood — that's why it's a fixed 14 days with very little load on your side, and the first step is just a 20-minute call. We do the heavy lifting; you mostly review and approve. When would a short slot suit you?",
+  },
+  {
+    objection: "Is our data safe if we let you scan us?",
+    response:
+      "Yes. The vulnerability snapshot is a safe external scan — no intrusive testing and nothing that disrupts your systems. We handle anything we see confidentially, and you control scope before we start.",
+  },
+  {
+    objection: "Are you licensed / official enough to do this?",
+    response:
+      "Goodnbad.exe is led by a certified cybersecurity professional, and we're upfront about scope: we do readiness, hardening, awareness, and documentation — not licensed 24/7 monitoring. For a managed SOC we coordinate you with NCA-licensed providers, so you always get the right party for the job.",
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/* Objections — Arabic                                                        */
+/* -------------------------------------------------------------------------- */
+
+export const SDR_OBJECTIONS_AR: SdrObjection[] = [
+  {
+    objection: "السعر مرتفع على منشأة بحجمنا.",
+    response:
+      "قلق مشروع — لذلك السبرنت الأساسي 4,500 ريال دفعة واحدة، ومراجعة التعرّض مجانية. غالباً ما يكلّف صندوق بريد واحد سيّئ الإعداد أو فجوة في PDPL أكثر من ذلك بكثير. والمراجعة المجانية ستحدّد لكم الباقة المناسبة دون أي ضغط.",
+  },
+  {
+    objection: "لدينا قسم تقنية معلومات / موظف يتولّى هذا.",
+    response:
+      "ممتاز — نعمل بجانبه لا بدلاً عنه. تقنية المعلومات العامة تُبقي العمل سائراً؛ وهذا فحص متخصّص للأمن وPDPL وجاهزية الذكاء الاصطناعي لا يغطّيه الدعم التقني المعتاد عادةً. كثير من الفرق الداخلية ترحّب بعين متخصّصة ثانية.",
+  },
+  {
+    objection: "أليس هذا مجرد فحص آلي أستطيع تشغيله بنفسي؟",
+    response:
+      "الفحص جزء واحد من ستة. العمل الحقيقي في تحصين إعدادات Microsoft 365، وتوثيق PDPL، وسياسة استخدام الذكاء الاصطناعي للموظفين، وجلسة توعية مباشرة — إضافة إلى تقرير تنفيذي لا تنتجه أداة. إنه خبرة وتقدير، لا مجرد قائمة تحقّق.",
+  },
+  {
+    objection: "هل نحتاج فعلاً إلى PDPL — لا ينطبق علينا.",
+    response:
+      "إن كنتم تجمعون أسماء العملاء أو أرقامهم أو ملفاتهم — عبر WhatsApp Business أو M365 أو نظام CRM — فإن PDPL ينطبق. أصدرت سدايا 48 قراراً بمخالفات في عام واحد، لذا يستحق الأمر معرفة فجواتكم. والمراجعة تبيّن موقعكم خلال 20 دقيقة.",
+  },
+  {
+    objection: "ليس لدينا وقت لهذا الآن.",
+    response:
+      "أتفهّم — لذلك المدة ثابتة 14 يوماً وبعبء بسيط جداً عليكم، والخطوة الأولى مجرد مكالمة 20 دقيقة. نحن نتولّى العمل الثقيل، وأنتم غالباً تراجعون وتعتمدون. متى يناسبكم موعد قصير؟",
+  },
+  {
+    objection: "هل بياناتنا آمنة إن سمحنا لكم بفحصنا؟",
+    response:
+      "نعم. لقطة الثغرات فحص خارجي آمن — بلا اختبارات تطفّلية وبلا أي تعطيل لأنظمتكم. نتعامل مع كل ما نراه بسرّية تامة، وأنتم تحدّدون النطاق قبل أن نبدأ.",
+  },
+  {
+    objection: "هل أنتم مرخّصون / رسميون بما يكفي للقيام بهذا؟",
+    response:
+      "يقود Goodnbad.exe متخصّص أمن سيبراني معتمد، ونحن صريحون بشأن النطاق: نقدّم الجاهزية والتحصين والتوعية والتوثيق — لا المراقبة المرخّصة على مدار الساعة. ولمركز عمليات مُدار، ننسّق لكم مع مزوّدين مرخّصين من الهيئة الوطنية للأمن السيبراني (NCA)، لتحصلوا دائماً على الجهة المناسبة لكل مهمة.",
+  },
+];

--- a/lib/sdr/openrouter.ts
+++ b/lib/sdr/openrouter.ts
@@ -1,0 +1,75 @@
+import "server-only"
+
+/**
+ * OpenRouter chat-completions helper for the AI SDR assistant.
+ *
+ * Server-side only. Calls OpenRouter's OpenAI-compatible endpoint with the
+ * key from the environment. No streaming — a single completion string is
+ * returned. All failure modes (missing key, non-200, malformed body) throw a
+ * clean Error so callers can degrade gracefully.
+ */
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+const DEFAULT_MODEL = "anthropic/claude-3.5-haiku"
+const TEMPERATURE = 0.4
+const MAX_TOKENS = 600
+
+export type SdrRole = "system" | "user" | "assistant"
+export type SdrMessage = { role: SdrRole; content: string }
+
+type OpenRouterChoice = { message?: { content?: string } }
+type OpenRouterResponse = { choices?: OpenRouterChoice[]; error?: { message?: string } }
+
+/**
+ * Send `messages` (including the system prompt) to OpenRouter and return the
+ * assistant's reply text.
+ *
+ * @throws Error when the API key is missing, the request fails, or the upstream
+ *   response is non-200 / empty.
+ */
+export async function sdrComplete(messages: readonly SdrMessage[]): Promise<string> {
+  const apiKey = process.env.OPENROUTER_API_KEY
+  if (!apiKey) {
+    throw new Error("OPENROUTER_API_KEY is not configured")
+  }
+
+  const model = process.env.SDR_MODEL || DEFAULT_MODEL
+
+  let response: Response
+  try {
+    response = await fetch(OPENROUTER_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature: TEMPERATURE,
+        max_tokens: MAX_TOKENS,
+      }),
+    })
+  } catch (cause) {
+    throw new Error("Failed to reach OpenRouter", { cause })
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(`OpenRouter returned ${response.status}${detail ? `: ${detail.slice(0, 300)}` : ""}`)
+  }
+
+  let data: OpenRouterResponse
+  try {
+    data = (await response.json()) as OpenRouterResponse
+  } catch (cause) {
+    throw new Error("OpenRouter returned a malformed response", { cause })
+  }
+
+  const reply = data.choices?.[0]?.message?.content?.trim()
+  if (!reply) {
+    throw new Error(data.error?.message ?? "OpenRouter returned an empty completion")
+  }
+
+  return reply
+}


### PR DESCRIPTION
Adds an AI sales/qualification assistant to the services pages.

- Floating bilingual (AR/EN) chat widget on /services and /services/cyber-sprint
- Qualifies SMEs, answers FAQs/objections, books the free 20-min Exposure Review
- Booking reuses existing /api/book-meeting (durationMins 20); no new payment plumbing
- LLM via OpenRouter (server-only helper, zod-validated API, per-IP rate limit)
- Hard guardrail: never claims to be a licensed MSOC/SOC

REQUIRES env var OPENROUTER_API_KEY in Vercel to activate chat (booking form works without it). Optional SDR_MODEL (default anthropic/claude-3.5-haiku). Production build verified locally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a bilingual (AR/EN) floating AI SDR chat widget to the `/services` routes, backed by a new `POST /api/sdr` endpoint that calls OpenRouter, plus a new `/services/cyber-sprint` product page detailing the 14-Day SME Cyber & AI Readiness Sprint.

- **New `/api/sdr` route**: validates requests with Zod, applies in-memory per-IP rate limiting, gracefully degrades when `OPENROUTER_API_KEY` is absent, and forwards the chat history to OpenRouter for a single completion.
- **`SdrAssistant` component**: floating chat panel with an inline booking form that reuses the existing `/api/book-meeting` endpoint (`durationMins: 20`); mounted via the shared `app/services/layout.tsx` so it appears on both `/services` and `/services/cyber-sprint`.
- **New `/services/cyber-sprint` page**: client component presenting deliverables, pricing tiers, and CTAs for the sprint offering.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The chat API endpoint has a rate-limiter that can be completely bypassed with a forged `x-forwarded-for` header, leaving the OpenRouter API key exposed to unlimited spend from a single attacker. Fix the IP resolution before deploying with a live key.

The core feature works correctly end-to-end — Zod validation, OpenRouter helper, graceful degradation, and booking reuse are all solid. However, the `clientIp` function trusts the leftmost `x-forwarded-for` value, which any client can forge, making the rate limiter trivially circumventable and putting the OpenRouter budget at risk. There are also minor issues: the `hits` Map never evicts stale entries, `minBookingDate` calculates tomorrow in UTC rather than AST, and `React.ReactNode` is referenced without an import in the new page.

`app/api/sdr/route.ts` — the IP-extraction logic needs to be fixed before going live with the API key set.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Rate-limit bypass (IP spoofing)** — `app/api/sdr/route.ts`: the `clientIp` function reads the leftmost value of `x-forwarded-for`, which is attacker-controlled. A client can cycle through forged IPs to exhaust the OpenRouter API key budget with no effective throttling. `x-real-ip` should be the primary source on Vercel.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/api/sdr/route.ts | New POST /api/sdr route with Zod validation and per-IP rate limiting; the rate limiter can be bypassed by spoofing `x-forwarded-for`, and the `hits` Map leaks memory over time |
| lib/sdr/openrouter.ts | Server-only OpenRouter fetch helper with clean error boundaries, env-key guard, and response validation — no issues found |
| components/sdr/sdr-assistant.tsx | Floating chat + inline booking widget; `minBookingDate` uses UTC instead of AST, which can push the minimum selectable date one day too late for users near midnight AST |
| app/services/cyber-sprint/page.tsx | New client-only product page for the Cyber Sprint service; uses `React.ReactNode` without importing React, which may cause a TS compile error depending on tsconfig settings |
| app/services/layout.tsx | Adds SdrAssistant to the services layout so it mounts on both /services and /services/cyber-sprint — clean and correct |
| app/services/page.tsx | Minor additions: stat counter bumped from 6 to 7, Cyber Sprint flagship card with link, and new service option in the inquiry form selector — all straightforward |
| content/sdr/knowledge.ts | Bilingual system prompts, FAQs, and objection scripts; guardrails (no SOC claims, no compliance guarantees) are clearly stated and consistent between AR and EN versions |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser (SdrAssistant)
    participant API as POST /api/sdr
    participant RL as In-memory RateLimiter
    participant OR as OpenRouter API
    participant BM as POST /api/book-meeting

    Browser->>API: "{ messages[], lang }"
    API->>RL: isRateLimited(clientIp)
    alt rate limited
        RL-->>API: true
        API-->>Browser: 429 Too Many Requests
    else within limit
        RL-->>API: false
        alt OPENROUTER_API_KEY missing
            API-->>Browser: "200 { ok: true, reply: fallback text }"
        else key present
            API->>OR: POST /chat/completions
            OR-->>API: "{ choices[0].message.content }"
            API-->>Browser: "200 { ok: true, reply }"
        end
    end
    Note over Browser: User clicks Book free review
    Browser->>BM: "{ name, email, startISO+03:00, durationMins: 20 }"
    BM-->>Browser: "{ ok: true, meetLink }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser (SdrAssistant)
    participant API as POST /api/sdr
    participant RL as In-memory RateLimiter
    participant OR as OpenRouter API
    participant BM as POST /api/book-meeting

    Browser->>API: "{ messages[], lang }"
    API->>RL: isRateLimited(clientIp)
    alt rate limited
        RL-->>API: true
        API-->>Browser: 429 Too Many Requests
    else within limit
        RL-->>API: false
        alt OPENROUTER_API_KEY missing
            API-->>Browser: "200 { ok: true, reply: fallback text }"
        else key present
            API->>OR: POST /chat/completions
            OR-->>API: "{ choices[0].message.content }"
            API-->>Browser: "200 { ok: true, reply }"
        end
    end
    Note over Browser: User clicks Book free review
    Browser->>BM: "{ name, email, startISO+03:00, durationMins: 20 }"
    BM-->>Browser: "{ ok: true, meetLink }"
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fapi%2Fsdr%2Froute.ts%3A46-50%0A**Rate-limit%20bypass%20via%20%60x-forwarded-for%60%20spoofing**%0A%0AThe%20%60clientIp%60%20function%20takes%20the%20*leftmost*%20value%20from%20the%20%60x-forwarded-for%60%20header.%20On%20Vercel%20%28and%20any%20CDN%2Fproxy%29%2C%20the%20platform%20appends%20the%20real%20client%20IP%20to%20the%20right%20side%20of%20the%20chain%2C%20so%20an%20attacker%20who%20sends%20%60x-forwarded-for%3A%201.2.3.4%60%20will%20have%20their%20request%20arrive%20with%20%60x-forwarded-for%3A%201.2.3.4%2C%20real.ip%60.%20By%20cycling%20through%20forged%20leftmost%20IPs%2C%20a%20single%20client%20can%20hit%20the%20endpoint%20unlimited%20times%2C%20fully%20bypassing%20the%20rate%20limiter%20and%20driving%20up%20OpenRouter%20spend%20without%20bound.%20%60x-real-ip%60%20is%20the%20trustworthy%20header%20on%20Vercel%20%E2%80%94%20prefer%20it%20first.%0A%0A%60%60%60suggestion%0Afunction%20clientIp%28req%3A%20Request%29%3A%20string%20%7B%0A%20%20%2F%2F%20Prefer%20x-real-ip%20%28set%20by%20Vercel's%20edge%2C%20not%20spoofable%20by%20the%20client%29.%0A%20%20%2F%2F%20Fall%20back%20to%20the%20*last*%20entry%20of%20x-forwarded-for%2C%20which%20is%20appended%20by%0A%20%20%2F%2F%20the%20platform%20proxy%20and%20therefore%20also%20not%20client-controlled.%0A%20%20const%20realIp%20%3D%20req.headers.get%28%22x-real-ip%22%29%3F.trim%28%29%0A%20%20if%20%28realIp%29%20return%20realIp%0A%20%20const%20fwd%20%3D%20req.headers.get%28%22x-forwarded-for%22%29%0A%20%20if%20%28fwd%29%20%7B%0A%20%20%20%20const%20parts%20%3D%20fwd.split%28%22%2C%22%29%0A%20%20%20%20return%20parts%5Bparts.length%20-%201%5D!.trim%28%29%0A%20%20%7D%0A%20%20return%20%22unknown%22%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aapp%2Fapi%2Fsdr%2Froute.ts%3A31%0A**%60hits%60%20Map%20grows%20without%20bound**%0A%0AEntries%20in%20the%20%60hits%60%20Map%20are%20never%20deleted%20%E2%80%94%20they%20are%20only%20reset%20in-place%20when%20the%20same%20IP%20makes%20a%20new%20request%20after%20the%20window%20expires.%20In%20a%20long-lived%20Node.js%20process%20%28or%20a%20warm%20serverless%20instance%20with%20sustained%20traffic%29%2C%20this%20Map%20accumulates%20one%20entry%20per%20unique%20IP%20address%20seen%2C%20permanently.%20A%20garbage-collection%20pass%20keyed%20on%20%60entry.resetAt%20%3C%20Date.now%28%29%60%20should%20run%20periodically%20%28e.g.%20via%20a%20%60setInterval%60%20or%20lazily%20inside%20%60isRateLimited%60%29%20to%20evict%20stale%20entries.%0A%0A%23%23%23%20Issue%203%20of%204%0Acomponents%2Fsdr%2Fsdr-assistant.tsx%3A28-32%0A**%60minBookingDate%60%20returns%20a%20UTC%20date%2C%20not%20AST**%0A%0A%60new%20Date%28%29.toISOString%28%29%60%20is%20always%20UTC.%20In%20Arabia%20Standard%20Time%20%28UTC%2B3%29%2C%20any%20call%20made%20between%2021%3A00%20and%20midnight%20AST%20will%20return%20today's%20UTC%20date%2C%20which%20is%20actually%20tomorrow%20in%20AST%20%E2%80%94%20so%20the%20minimum%20selectable%20date%20will%20be%20one%20day%20further%20ahead%20than%20intended%2C%20blocking%20same-next-day%20bookings.%20Use%20%60toLocaleDateString%28'en-CA'%2C%20%7B%20timeZone%3A%20'Asia%2FRiyadh'%20%7D%29%60%20to%20get%20the%20correct%20AST%20date%2C%20then%20add%20one%20day%20from%20that.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fservices%2Fcyber-sprint%2Fpage.tsx%3A147%0A**%60React.ReactNode%60%20used%20without%20importing%20%60React%60**%0A%0AThe%20type%20annotation%20%60React.ReactNode%60%20on%20the%20%60DELIVERABLES%60%20array%20requires%20%60React%60%20to%20be%20in%20scope%20as%20a%20namespace.%20Modern%20Next.js%20with%20the%20automatic%20JSX%20transform%20does%20not%20require%20%60import%20React%20from%20'react'%60%20for%20JSX%20itself%2C%20but%20the%20namespace%20is%20still%20needed%20for%20type%20references.%20Depending%20on%20whether%20the%20project's%20%60tsconfig.json%60%20exposes%20global%20React%20types%2C%20this%20can%20surface%20as%20a%20TypeScript%20error%20%28%60Cannot%20find%20name%20'React'%60%29.%20Adding%20%60import%20type%20%7B%20ReactNode%20%7D%20from%20'react'%60%20and%20changing%20the%20annotation%20to%20%60ReactNode%60%20is%20the%20explicit%2C%20safe%20form.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=54&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22goodnbadexe%2Fdev-hamzah-alramli%22%20on%20the%20existing%20branch%20%22feat%2Fai-sdr-agent%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fai-sdr-agent%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fapi%2Fsdr%2Froute.ts%3A46-50%0A**Rate-limit%20bypass%20via%20%60x-forwarded-for%60%20spoofing**%0A%0AThe%20%60clientIp%60%20function%20takes%20the%20*leftmost*%20value%20from%20the%20%60x-forwarded-for%60%20header.%20On%20Vercel%20%28and%20any%20CDN%2Fproxy%29%2C%20the%20platform%20appends%20the%20real%20client%20IP%20to%20the%20right%20side%20of%20the%20chain%2C%20so%20an%20attacker%20who%20sends%20%60x-forwarded-for%3A%201.2.3.4%60%20will%20have%20their%20request%20arrive%20with%20%60x-forwarded-for%3A%201.2.3.4%2C%20real.ip%60.%20By%20cycling%20through%20forged%20leftmost%20IPs%2C%20a%20single%20client%20can%20hit%20the%20endpoint%20unlimited%20times%2C%20fully%20bypassing%20the%20rate%20limiter%20and%20driving%20up%20OpenRouter%20spend%20without%20bound.%20%60x-real-ip%60%20is%20the%20trustworthy%20header%20on%20Vercel%20%E2%80%94%20prefer%20it%20first.%0A%0A%60%60%60suggestion%0Afunction%20clientIp%28req%3A%20Request%29%3A%20string%20%7B%0A%20%20%2F%2F%20Prefer%20x-real-ip%20%28set%20by%20Vercel's%20edge%2C%20not%20spoofable%20by%20the%20client%29.%0A%20%20%2F%2F%20Fall%20back%20to%20the%20*last*%20entry%20of%20x-forwarded-for%2C%20which%20is%20appended%20by%0A%20%20%2F%2F%20the%20platform%20proxy%20and%20therefore%20also%20not%20client-controlled.%0A%20%20const%20realIp%20%3D%20req.headers.get%28%22x-real-ip%22%29%3F.trim%28%29%0A%20%20if%20%28realIp%29%20return%20realIp%0A%20%20const%20fwd%20%3D%20req.headers.get%28%22x-forwarded-for%22%29%0A%20%20if%20%28fwd%29%20%7B%0A%20%20%20%20const%20parts%20%3D%20fwd.split%28%22%2C%22%29%0A%20%20%20%20return%20parts%5Bparts.length%20-%201%5D!.trim%28%29%0A%20%20%7D%0A%20%20return%20%22unknown%22%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aapp%2Fapi%2Fsdr%2Froute.ts%3A31%0A**%60hits%60%20Map%20grows%20without%20bound**%0A%0AEntries%20in%20the%20%60hits%60%20Map%20are%20never%20deleted%20%E2%80%94%20they%20are%20only%20reset%20in-place%20when%20the%20same%20IP%20makes%20a%20new%20request%20after%20the%20window%20expires.%20In%20a%20long-lived%20Node.js%20process%20%28or%20a%20warm%20serverless%20instance%20with%20sustained%20traffic%29%2C%20this%20Map%20accumulates%20one%20entry%20per%20unique%20IP%20address%20seen%2C%20permanently.%20A%20garbage-collection%20pass%20keyed%20on%20%60entry.resetAt%20%3C%20Date.now%28%29%60%20should%20run%20periodically%20%28e.g.%20via%20a%20%60setInterval%60%20or%20lazily%20inside%20%60isRateLimited%60%29%20to%20evict%20stale%20entries.%0A%0A%23%23%23%20Issue%203%20of%204%0Acomponents%2Fsdr%2Fsdr-assistant.tsx%3A28-32%0A**%60minBookingDate%60%20returns%20a%20UTC%20date%2C%20not%20AST**%0A%0A%60new%20Date%28%29.toISOString%28%29%60%20is%20always%20UTC.%20In%20Arabia%20Standard%20Time%20%28UTC%2B3%29%2C%20any%20call%20made%20between%2021%3A00%20and%20midnight%20AST%20will%20return%20today's%20UTC%20date%2C%20which%20is%20actually%20tomorrow%20in%20AST%20%E2%80%94%20so%20the%20minimum%20selectable%20date%20will%20be%20one%20day%20further%20ahead%20than%20intended%2C%20blocking%20same-next-day%20bookings.%20Use%20%60toLocaleDateString%28'en-CA'%2C%20%7B%20timeZone%3A%20'Asia%2FRiyadh'%20%7D%29%60%20to%20get%20the%20correct%20AST%20date%2C%20then%20add%20one%20day%20from%20that.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fservices%2Fcyber-sprint%2Fpage.tsx%3A147%0A**%60React.ReactNode%60%20used%20without%20importing%20%60React%60**%0A%0AThe%20type%20annotation%20%60React.ReactNode%60%20on%20the%20%60DELIVERABLES%60%20array%20requires%20%60React%60%20to%20be%20in%20scope%20as%20a%20namespace.%20Modern%20Next.js%20with%20the%20automatic%20JSX%20transform%20does%20not%20require%20%60import%20React%20from%20'react'%60%20for%20JSX%20itself%2C%20but%20the%20namespace%20is%20still%20needed%20for%20type%20references.%20Depending%20on%20whether%20the%20project's%20%60tsconfig.json%60%20exposes%20global%20React%20types%2C%20this%20can%20surface%20as%20a%20TypeScript%20error%20%28%60Cannot%20find%20name%20'React'%60%29.%20Adding%20%60import%20type%20%7B%20ReactNode%20%7D%20from%20'react'%60%20and%20changing%20the%20annotation%20to%20%60ReactNode%60%20is%20the%20explicit%2C%20safe%20form.%0A%0A&repo=goodnbadexe%2Fdev-hamzah-alramli&pr=54&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: SDR chat degrades gracefully when O..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/4da8a6afbae0a554c4666e98780834db81ba8542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40599016)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->