### PR TITLE
feat(vault): weekly drip cron delivering issues 2-6 to subscribers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,19 @@ SUPABASE_SERVICE_ROLE_KEY=
 # long random value (e.g. `openssl rand -hex 32`). Server-only.
 VAULT_SIGNING_SECRET=
 
+# ── Weekly vault drip (cron: /api/cron/vault-drip, Mondays 09:00) ────────────
+# Emails weeks 2–6 to active subscribers, one issue/week, keeping the welcome
+# email's promise. Reuses VAULT_SIGNING_SECRET for the download links.
+# CRON_SECRET: shared bearer Vercel Cron sends. MUST be set in production — when
+#   unset the endpoint fails closed (401) in prod. Same secret guards all crons.
+CRON_SECRET=
+# VAULT_DRIP_DRY_RUN: safety switch. Anything except the literal "false" = dry run
+#   (logs who WOULD receive what, sends nothing). Set to "false" ONLY after a
+#   verified test send to yourself.
+VAULT_DRIP_DRY_RUN=true
+# NEXT_PUBLIC_SITE_URL: absolute origin used to build download links in drip emails.
+NEXT_PUBLIC_SITE_URL=https://www.goodnbad.info
+
 # ── Gumroad storefront (current payment + delivery) ──────────────────────────
 # One product per track + an all-access bundle. Paste each product's Gumroad URL.
 # NEXT_PUBLIC_* = inlined at build → redeploy after changing. The quiz recommends

--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,10 @@ SUPABASE_SERVICE_ROLE_KEY=
 # long random value (e.g. `openssl rand -hex 32`). Server-only.
 VAULT_SIGNING_SECRET=
 
-# ── Weekly vault drip (cron: /api/cron/vault-drip, Mondays 09:00) ────────────
-# Emails weeks 2–6 to active subscribers, one issue/week, keeping the welcome
-# email's promise. Reuses VAULT_SIGNING_SECRET for the download links.
+# ── Vault drip (daily cron: /api/cron/vault-drip, 09:00 UTC) ─────────────────
+# Emails weeks 2–6 to active subscribers, ~one issue/week per buyer (delivery is
+# anchored to purchase time; the daily run + 6-day spacing gate keep it weekly),
+# keeping the welcome email's promise. Reuses VAULT_SIGNING_SECRET for the links.
 # CRON_SECRET: shared bearer Vercel Cron sends. MUST be set in production — when
 #   unset the endpoint fails closed (401) in prod. Same secret guards all crons.
 CRON_SECRET=

--- a/app/api/cron/vault-drip/ACTIVATION.md
+++ b/app/api/cron/vault-drip/ACTIVATION.md
@@ -5,14 +5,16 @@ commit/push/deploy yourself). Closes the welcome-email promise "Weeks 2–4 land
 inbox automatically." Content already exists (all 6 track PDFs); this ships the delivery.
 
 ## What it does
-Weekly cron (`/api/cron/vault-drip`, Mondays 09:00 UTC) emails active, non-refunded
-subscribers the next issue's entitlement-gated download link — week 1 at purchase
-(Gumroad), then weeks 2→6 (developers, agents, automation, quant, creative), one per week.
+Daily cron (`/api/cron/vault-drip`, 09:00 UTC) emails active, non-refunded subscribers the
+next issue's entitlement-gated download link — week 1 at purchase (Gumroad), then weeks
+2→6 (developers, agents, automation, quant, creative). Delivery is anchored to each buyer's
+purchase time (~7 days apart per buyer); the daily schedule + a 6-day spacing gate make
+Week 2 arrive ~a week after purchase regardless of weekday, with no bursts.
 
 ## Files
 - `app/api/cron/vault-drip/route.ts` — the cron (dry-run by default)
 - `supabase/migrations/0003_drip_sends.sql` — idempotency ledger
-- `vercel.json` — added the weekly cron entry
+- `vercel.json` — added the daily cron entry
 - `.env.example` — documented CRON_SECRET / VAULT_DRIP_DRY_RUN / NEXT_PUBLIC_SITE_URL
 
 ## Activate (in order)

--- a/app/api/cron/vault-drip/ACTIVATION.md
+++ b/app/api/cron/vault-drip/ACTIVATION.md
@@ -1,0 +1,50 @@
+# Vault Weekly Drip — activation checklist
+
+Built on branch `feat/vault-weekly-drip` (uncommitted, per EXECUTE mode — review, then
+commit/push/deploy yourself). Closes the welcome-email promise "Weeks 2–4 land in your
+inbox automatically." Content already exists (all 6 track PDFs); this ships the delivery.
+
+## What it does
+Weekly cron (`/api/cron/vault-drip`, Mondays 09:00 UTC) emails active, non-refunded
+subscribers the next issue's entitlement-gated download link — week 1 at purchase
+(Gumroad), then weeks 2→6 (developers, agents, automation, quant, creative), one per week.
+
+## Files
+- `app/api/cron/vault-drip/route.ts` — the cron (dry-run by default)
+- `supabase/migrations/0003_drip_sends.sql` — idempotency ledger
+- `vercel.json` — added the weekly cron entry
+- `.env.example` — documented CRON_SECRET / VAULT_DRIP_DRY_RUN / NEXT_PUBLIC_SITE_URL
+
+## Activate (in order)
+1. **Apply the migration** to prod Supabase: run `0003_drip_sends.sql` (SQL editor or CLI).
+2. **Set env vars** in Vercel (Production): `CRON_SECRET` (any long random string),
+   `NEXT_PUBLIC_SITE_URL=https://www.goodnbad.info`, and confirm `VAULT_SIGNING_SECRET`,
+   `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `EMAIL_FROM` are set.
+   Leave `VAULT_DRIP_DRY_RUN=true` for now.
+3. **Deploy** the branch.
+4. **Dry-run test:** `curl -H "Authorization: Bearer $CRON_SECRET" https://www.goodnbad.info/api/cron/vault-drip`
+   → JSON shows `dryRun:true` and masked would-send rows. (With 0 sales it reports
+   `subscribers:0` — that's expected until the first buyer.)
+5. **Live test on yourself:** make a real purchase (or insert a test `sales` row with your
+   email), set `VAULT_DRIP_DRY_RUN=false`, hit the endpoint, confirm you receive the email
+   and the download link works. Then verify a second call does NOT re-send (idempotent).
+6. **Go live:** keep `VAULT_DRIP_DRY_RUN=false`. The Monday cron now runs automatically.
+
+## Safety properties (verified by security + correctness review)
+- Fails closed: no `CRON_SECRET` in prod → 401 (not an open endpoint).
+- Reserve-then-send: claims the `drip_sends(email,week)` row before sending; releases it if
+  the send fails. A crash or concurrent run cannot double-send.
+- Weekly spacing gate: won't ship a 2nd issue within ~6 days even if the endpoint is hit
+  extra times.
+- Entitlement re-checked on every download → refunded buyers lose access even mid-week.
+- Response is PII-masked (no raw customer emails leak to the caller).
+
+## Known follow-ups (non-blocking)
+- **Email casing:** the download token uses the buyer's original-case email so the
+  case-sensitive `sales` lookup matches. For belt-and-suspenders, also lowercase
+  `sales.email` at write time in `app/api/gumroad/ping/route.ts` and in `hasConfirmedSale`.
+- **Anchor = row-insert time** (`sales.created_at`), not Gumroad's sale timestamp. Fine
+  normally; if you ever re-import sales rows the schedule resets (the ledger still prevents
+  duplicate emails). Store the real sale time if you want re-import safety.
+- The "tuned for your setup" copy delivers a fixed 6-issue tour (one per track), OS-tuned.
+  If you want per-track depth instead, that's a content + manifest change, not a code one.

--- a/app/api/cron/vault-drip/route.ts
+++ b/app/api/cron/vault-drip/route.ts
@@ -1,7 +1,13 @@
-// vault-drip/route.ts — weekly cron that keeps the welcome-email promise:
+// vault-drip/route.ts — DAILY cron that keeps the welcome-email promise:
 // "Weeks 2–4 land in your inbox automatically." Week 1 is delivered at purchase by
 // Gumroad; this job emails the next issue's entitlement-gated download link to each
-// active subscriber, one issue at a time, spaced a week apart.
+// active subscriber, one issue at a time, ~a week apart PER BUYER.
+//
+// Why daily (not weekly): delivery is anchored to each buyer's purchase time
+// (weeksSince = elapsed/7d), and the weekly-spacing gate below caps them at one issue
+// per ~week. Running daily makes Week 2 arrive ~7 days after purchase regardless of
+// weekday; a weekly (Monday-only) cron makes a buyer who just missed Monday's run wait
+// up to ~14 days for Week 2. Daily + the spacing gate = purchase-relative, no bursts.
 //
 // SAFETY (hardened after security + correctness review):
 //  - DRY RUN BY DEFAULT. Sends only when VAULT_DRIP_DRY_RUN === "false".

--- a/app/api/cron/vault-drip/route.ts
+++ b/app/api/cron/vault-drip/route.ts
@@ -1,0 +1,182 @@
+// vault-drip/route.ts — weekly cron that keeps the welcome-email promise:
+// "Weeks 2–4 land in your inbox automatically." Week 1 is delivered at purchase by
+// Gumroad; this job emails the next issue's entitlement-gated download link to each
+// active subscriber, one issue at a time, spaced a week apart.
+//
+// SAFETY (hardened after security + correctness review):
+//  - DRY RUN BY DEFAULT. Sends only when VAULT_DRIP_DRY_RUN === "false".
+//  - Auth: needs Authorization: Bearer $CRON_SECRET. In production a MISSING secret
+//    means 401 (fail closed) — never an open endpoint.
+//  - Reserve-then-send: the drip_sends(email,week) row is inserted FIRST (its unique
+//    constraint is the claim/lock); the email is sent only if we won the insert, and
+//    the row is deleted if the send fails. So a crash/2nd-run cannot double-send.
+//  - Weekly spacing gate: a subscriber whose last issue went out < 6 days ago is
+//    skipped, so a misfired/manual extra run can't ship two issues the same week.
+//  - Entitlement re-checked on every download (lib/vault/entitlement), so a refunded
+//    buyer's link stops working even while the token is unexpired. The token carries
+//    the buyer's ORIGINAL-CASE email so the case-sensitive sales lookup matches.
+//  - Response body is PII-masked (no raw customer emails leak to the caller).
+
+import { NextResponse } from "next/server"
+import { isSupabaseConfigured, supabaseAdmin } from "@/lib/supabase/server"
+import { isEmailConfigured, sendEmail } from "@/lib/email/resend"
+import { signClaim } from "@/lib/vault/sign"
+import { VAULT } from "@/lib/vault/manifest"
+import { DEFAULT_OS, type OsId, type TrackId, isOsId } from "@/lib/subscribe/tracks"
+
+export const dynamic = "force-dynamic"
+
+const WEEK_TTL_SECONDS = 7 * 24 * 3600 // drip links live a week (entitlement re-checked on use)
+const MIN_SPACING_MS = 6 * 24 * 3600 * 1000 // don't ship a 2nd issue within ~a week
+const LAST_WEEK = 6
+const SITE = process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.goodnbad.info"
+
+// week number -> { track, deliverable }, built from the manifest (week 1..6).
+const WEEK_MAP = (() => {
+  const m = new Map<number, { track: TrackId; deliverable: (typeof VAULT)[TrackId][number] }>()
+  for (const track of Object.keys(VAULT) as TrackId[]) {
+    for (const d of VAULT[track]) {
+      if (m.has(d.week)) throw new Error(`vault-drip: duplicate manifest week ${d.week}`)
+      m.set(d.week, { track, deliverable: d })
+    }
+  }
+  return m
+})()
+// Which weeks are missing from the manifest (defense against a future edit stranding buyers).
+const MISSING_WEEKS = Array.from({ length: LAST_WEEK }, (_, i) => i + 1).filter((w) => !WEEK_MAP.has(w))
+
+// Mask an email for logging/response so PII never leaves the server. "alice@gmail.com" -> "a***@gmail.com"
+function mask(email: string): string {
+  const [local, domain] = email.split("@")
+  if (!domain) return "***"
+  return `${local.slice(0, 1)}***@${domain}`
+}
+
+function isAuthorized(req: Request): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) return process.env.NODE_ENV !== "production" // fail CLOSED in prod when unset
+  return req.headers.get("authorization") === `Bearer ${secret}`
+}
+
+function dripHtml(outcomeEn: string, outcomeAr: string, url: string): string {
+  return `<div style="font:15px/1.6 ui-sans-serif,system-ui;color:#18181b;max-width:520px">
+    <p><b>This week's Vault is ready.</b></p>
+    <p>${outcomeEn}</p>
+    <p style="direction:rtl">${outcomeAr}</p>
+    <p><a href="${url}" style="display:inline-block;padding:10px 18px;background:#10b981;color:#fff;border-radius:8px;text-decoration:none">Download this week's PDF →</a></p>
+    <p style="color:#71717a;font-size:13px">Link is personal to you and expires in 7 days. The Toolkit Vault · goodnbad.info</p>
+  </div>`
+}
+
+export async function GET(req: Request) {
+  if (!isAuthorized(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  if (MISSING_WEEKS.length) {
+    return NextResponse.json({ ok: false, error: `manifest missing weeks: ${MISSING_WEEKS.join(",")}` }, { status: 500 })
+  }
+  if (!isSupabaseConfigured()) return NextResponse.json({ ok: false, error: "supabase not configured" }, { status: 200 })
+
+  const dryRun = process.env.VAULT_DRIP_DRY_RUN !== "false"
+  const db = supabaseAdmin()
+  const results: Array<Record<string, unknown>> = []
+
+  // Active subscribers: not-refunded sales (treat NULL refunded as active), earliest purchase per person.
+  // Keyed by lowercased email for stable dedup; keep the ORIGINAL-CASE email for the token/recipient.
+  const { data: sales, error: salesErr } = await db
+    .from("sales")
+    .select("email, created_at, refunded")
+    .neq("refunded", true)
+  if (salesErr) return NextResponse.json({ ok: false, error: `sales query: ${salesErr.message}` }, { status: 200 })
+
+  type Sub = { emailOriginal: string; anchorMs: number }
+  const subs = new Map<string, Sub>()
+  for (const s of sales ?? []) {
+    const original = String(s.email || "").trim()
+    if (!original) continue
+    const key = original.toLowerCase()
+    const t = Date.parse(s.created_at as string)
+    if (!Number.isFinite(t)) continue
+    const prev = subs.get(key)
+    if (!prev) subs.set(key, { emailOriginal: original, anchorMs: t })
+    else if (t < prev.anchorMs) prev.anchorMs = t
+  }
+  if (subs.size === 0) {
+    return NextResponse.json({ ok: true, dryRun, subscribers: 0, sent: 0, note: "no active subscribers yet" })
+  }
+
+  // Ledger: which (email,week) already went out + when the last issue was sent (for spacing).
+  const { data: sentRows } = await db.from("drip_sends").select("email, week, sent_at")
+  const sentSet = new Set<string>()
+  const lastSentMs = new Map<string, number>()
+  for (const r of sentRows ?? []) {
+    const key = String(r.email).toLowerCase()
+    sentSet.add(`${key}|${r.week}`)
+    const t = Date.parse(r.sent_at as string)
+    if (Number.isFinite(t)) lastSentMs.set(key, Math.max(lastSentMs.get(key) ?? 0, t))
+  }
+
+  // Batch OS lookup (one query, not N) — OS is variant-only, missing => default, never blocks.
+  const osByEmail = new Map<string, OsId>()
+  const { data: leadRows } = await db
+    .from("leads")
+    .select("email, os, created_at")
+    .in("email", [...subs.values()].map((s) => s.emailOriginal))
+    .order("created_at", { ascending: false })
+  for (const l of leadRows ?? []) {
+    const key = String(l.email).toLowerCase()
+    if (!osByEmail.has(key) && l.os && isOsId(l.os)) osByEmail.set(key, l.os) // first = latest
+  }
+
+  const emailReady = isEmailConfigured()
+  const now = Date.now()
+  const nowSec = Math.floor(now / 1000)
+  let sentCount = 0
+
+  for (const [key, sub] of subs) {
+    // Weekly spacing: skip anyone whose last issue is younger than ~a week.
+    const last = lastSentMs.get(key)
+    if (last && now - last < MIN_SPACING_MS) continue
+
+    const weeksSince = Math.floor((now - sub.anchorMs) / (7 * 86_400_000))
+    const dueWeek = Math.min(1 + weeksSince, LAST_WEEK) // week 1 at purchase; +1 per elapsed week
+
+    let target = 0
+    for (let w = 2; w <= dueWeek; w++) {
+      if (!sentSet.has(`${key}|${w}`)) { target = w; break }
+    }
+    if (!target) continue
+
+    const entry = WEEK_MAP.get(target)
+    if (!entry) { results.push({ email: mask(sub.emailOriginal), week: target, action: "ERROR: week unmapped" }); continue }
+
+    const os: OsId = osByEmail.get(key) ?? DEFAULT_OS
+    const token = signClaim({ id: entry.deliverable.id, email: sub.emailOriginal, exp: nowSec + WEEK_TTL_SECONDS })
+    const url = `${SITE}/api/vault/${entry.deliverable.id}?t=${encodeURIComponent(token)}`
+
+    if (dryRun) {
+      results.push({ email: mask(sub.emailOriginal), week: target, deliverable: entry.deliverable.id, os, action: "DRY_RUN (would send)" })
+      continue
+    }
+    if (!emailReady) { results.push({ email: mask(sub.emailOriginal), week: target, action: "SKIPPED — email not configured" }); continue }
+
+    // RESERVE first: the unique(email,week) row is our claim. If someone already claimed
+    // it (concurrent run), the insert errors and we skip — no send.
+    const { error: claimErr } = await db.from("drip_sends").insert({ email: key, week: target })
+    if (claimErr) { results.push({ email: mask(sub.emailOriginal), week: target, action: `skipped — already claimed (${claimErr.code ?? "err"})` }); continue }
+
+    // ACT: send. If it fails, release the claim so a later run retries (miss > spam).
+    const r = await sendEmail({
+      to: sub.emailOriginal,
+      subject: entry.deliverable.outcomeEn,
+      html: dripHtml(entry.deliverable.outcomeEn, entry.deliverable.outcomeAr, url),
+    })
+    if (r.ok) {
+      sentCount++
+      results.push({ email: mask(sub.emailOriginal), week: target, deliverable: entry.deliverable.id, os, action: "SENT" })
+    } else {
+      await db.from("drip_sends").delete().eq("email", key).eq("week", target)
+      results.push({ email: mask(sub.emailOriginal), week: target, action: `send failed, claim released: ${r.error}` })
+    }
+  }
+
+  return NextResponse.json({ ok: true, dryRun, subscribers: subs.size, sent: sentCount, results })
+}

--- a/supabase/migrations/0003_drip_sends.sql
+++ b/supabase/migrations/0003_drip_sends.sql
@@ -1,0 +1,17 @@
+-- 0003_drip_sends.sql — idempotency ledger for the weekly vault drip.
+-- One row per (email, week) that was successfully emailed, so a cron re-run (or an
+-- overlapping run) never double-sends the same issue to the same buyer.
+-- Service-role only: RLS on, no anon policies (same posture as sales/leads).
+
+create table if not exists public.drip_sends (
+  id       bigint generated always as identity primary key,
+  email    text        not null,
+  week     int         not null check (week between 1 and 6),
+  sent_at  timestamptz not null default now(),
+  unique (email, week)
+);
+
+create index if not exists drip_sends_email_idx on public.drip_sends (email);
+
+alter table public.drip_sends enable row level security;
+-- No policies => only the service-role key (used server-side) can read/write.

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
     },
     {
       "path": "/api/cron/vault-drip",
-      "schedule": "0 9 * * 1"
+      "schedule": "0 9 * * *"
     }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
     {
       "path": "/api/cron/meeting-reminders",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/vault-drip",
+      "schedule": "0 9 * * 1"
     }
   ],
   "headers": [


### PR DESCRIPTION
## What & why

The subscribe welcome email promises *"Weeks 2–4 land in your inbox automatically."* The content for all six track vaults already exists (issue JSONs + per-OS PDFs), but **no code delivered subsequent weeks** — the only cron was `meeting-reminders`. This PR ships that delivery.

Week 1 is delivered at purchase by Gumroad. This weekly cron (`/api/cron/vault-drip`, Mondays 09:00 UTC) emails each active, non-refunded subscriber the next issue's **entitlement-gated download link** — weeks 2→6 (developers, agents, automation, quant, creative), one issue per week. It reuses the existing (previously dormant) HMAC `signClaim` + `/api/vault/[file]` serve path, which re-checks `hasConfirmedSale` on every download, so a refunded buyer's link stops working even while unexpired.

## Safety (hardened after security + correctness review)

- **Dry-run by default** — sends only when `VAULT_DRIP_DRY_RUN="false"`. Any other value logs who *would* receive what and sends nothing.
- **Fails closed** — missing `CRON_SECRET` in production returns 401 (never an open endpoint).
- **Reserve-then-send** — claims the `drip_sends(email,week)` row before sending and releases it on failure, so a crash or concurrent run cannot double-send a paying customer.
- **Weekly-spacing gate** — won't ship a second issue within ~6 days even if the endpoint is hit extra times.
- **PII-masked response**, `NULL`-refunded rows treated as active, original-case email in the token so the case-sensitive `sales` lookup matches.

## Files

- `app/api/cron/vault-drip/route.ts` — the cron
- `supabase/migrations/0003_drip_sends.sql` — idempotency ledger (RLS on, service-role only)
- `vercel.json` — weekly cron entry
- `.env.example` — documents `CRON_SECRET` / `VAULT_DRIP_DRY_RUN` / `NEXT_PUBLIC_SITE_URL`
- `app/api/cron/vault-drip/ACTIVATION.md` — step-by-step activation

## Verification done

- `tsc --noEmit` — 0 errors across the project
- Adversarial security + correctness review; all blocking findings fixed in this branch

## Test plan (activation — not active until done)

- [ ] Apply `0003_drip_sends.sql` to prod Supabase
- [ ] Set `CRON_SECRET`, `NEXT_PUBLIC_SITE_URL` in Vercel; confirm `VAULT_SIGNING_SECRET`, `SUPABASE_*`, `RESEND_API_KEY`, `EMAIL_FROM` present; leave `VAULT_DRIP_DRY_RUN=true`
- [ ] Deploy; `curl -H "Authorization: Bearer $CRON_SECRET" .../api/cron/vault-drip` → expect `dryRun:true`, masked rows (with 0 sales: `subscribers:0`)
- [ ] Real test: purchase (or insert a test `sales` row with your email), set `VAULT_DRIP_DRY_RUN=false`, hit endpoint, confirm you receive the email + the link downloads; call again and confirm **no** re-send (idempotent)
- [ ] Go live: keep `VAULT_DRIP_DRY_RUN=false`

## Notes

- Merging deploys to production via the existing Vercel sync, but the cron stays dry-run + env-gated, so **no emails send until the checklist above is completed.**
- Follow-ups (non-blocking) in `ACTIVATION.md`: lowercase `sales.email` at webhook write time; anchor on Gumroad's true sale timestamp for re-import safety.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a weekly vault drip delivery path for paid subscribers. The main changes are:

- New authenticated `/api/cron/vault-drip` endpoint for weeks 2–6 delivery.
- Dry-run-by-default behavior controlled by `VAULT_DRIP_DRY_RUN`.
- Supabase `drip_sends` ledger for idempotent email reservations.
- Entitlement-gated signed download links reused for drip emails.
- Vercel cron registration and activation/env documentation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the reviewed changes.

The cron is authorization-gated, dry-run-by-default, masks response PII, and reserves sends before delivery. The migration supports idempotent delivery with a unique `(email, week)` ledger. No new accepted issues were identified in this final pass.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the baseline vault-drip runtime state in vault-drip-01-before.log to establish pre-change behavior, noting an unauthorized 401 and an authorized dry-run 200 with supabase not configured.
- Captured the current-code vault-drip runtime state in vault-drip-02-after.log to compare against the baseline, confirming unauthorized 401 and authorized dry-run 200 with supabase not configured, and that VAULT\_DRIP\_DRY\_RUN is true with the email env omitted.
- Executed a mocked-dry-run scenario using the vault-drip-mocked-dry-run.log path with dummy Supabase config, observing unauthorized 401 and authorized 200 with a local setup error TypeError: fetch failed, while the email env remained omitted and DRY\_RUN stayed true.
- Generated the vault-drip-harness.mjs harness to enable the additional runtime request capture under controlled conditions.
- Compiled and cross-checked the three runtime captures and the harness to validate consistent behavior across baseline, current, and mocked vault-drip scenarios.

<a href="https://app.greptile.com/trex/runs/14950883/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .env.example | Documents the new cron secret, dry-run flag, and site URL environment variables for vault drip activation. |
| app/api/cron/vault-drip/ACTIVATION.md | Adds an activation checklist and operational notes for enabling the vault drip safely. |
| app/api/cron/vault-drip/route.ts | Introduces the authenticated dry-run-by-default drip cron with subscriber selection, entitlement-link signing, spacing, and idempotent send reservation. |
| supabase/migrations/0003_drip_sends.sql | Adds the `drip_sends` ledger table with uniqueness and RLS enabled for service-role-only idempotency. |
| vercel.json | Registers the new `/api/cron/vault-drip` schedule alongside the existing meeting reminder cron. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Cron as Vercel Cron / Caller
participant Route as /api/cron/vault-drip
participant DB as Supabase
participant Sign as Vault HMAC signer
participant Email as Resend
participant Vault as /api/vault/[file]

Cron->>Route: GET with Authorization bearer
Route->>Route: Check CRON_SECRET and dry-run flag
Route->>DB: Read active sales and prior drip_sends
Route->>DB: Read latest lead OS variants
loop due subscriber
    Route->>Route: Apply weekly spacing and choose next unsent week
    Route->>Sign: Sign deliverable claim with buyer email + expiry
    alt dry run
        Route-->>Cron: Masked would-send result
    else live send
        Route->>DB: Insert drip_sends(email, week) reservation
        Route->>Email: Send gated download link
        alt send fails
            Route->>DB: Delete reservation for retry
        end
    end
end
Cron-->>Route: Later buyer opens emailed link
Route->>Vault: "/api/vault/{deliverable}?t=token"
Vault->>DB: Re-check confirmed non-refunded sale before PDF response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Cron as Vercel Cron / Caller
participant Route as /api/cron/vault-drip
participant DB as Supabase
participant Sign as Vault HMAC signer
participant Email as Resend
participant Vault as /api/vault/[file]

Cron->>Route: GET with Authorization bearer
Route->>Route: Check CRON_SECRET and dry-run flag
Route->>DB: Read active sales and prior drip_sends
Route->>DB: Read latest lead OS variants
loop due subscriber
    Route->>Route: Apply weekly spacing and choose next unsent week
    Route->>Sign: Sign deliverable claim with buyer email + expiry
    alt dry run
        Route-->>Cron: Masked would-send result
    else live send
        Route->>DB: Insert drip_sends(email, week) reservation
        Route->>Email: Send gated download link
        alt send fails
            Route->>DB: Delete reservation for retry
        end
    end
end
Cron-->>Route: Later buyer opens emailed link
Route->>Vault: "/api/vault/{deliverable}?t=token"
Vault->>DB: Re-check confirmed non-refunded sale before PDF response
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(vault): run drip cron daily so Week ..."](https://github.com/goodnbadexe/dev-hamzah-alramli/commit/52492f60f475a391577d13a8e701f260c04bbfa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45318839)</sub>

<!-- /greptile_comment -->